### PR TITLE
feat: abstract tools field, MCP native projection, HTTP transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,6 +1317,7 @@ dependencies = [
  "termcolor",
  "thiserror 2.0.18",
  "toml",
+ "toml_edit",
  "ureq",
  "wait-timeout",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
+toml_edit = "0.22"
 serde_yaml = "0.9"
 ureq = "3"
 flate2 = "1"

--- a/docs/config/mcp-and-hooks.md
+++ b/docs/config/mcp-and-hooks.md
@@ -4,14 +4,28 @@ Packages can ship MCP server registrations and lifecycle hooks alongside their
 agents and skills. Mars compiles these into target-specific config files during
 `mars sync`.
 
-- **MCP servers** are registered per harness target (`.claude/.mcp.json`,
-  `.codex/mcp.json`, etc.).
+- **MCP servers** are registered per harness target (for example
+  `.claude/.mcp.json`, `.codex/config.toml`, `.opencode/opencode.json`).
 - **Hooks** run scripts in response to harness lifecycle events
   (`session.start`, `tool.pre`, etc.) and are registered in each target's
   hook config file.
 
 Config entries are tracked in `mars.lock` so Mars can clean them up
 automatically when a package is removed or updated.
+
+## Target-Specific MCP Output
+
+Mars lowers MCP entries to each harness's native schema:
+
+- **`.claude`**: `.mcp.json` with `mcpServers`
+- **`.codex`**: `config.toml` with `[mcp.servers.<name>]`
+  - `env` is a list of variable names (`["MY_API_KEY"]`)
+  - Legacy `codex_mcp.json` is removed automatically during sync, with a
+    diagnostic entry.
+- **`.opencode`**: `opencode.json` with `mcp`
+  - Each stdio server is `{ "type": "local", "command": [cmd, ...args] }`
+  - Env maps to `environment`
+  - Legacy `mcpServers` is migrated to `mcp` when `mcp` is absent.
 
 ## Declaring MCP Servers in a Package
 

--- a/docs/config/mcp-and-hooks.md
+++ b/docs/config/mcp-and-hooks.md
@@ -18,13 +18,20 @@ automatically when a package is removed or updated.
 Mars lowers MCP entries to each harness's native schema:
 
 - **`.claude`**: `.mcp.json` with `mcpServers`
+  - **stdio**: `{ "command": "...", "args": [...], "env": { "KEY": "${VAR}" } }`
+  - **http**: `{ "type": "http", "url": "...", "headers": { ... } }`
 - **`.codex`**: `config.toml` with `[mcp.servers.<name>]`
-  - `env` is a list of variable names (`["MY_API_KEY"]`)
+  - **stdio**: `command`, `args`, optional `env = ["MY_API_KEY"]`
+  - **http**: `url`, optional `bearer_token_env_var`, optional `[http_headers]`
+    - `Authorization = { from = "env", var = "API_TOKEN" }` lowers to
+      `bearer_token_env_var = "API_TOKEN"`
+    - Other env-ref headers lower to `http_headers` values with the var name
   - Legacy `codex_mcp.json` is removed automatically during sync, with a
     diagnostic entry.
 - **`.opencode`**: `opencode.json` with `mcp`
   - Each stdio server is `{ "type": "local", "command": [cmd, ...args] }`
-  - Env maps to `environment`
+  - Each HTTP server is `{ "type": "remote", "url": "...", "headers": { ... } }`
+  - Env maps to `environment`; header env refs lower to plain var-name strings
   - Legacy `mcpServers` is migrated to `mcp` when `mcp` is absent.
 
 ## Declaring MCP Servers in a Package
@@ -55,6 +62,28 @@ targets = [".claude", ".codex"]
 # "exported" = propagates to transitive consumers too
 visibility = "local"
 ```
+
+Transport is explicit with `type`:
+
+- `type = "stdio"` (default when omitted)
+- `type = "http"`
+
+HTTP servers use `url` and optional headers:
+
+```toml
+type = "http"
+url  = "https://api.example.com/mcp"
+
+[headers]
+Authorization = { from = "env", var = "API_TOKEN" }
+X-Custom      = "static-value"
+```
+
+### Field legality by transport
+
+- **stdio** (default): `command` required. `url` must be absent. `headers` must be empty.
+- **http**: `url` required. `command` must be absent. `args` must be empty.
+  `headers` and `env` are allowed.
 
 **Env references** — if the server needs secrets, declare them symbolically.
 Mars never resolves the values; harnesses substitute them at runtime:

--- a/docs/internals/sync-pipeline.md
+++ b/docs/internals/sync-pipeline.md
@@ -195,8 +195,11 @@ writes them to per-target config files.
    field → hook name.
 7. Translate universal hook events to native target events (with lossiness
    classification); drop events with no native support and emit a warning.
-8. Write entries to target config files via target adapters (`.mcp.json`,
-   `settings.json`, etc.). Non-fatal per-target.
+8. Write entries to target config files via target adapters (for example:
+   `.claude/.mcp.json`, `.codex/config.toml` `[mcp.servers.*]`,
+   `.opencode/opencode.json` `"mcp"` + `"type":"local"`). Non-fatal per-target.
+   - Codex writer removes legacy `.codex/codex_mcp.json` if present.
+   - OpenCode writer migrates legacy `mcpServers` to `mcp` when `mcp` is absent.
 9. Compare current config entries against the previous lock to find stale
    entries, then remove them via `adapter.remove_config_entries()`.
 

--- a/docs/internals/sync-pipeline.md
+++ b/docs/internals/sync-pipeline.md
@@ -181,10 +181,14 @@ writes them to per-target config files.
 
 1. Discover `mcp/<name>/mcp.toml` items from each package (local first, then
    dependencies in topological order).
+   - Parse and validate transport schema:
+     - `type = "stdio"` (default): requires `command`, forbids `url` and `headers`
+     - `type = "http"`: requires `url`, forbids `command` and non-empty `args`
 2. Discover `hooks/<name>/hook.toml` items from each package.
 3. Filter items whose `visibility` is `"local"` (default) when they originate
    from a dependency — only `"exported"` items cross the package boundary.
-4. Check env references — warn (or error under `--strict`) for missing env vars.
+4. Check env references (both `env` and header env refs) — warn (or error under
+   `--strict`) for missing env vars.
 5. Resolve per-target MCP name collisions:
    - `_self` (local package) wins over any dependency, silently.
    - Among dependencies, earlier `[dependencies]` declaration order wins; a
@@ -197,7 +201,13 @@ writes them to per-target config files.
    classification); drop events with no native support and emit a warning.
 8. Write entries to target config files via target adapters (for example:
    `.claude/.mcp.json`, `.codex/config.toml` `[mcp.servers.*]`,
-   `.opencode/opencode.json` `"mcp"` + `"type":"local"`). Non-fatal per-target.
+   `.opencode/opencode.json` `"mcp"`).
+   - stdio lowers to existing native stdio records.
+   - http lowers to native remote/http records:
+     - Claude: `"type":"http"` + `url` + `headers`
+     - Codex: `url`, optional `bearer_token_env_var`, optional `http_headers`
+     - OpenCode: `"type":"remote"` + `url` + `headers`
+   Non-fatal per-target.
    - Codex writer removes legacy `.codex/codex_mcp.json` if present.
    - OpenCode writer migrates legacy `mcpServers` to `mcp` when `mcp` is absent.
 9. Compare current config entries against the previous lock to find stale

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+unset GIT_DIR GIT_WORK_TREE
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MODE="${1:-full}"
 
@@ -18,8 +20,8 @@ case "$MODE" in
     cd "$ROOT_DIR"
     run_step cargo fmt --check
     run_step cargo clippy --all-targets -- -D warnings
-    run_step cargo test
-    run_step cargo build --release
+    run_step cargo test --quiet
+    run_step cargo build --release --quiet
     ;;
   *)
     printf 'Usage: preflight.sh [fast|full]\n' >&2

--- a/src/compiler/agents/lower.rs
+++ b/src/compiler/agents/lower.rs
@@ -243,34 +243,44 @@ fn action_for_capability(tools: &ToolsField, capability: &str) -> ToolAction {
     }
 }
 
+fn explicit_action_for_capability(tools: &ToolsField, capability: &str) -> Option<ToolAction> {
+    match tools {
+        ToolsField::Shorthand(_) => None,
+        ToolsField::Map(map) => match map.get(capability) {
+            Some(ToolRule::Action(action)) => Some(action.clone()),
+            _ => None,
+        },
+    }
+}
+
+fn has_wildcard_allow(tools: &ToolsField) -> bool {
+    match tools {
+        ToolsField::Shorthand(action) => *action != ToolAction::Deny,
+        ToolsField::Map(map) => default_tool_action(map) != ToolAction::Deny,
+    }
+}
+
 fn infer_codex_sandbox_from_tools(tools: Option<&ToolsField>) -> &'static str {
     let Some(tools) = tools else {
         return "read-only";
     };
 
-    let ext = action_for_capability(tools, "external_directory");
-    if ext != ToolAction::Deny {
+    let bash_allowed = action_for_capability(tools, "bash") != ToolAction::Deny;
+    let edit_allowed = action_for_capability(tools, "edit") != ToolAction::Deny;
+    let external_directory_allowed =
+        action_for_capability(tools, "external_directory") != ToolAction::Deny;
+    let bash_denied = explicit_action_for_capability(tools, "bash") == Some(ToolAction::Deny);
+    let edit_denied = explicit_action_for_capability(tools, "edit") == Some(ToolAction::Deny);
+
+    if (external_directory_allowed || has_wildcard_allow(tools)) && !bash_denied && !edit_denied {
         return "danger-full-access";
     }
 
-    if let ToolsField::Map(map) = tools {
-        let default = default_tool_action(map);
-        if default != ToolAction::Deny {
-            let bash = action_for_capability(tools, "bash");
-            let edit = action_for_capability(tools, "edit");
-            if bash != ToolAction::Deny || edit != ToolAction::Deny {
-                return "danger-full-access";
-            }
-        }
+    if bash_allowed || edit_allowed {
+        return "workspace-write";
     }
 
-    let bash = action_for_capability(tools, "bash");
-    let edit = action_for_capability(tools, "edit");
-    if bash != ToolAction::Deny || edit != ToolAction::Deny {
-        "workspace-write"
-    } else {
-        "read-only"
-    }
+    "read-only"
 }
 
 fn collect_codex_tools_lossiness(
@@ -965,6 +975,7 @@ pub fn lower_for_harness(
 
 #[cfg(test)]
 mod tests {
+    // qa-validated: mars-tools-abstraction
     use super::*;
     use crate::compiler::agents::{AgentDiagnostic, parse_agent_content};
 
@@ -1196,6 +1207,20 @@ mod tests {
     }
 
     #[test]
+    fn codex_wildcard_allow_with_explicit_bash_deny_does_not_infer_danger_full_access() {
+        let content =
+            "---\nname: r\nharness: codex\ntools:\n  \"*\": allow\n  bash: deny\n---\n# body";
+        let (profile, fm, _) = profile_from(content);
+        let out = lower_to_codex(&profile, fm.body());
+        let text = String::from_utf8(out.bytes).unwrap();
+        assert!(
+            text.contains("sandbox_mode = \"workspace-write\""),
+            "sandbox should not infer danger-full-access when bash is explicitly denied: {text}"
+        );
+        assert!(!text.contains("danger-full-access"));
+    }
+
+    #[test]
     fn codex_lowering_multiline_instructions_are_parseable() {
         let content = "---\nname: explorer\ndescription: \"Line one\\nLine two\"\nharness: codex\napproval: yolo\n---\n# Explore\nUse \"quotes\" and backslashes \\\\\nKeep going.";
         let (profile, fm, _) = profile_from(content);
@@ -1214,6 +1239,50 @@ mod tests {
                 .unwrap_or_default(),
             "# Explore\nUse \"quotes\" and backslashes \\\\\nKeep going."
         );
+    }
+
+    #[test]
+    fn codex_ask_tool_is_compiled_as_allow_with_approximate_lossiness() {
+        let mut tools = std::collections::BTreeMap::new();
+        tools.insert("*".to_string(), ToolRule::Action(ToolAction::Deny));
+        tools.insert("bash".to_string(), ToolRule::Action(ToolAction::Ask));
+        let profile = AgentProfile {
+            name: Some("coder".to_string()),
+            description: None,
+            harness: Some(HarnessKind::Codex),
+            model: None,
+            mode: None,
+            approval: None,
+            sandbox: None,
+            effort: None,
+            autocompact: None,
+            autocompact_pct: None,
+            skills: Vec::new(),
+            tools: Some(ToolsField::Map(tools)),
+            mcp_tools: Vec::new(),
+            harness_overrides: crate::compiler::agents::HarnessOverrides::default(),
+            model_policies: Vec::new(),
+            fanout: Vec::new(),
+        };
+
+        let out = lower_to_codex(&profile, "# body");
+        let text = String::from_utf8(out.bytes).unwrap();
+        let parsed: toml::Value = toml::from_str(&text).expect("lowered TOML should parse");
+        assert!(
+            text.contains("sandbox_mode ="),
+            "sandbox_mode should be present: {text}"
+        );
+        assert!(
+            parsed
+                .get("sandbox_mode")
+                .and_then(|v| v.as_str())
+                .is_some(),
+            "parsed TOML should include sandbox_mode: {parsed:?}"
+        );
+        assert!(out.lossy_fields.iter().any(|lf| {
+            matches!(lf.classification, Lossiness::Approximate { .. })
+                && (lf.field.contains("tools") || lf.field.contains("bash"))
+        }));
     }
 
     // --- 3.3: OpenCode lowering ---

--- a/src/compiler/agents/lower.rs
+++ b/src/compiler/agents/lower.rs
@@ -10,7 +10,9 @@
 /// - **meridian-only** — consumed exclusively by Meridian; never lowered
 ///
 /// Dropped fields with non-default values emit [`LossyField`] diagnostics.
-use crate::compiler::agents::{AgentProfile, HarnessKind, OverrideFields};
+use crate::compiler::agents::{
+    AgentProfile, HarnessKind, OverrideFields, ToolAction, ToolRule, ToolsField,
+};
 use crate::frontmatter::Frontmatter;
 
 // ---------------------------------------------------------------------------
@@ -82,24 +84,298 @@ impl<'a> Effective<'a> {
         &self.profile.skills
     }
 
-    fn tools(&self) -> &[String] {
-        if let Some(ov) = self.over.and_then(|o| o.tools.as_ref()) {
-            return ov;
-        }
-        &self.profile.tools
-    }
-
-    fn disallowed_tools(&self) -> &[String] {
-        if let Some(ov) = self.over.and_then(|o| o.disallowed_tools.as_ref()) {
-            return ov;
-        }
-        &self.profile.disallowed_tools
+    fn tools(&self) -> Option<&ToolsField> {
+        self.over
+            .and_then(|o| o.tools.as_ref())
+            .or(self.profile.tools.as_ref())
     }
 
     fn autocompact_pct(&self) -> Option<u8> {
         self.over
             .and_then(|o| o.autocompact_pct)
             .or(self.profile.autocompact_pct)
+    }
+}
+
+const CAPABILITY_TO_CLAUDE_TOOLS: &[(&str, &[&str])] = &[
+    ("bash", &["Bash"]),
+    ("read", &["Read"]),
+    ("edit", &["Edit", "Write"]),
+    ("glob", &["Glob"]),
+    ("grep", &["Grep"]),
+    ("task", &["Agent"]),
+    ("web", &["WebSearch", "WebFetch"]),
+    ("lsp", &["LSP"]),
+];
+
+fn push_lossy(
+    lossy: &mut Vec<LossyField>,
+    field: impl Into<String>,
+    target: &str,
+    classification: Lossiness,
+) {
+    lossy.push(LossyField {
+        field: field.into(),
+        target: target.to_string(),
+        classification,
+    });
+}
+
+fn push_unique(dest: &mut Vec<String>, values: &[String]) {
+    for value in values {
+        if !dest.contains(value) {
+            dest.push(value.clone());
+        }
+    }
+}
+
+fn cap_to_claude_tools(cap: &str) -> Vec<String> {
+    CAPABILITY_TO_CLAUDE_TOOLS
+        .iter()
+        .find_map(|(capability, tools)| {
+            (*capability == cap).then_some(tools.iter().map(|s| (*s).to_string()).collect())
+        })
+        .unwrap_or_else(|| vec![cap.to_string()])
+}
+
+fn compile_tools_for_claude(
+    tools: Option<&ToolsField>,
+    lossy: &mut Vec<LossyField>,
+    target: &str,
+) -> (Option<Vec<String>>, Option<Vec<String>>) {
+    let Some(tools) = tools else {
+        return (None, None);
+    };
+
+    match tools {
+        ToolsField::Shorthand(ToolAction::Allow) => (None, None),
+        ToolsField::Shorthand(ToolAction::Deny) => (Some(Vec::new()), None),
+        ToolsField::Shorthand(ToolAction::Ask) => {
+            push_lossy(
+                lossy,
+                "tools",
+                target,
+                Lossiness::Approximate {
+                    note: "Claude cannot preserve ask policy; lowered as allow",
+                },
+            );
+            (None, None)
+        }
+        ToolsField::Map(map) => {
+            let default_action = match map.get("*") {
+                Some(ToolRule::Action(action)) => action.clone(),
+                Some(ToolRule::Scoped(_)) => {
+                    push_lossy(lossy, "tools.*", target, Lossiness::Dropped);
+                    ToolAction::Allow
+                }
+                None => ToolAction::Allow,
+            };
+            if default_action == ToolAction::Ask {
+                push_lossy(
+                    lossy,
+                    "tools.*",
+                    target,
+                    Lossiness::Approximate {
+                        note: "Claude cannot preserve ask policy; lowered as allow",
+                    },
+                );
+            }
+
+            let mut allow = Vec::new();
+            let mut deny = Vec::new();
+
+            for (cap, rule) in map {
+                if cap == "*" {
+                    continue;
+                }
+                match rule {
+                    ToolRule::Scoped(_) => {
+                        push_lossy(lossy, format!("tools.{cap}"), target, Lossiness::Dropped);
+                    }
+                    ToolRule::Action(action) => {
+                        if *action == ToolAction::Ask {
+                            push_lossy(
+                                lossy,
+                                format!("tools.{cap}"),
+                                target,
+                                Lossiness::Approximate {
+                                    note: "Claude cannot preserve ask policy; lowered as allow",
+                                },
+                            );
+                        }
+                        let mapped = cap_to_claude_tools(cap);
+                        let action_as_allow = *action != ToolAction::Deny;
+                        let default_allows = default_action != ToolAction::Deny;
+                        if action_as_allow && !default_allows {
+                            push_unique(&mut allow, &mapped);
+                        } else if !action_as_allow && default_allows {
+                            push_unique(&mut deny, &mapped);
+                        }
+                    }
+                }
+            }
+
+            let tools_list = if default_action == ToolAction::Deny || !allow.is_empty() {
+                Some(allow)
+            } else {
+                None
+            };
+            let deny_list = (!deny.is_empty()).then_some(deny);
+            (tools_list, deny_list)
+        }
+    }
+}
+
+fn default_tool_action(map: &std::collections::BTreeMap<String, ToolRule>) -> ToolAction {
+    match map.get("*") {
+        Some(ToolRule::Action(action)) => action.clone(),
+        _ => ToolAction::Allow,
+    }
+}
+
+fn action_for_capability(tools: &ToolsField, capability: &str) -> ToolAction {
+    match tools {
+        ToolsField::Shorthand(action) => action.clone(),
+        ToolsField::Map(map) => match map.get(capability) {
+            Some(ToolRule::Action(action)) => action.clone(),
+            _ => default_tool_action(map),
+        },
+    }
+}
+
+fn infer_codex_sandbox_from_tools(tools: Option<&ToolsField>) -> &'static str {
+    let Some(tools) = tools else {
+        return "read-only";
+    };
+
+    let ext = action_for_capability(tools, "external_directory");
+    if ext != ToolAction::Deny {
+        return "danger-full-access";
+    }
+
+    if let ToolsField::Map(map) = tools {
+        let default = default_tool_action(map);
+        if default != ToolAction::Deny {
+            let bash = action_for_capability(tools, "bash");
+            let edit = action_for_capability(tools, "edit");
+            if bash != ToolAction::Deny || edit != ToolAction::Deny {
+                return "danger-full-access";
+            }
+        }
+    }
+
+    let bash = action_for_capability(tools, "bash");
+    let edit = action_for_capability(tools, "edit");
+    if bash != ToolAction::Deny || edit != ToolAction::Deny {
+        "workspace-write"
+    } else {
+        "read-only"
+    }
+}
+
+fn collect_codex_tools_lossiness(
+    tools: Option<&ToolsField>,
+    lossy: &mut Vec<LossyField>,
+    target: &str,
+) {
+    let Some(tools) = tools else {
+        return;
+    };
+
+    match tools {
+        ToolsField::Shorthand(ToolAction::Ask) => push_lossy(
+            lossy,
+            "tools",
+            target,
+            Lossiness::Approximate {
+                note: "Codex tools collapse to sandbox-only policy",
+            },
+        ),
+        ToolsField::Shorthand(_) => {}
+        ToolsField::Map(map) => {
+            for (cap, rule) in map {
+                if let ToolRule::Action(ToolAction::Ask) = rule {
+                    push_lossy(
+                        lossy,
+                        format!("tools.{cap}"),
+                        target,
+                        Lossiness::Approximate {
+                            note: "ask lowered as allow in sandbox inference",
+                        },
+                    );
+                    continue;
+                }
+                push_lossy(
+                    lossy,
+                    format!("tools.{cap}"),
+                    target,
+                    Lossiness::Approximate {
+                        note: "Codex tools collapse to sandbox-only policy",
+                    },
+                );
+            }
+        }
+    }
+}
+
+fn compile_tools_for_pi(
+    tools: Option<&ToolsField>,
+    lossy: &mut Vec<LossyField>,
+    target: &str,
+) -> Option<String> {
+    let tools = tools?;
+
+    match tools {
+        ToolsField::Shorthand(ToolAction::Allow) => None,
+        ToolsField::Shorthand(ToolAction::Deny) => Some(String::new()),
+        ToolsField::Shorthand(ToolAction::Ask) => {
+            push_lossy(
+                lossy,
+                "tools",
+                target,
+                Lossiness::Approximate {
+                    note: "Pi cannot preserve ask policy; lowered as allow",
+                },
+            );
+            None
+        }
+        ToolsField::Map(map) => {
+            let mut allowed = Vec::new();
+            for (cap, rule) in map {
+                if cap == "*" {
+                    if let ToolRule::Action(ToolAction::Ask) = rule {
+                        push_lossy(
+                            lossy,
+                            "tools.*",
+                            target,
+                            Lossiness::Approximate {
+                                note: "Pi cannot preserve ask policy; lowered as allow",
+                            },
+                        );
+                    }
+                    continue;
+                }
+                match rule {
+                    ToolRule::Scoped(_) => {
+                        push_lossy(lossy, format!("tools.{cap}"), target, Lossiness::Dropped);
+                    }
+                    ToolRule::Action(ToolAction::Allow) => allowed.push(cap.to_string()),
+                    ToolRule::Action(ToolAction::Ask) => {
+                        allowed.push(cap.to_string());
+                        push_lossy(
+                            lossy,
+                            format!("tools.{cap}"),
+                            target,
+                            Lossiness::Approximate {
+                                note: "Pi cannot preserve ask policy; lowered as allow",
+                            },
+                        );
+                    }
+                    ToolRule::Action(ToolAction::Deny) => {}
+                }
+            }
+            (!allowed.is_empty()).then_some(allowed.join(", "))
+        }
     }
 }
 
@@ -145,18 +421,15 @@ pub fn lower_to_claude(profile: &AgentProfile, _fm: &Frontmatter, body: &str) ->
             serde_yaml::Value::Sequence(skills.iter().map(|s| yv(s)).collect());
         yaml.insert(yk("skills"), seq);
     }
-    // tools — exact
-    let tools = eff.tools();
-    if !tools.is_empty() {
+    let (tools_allow, tools_deny) = compile_tools_for_claude(eff.tools(), &mut lossy, "Claude");
+    if let Some(tools) = tools_allow {
         let seq: serde_yaml::Value =
             serde_yaml::Value::Sequence(tools.iter().map(|s| yv(s)).collect());
         yaml.insert(yk("tools"), seq);
     }
-    // disallowed-tools — exact
-    let dt = eff.disallowed_tools();
-    if !dt.is_empty() {
+    if let Some(disallowed) = tools_deny {
         let seq: serde_yaml::Value =
-            serde_yaml::Value::Sequence(dt.iter().map(|s| yv(s)).collect());
+            serde_yaml::Value::Sequence(disallowed.iter().map(|s| yv(s)).collect());
         yaml.insert(yk("disallowed-tools"), seq);
     }
 
@@ -175,14 +448,14 @@ pub fn lower_to_claude(profile: &AgentProfile, _fm: &Frontmatter, body: &str) ->
 
     // --- Dropped / meridian-only fields ---
     let target = "Claude";
-    if profile.approval.is_some() {
+    if eff.approval().is_some() {
         lossy.push(LossyField {
             field: "approval".into(),
             target: target.into(),
             classification: Lossiness::Dropped,
         });
     }
-    if profile.sandbox.is_some() {
+    if eff.sandbox().is_some() {
         lossy.push(LossyField {
             field: "sandbox".into(),
             target: target.into(),
@@ -273,8 +546,11 @@ pub fn lower_to_codex(profile: &AgentProfile, body: &str) -> LoweredOutput {
     // Effort — exact (lowered to model_reasoning_effort)
     let effort_str = eff.effort().map(|e| e.as_str());
 
-    // Sandbox — exact
-    let sandbox_str = eff.sandbox().map(|s| s.as_str());
+    // Sandbox — explicit policy wins; otherwise infer from tools.
+    let sandbox_str = eff
+        .sandbox()
+        .map(|s| s.as_str())
+        .or_else(|| Some(infer_codex_sandbox_from_tools(eff.tools())));
 
     // Approval — exact (lowered to approval_policy)
     let approval_policy = eff.approval().and_then(|a| {
@@ -296,22 +572,7 @@ pub fn lower_to_codex(profile: &AgentProfile, body: &str) -> LoweredOutput {
             classification: Lossiness::Dropped,
         });
     }
-    let tools = eff.tools();
-    if !tools.is_empty() {
-        lossy.push(LossyField {
-            field: "tools".into(),
-            target: target.into(),
-            classification: Lossiness::Dropped,
-        });
-    }
-    let dt = eff.disallowed_tools();
-    if !dt.is_empty() {
-        lossy.push(LossyField {
-            field: "disallowed-tools".into(),
-            target: target.into(),
-            classification: Lossiness::Dropped,
-        });
-    }
+    collect_codex_tools_lossiness(eff.tools(), &mut lossy, target);
     if !profile.mcp_tools.is_empty() {
         lossy.push(LossyField {
             field: "mcp-tools".into(),
@@ -452,20 +713,6 @@ pub fn lower_to_opencode(profile: &AgentProfile, body: &str) -> LoweredOutput {
             classification: Lossiness::Dropped,
         });
     }
-    if !eff.tools().is_empty() {
-        lossy.push(LossyField {
-            field: "tools".into(),
-            target: target.into(),
-            classification: Lossiness::Dropped,
-        });
-    }
-    if !eff.disallowed_tools().is_empty() {
-        lossy.push(LossyField {
-            field: "disallowed-tools".into(),
-            target: target.into(),
-            classification: Lossiness::Dropped,
-        });
-    }
     if eff.effort().is_some() {
         lossy.push(LossyField {
             field: "effort".into(),
@@ -548,6 +795,7 @@ pub fn lower_to_opencode(profile: &AgentProfile, body: &str) -> LoweredOutput {
 pub fn lower_to_pi(profile: &AgentProfile, body: &str) -> LoweredOutput {
     let mut lossy = Vec::new();
     let target = "Pi";
+    let eff = Effective::new(profile, &HarnessKind::Pi);
 
     let mut yaml = serde_yaml::Mapping::new();
     let yk = |s: &str| serde_yaml::Value::String(s.to_string());
@@ -574,8 +822,11 @@ pub fn lower_to_pi(profile: &AgentProfile, body: &str) -> LoweredOutput {
         });
     }
 
+    if let Some(tools) = compile_tools_for_pi(eff.tools(), &mut lossy, target) {
+        yaml.insert(yk("tools"), yv(&tools));
+    }
+
     // Everything else is dropped
-    let eff = Effective::new(profile, &HarnessKind::Pi);
     if eff.approval().is_some() {
         lossy.push(LossyField {
             field: "approval".into(),
@@ -586,20 +837,6 @@ pub fn lower_to_pi(profile: &AgentProfile, body: &str) -> LoweredOutput {
     if eff.sandbox().is_some() {
         lossy.push(LossyField {
             field: "sandbox".into(),
-            target: target.into(),
-            classification: Lossiness::Dropped,
-        });
-    }
-    if !eff.tools().is_empty() {
-        lossy.push(LossyField {
-            field: "tools".into(),
-            target: target.into(),
-            classification: Lossiness::Dropped,
-        });
-    }
-    if !eff.disallowed_tools().is_empty() {
-        lossy.push(LossyField {
-            field: "disallowed-tools".into(),
             target: target.into(),
             classification: Lossiness::Dropped,
         });
@@ -701,7 +938,7 @@ mod tests {
 
     #[test]
     fn claude_lowering_preserves_name_description_model_skills_tools_body() {
-        let content = "---\nname: coder\ndescription: Code impl agent\nmodel: gpt55\nharness: claude\nskills: [dev-principles]\ntools: [Bash, Write]\n---\n# Coder\nYou write code.";
+        let content = "---\nname: coder\ndescription: Code impl agent\nmodel: gpt55\nharness: claude\nskills: [dev-principles]\ntools:\n  \"*\": deny\n  bash: allow\n  edit: allow\n---\n# Coder\nYou write code.";
         let (profile, fm, _) = profile_from(content);
         let body = fm.body();
         let out = lower_to_claude(&profile, &fm, body);
@@ -714,7 +951,41 @@ mod tests {
         assert!(text.contains("model: gpt55"), "model missing");
         assert!(text.contains("skills"), "skills missing");
         assert!(text.contains("tools"), "tools missing");
+        assert!(text.contains("Bash"), "bash missing");
+        assert!(text.contains("Edit"), "edit missing");
+        assert!(text.contains("Write"), "write missing");
         assert!(text.contains("# Coder"), "body missing");
+    }
+
+    #[test]
+    fn claude_tools_ask_is_approximate_and_scoped_is_dropped() {
+        let content = "---\nname: coder\nharness: claude\ntools:\n  \"*\": deny\n  bash: ask\n  read:\n    \"*.env\": allow\n---\n# Body";
+        let (profile, fm, _) = profile_from(content);
+        let out = lower_to_claude(&profile, &fm, fm.body());
+        let text = String::from_utf8(out.bytes).unwrap();
+        assert!(text.contains("Bash"), "ask should lower to allow");
+        assert!(!text.contains("*.env"), "scoped rule should be dropped");
+        assert!(out.lossy_fields.iter().any(|lf| {
+            lf.field == "tools.bash" && matches!(lf.classification, Lossiness::Approximate { .. })
+        }));
+        assert!(out.lossy_fields.iter().any(|lf| {
+            lf.field == "tools.read" && matches!(lf.classification, Lossiness::Dropped)
+        }));
+    }
+
+    #[test]
+    fn claude_tools_map_default_allow_emits_disallowed_tools() {
+        let content =
+            "---\nname: r\nharness: claude\ntools:\n  \"*\": allow\n  task: deny\n---\n# body";
+        let (profile, fm, _) = profile_from(content);
+        let out = lower_to_claude(&profile, &fm, fm.body());
+        let text = String::from_utf8(out.bytes).unwrap();
+        assert!(!text.contains("tools: []"), "should not emit allowlist");
+        assert!(
+            text.contains("disallowed-tools"),
+            "deny list should be emitted"
+        );
+        assert!(text.contains("Agent"), "task deny should map to Agent");
     }
 
     #[test]
@@ -823,24 +1094,33 @@ mod tests {
     }
 
     #[test]
-    fn codex_lowering_drops_skills_and_tools() {
-        let content = "---\nname: r\nharness: codex\nskills: [review]\ntools: [Bash]\ndisallowed-tools: [Agent]\n---\n# body";
+    fn codex_lowering_drops_skills_and_inferrs_sandbox_from_tools() {
+        let content = "---\nname: r\nharness: codex\nskills: [review]\ntools:\n  \"*\": deny\n  bash: allow\n---\n# body";
         let (profile, fm, _) = profile_from(content);
         let out = lower_to_codex(&profile, fm.body());
-        let dropped: Vec<_> = out
+        let approx: Vec<_> = out
             .lossy_fields
             .iter()
-            .filter(|f| matches!(f.classification, Lossiness::Dropped))
+            .filter(|f| matches!(f.classification, Lossiness::Approximate { .. }))
             .map(|f| f.field.as_str())
             .collect();
-        assert!(dropped.contains(&"skills"));
-        assert!(dropped.contains(&"tools"));
-        assert!(dropped.contains(&"disallowed-tools"));
+        assert!(approx.contains(&"tools.bash"));
+        assert!(
+            out.lossy_fields
+                .iter()
+                .any(|f| { f.field == "skills" && matches!(f.classification, Lossiness::Dropped) })
+        );
+
+        let text = String::from_utf8(out.bytes).unwrap();
+        assert!(
+            text.contains("sandbox_mode = \"workspace-write\""),
+            "sandbox should be inferred from bash allow: {text}"
+        );
     }
 
     #[test]
     fn codex_harness_override_applied() {
-        let content = "---\nname: r\nharness: codex\neffort: low\nharness-overrides:\n  codex:\n    effort: high\n    sandbox: workspace-write\n---\n# body";
+        let content = "---\nname: r\nharness: codex\ntools:\n  \"*\": deny\n  bash: allow\nharness-overrides:\n  codex:\n    effort: high\n    sandbox: read-only\n    tools:\n      \"*\": deny\n      read: allow\n---\n# body";
         let (profile, fm, _) = profile_from(content);
         let out = lower_to_codex(&profile, fm.body());
         let text = String::from_utf8(out.bytes).unwrap();
@@ -849,8 +1129,29 @@ mod tests {
             "override not applied: {text}"
         );
         assert!(
-            text.contains("sandbox_mode = \"workspace-write\""),
+            text.contains("sandbox_mode = \"read-only\""),
             "sandbox override not applied: {text}"
+        );
+        assert!(
+            out.lossy_fields.iter().any(|lf| lf.field == "tools.read"
+                && matches!(lf.classification, Lossiness::Approximate { .. })),
+            "override tools should replace top-level tools"
+        );
+        assert!(
+            !out.lossy_fields.iter().any(|lf| lf.field == "tools.bash"),
+            "top-level tools should be replaced by override tools"
+        );
+    }
+
+    #[test]
+    fn codex_infers_danger_full_access_when_default_allow_and_no_write_denies() {
+        let content = "---\nname: r\nharness: codex\ntools:\n  \"*\": allow\n---\n# body";
+        let (profile, fm, _) = profile_from(content);
+        let out = lower_to_codex(&profile, fm.body());
+        let text = String::from_utf8(out.bytes).unwrap();
+        assert!(
+            text.contains("sandbox_mode = \"danger-full-access\""),
+            "sandbox should infer danger-full-access: {text}"
         );
     }
 
@@ -889,6 +1190,20 @@ mod tests {
         assert!(text.contains("mode: primary"), "mode missing");
     }
 
+    #[test]
+    fn opencode_lowering_omits_tools_fields() {
+        let content =
+            "---\nname: r\nharness: opencode\ntools:\n  \"*\": deny\n  bash: allow\n---\n# body";
+        let (profile, fm, _) = profile_from(content);
+        let out = lower_to_opencode(&profile, fm.body());
+        let text = String::from_utf8(out.bytes).unwrap();
+        assert!(!text.contains("tools:"), "tools must not be emitted");
+        assert!(
+            !text.contains("disallowed-tools"),
+            "legacy field must not appear"
+        );
+    }
+
     // --- 3.3: Pi lowering ---
 
     #[test]
@@ -899,6 +1214,24 @@ mod tests {
         let text = String::from_utf8(out.bytes).unwrap();
         assert!(text.contains("name: pi-agent"), "name missing");
         assert!(text.contains("description: Pi agent"), "desc missing");
+    }
+
+    #[test]
+    fn pi_lowering_emits_tools_and_flags_ask_and_scoped() {
+        let content = "---\nname: pi-agent\nharness: pi\ntools:\n  \"*\": deny\n  bash: allow\n  web: ask\n  read:\n    \"*.env\": allow\n---\n# body";
+        let (profile, fm, _) = profile_from(content);
+        let out = lower_to_pi(&profile, fm.body());
+        let text = String::from_utf8(out.bytes).unwrap();
+        assert!(
+            text.contains("tools: bash, web"),
+            "tools list missing: {text}"
+        );
+        assert!(out.lossy_fields.iter().any(|lf| {
+            lf.field == "tools.web" && matches!(lf.classification, Lossiness::Approximate { .. })
+        }));
+        assert!(out.lossy_fields.iter().any(|lf| {
+            lf.field == "tools.read" && matches!(lf.classification, Lossiness::Dropped)
+        }));
     }
 
     // --- 3.3: Dispatch ---

--- a/src/compiler/agents/lower.rs
+++ b/src/compiler/agents/lower.rs
@@ -11,7 +11,7 @@
 ///
 /// Dropped fields with non-default values emit [`LossyField`] diagnostics.
 use crate::compiler::agents::{
-    AgentProfile, HarnessKind, OverrideFields, ToolAction, ToolRule, ToolsField,
+    AgentProfile, HarnessKind, OverrideFields, SandboxMode, ToolAction, ToolRule, ToolsField,
 };
 use crate::frontmatter::Frontmatter;
 
@@ -294,28 +294,68 @@ fn collect_codex_tools_lossiness(
         ToolsField::Shorthand(_) => {}
         ToolsField::Map(map) => {
             for (cap, rule) in map {
-                if let ToolRule::Action(ToolAction::Ask) = rule {
-                    push_lossy(
-                        lossy,
-                        format!("tools.{cap}"),
-                        target,
-                        Lossiness::Approximate {
-                            note: "ask lowered as allow in sandbox inference",
-                        },
-                    );
+                // Wildcard allow/deny map exactly to sandbox semantics — no lossiness.
+                if cap == "*" {
+                    if let ToolRule::Action(ToolAction::Ask) = rule {
+                        push_lossy(
+                            lossy,
+                            "tools.*",
+                            target,
+                            Lossiness::Approximate {
+                                note: "ask lowered as allow in sandbox inference",
+                            },
+                        );
+                    }
                     continue;
                 }
-                push_lossy(
-                    lossy,
-                    format!("tools.{cap}"),
-                    target,
-                    Lossiness::Approximate {
-                        note: "Codex tools collapse to sandbox-only policy",
-                    },
-                );
+                match rule {
+                    ToolRule::Action(ToolAction::Ask) => {
+                        push_lossy(
+                            lossy,
+                            format!("tools.{cap}"),
+                            target,
+                            Lossiness::Approximate {
+                                note: "ask lowered as allow in sandbox inference",
+                            },
+                        );
+                    }
+                    ToolRule::Scoped(_) => {
+                        push_lossy(
+                            lossy,
+                            format!("tools.{cap}"),
+                            target,
+                            Lossiness::Dropped,
+                        );
+                    }
+                    _ => {
+                        push_lossy(
+                            lossy,
+                            format!("tools.{cap}"),
+                            target,
+                            Lossiness::Approximate {
+                                note: "Codex tools collapse to sandbox-only policy",
+                            },
+                        );
+                    }
+                }
             }
         }
     }
+}
+
+/// Capability expansions for Pi — capabilities that map to multiple tool names.
+const PI_CAPABILITY_EXPANSIONS: &[(&str, &[&str])] = &[
+    ("edit", &["edit", "write"]),
+    ("web", &["websearch", "webfetch"]),
+];
+
+fn expand_pi_capability(cap: &str) -> Vec<String> {
+    PI_CAPABILITY_EXPANSIONS
+        .iter()
+        .find_map(|(c, expanded)| {
+            (*c == cap).then_some(expanded.iter().map(|s| (*s).to_string()).collect())
+        })
+        .unwrap_or_else(|| vec![cap.to_string()])
 }
 
 fn compile_tools_for_pi(
@@ -359,9 +399,11 @@ fn compile_tools_for_pi(
                     ToolRule::Scoped(_) => {
                         push_lossy(lossy, format!("tools.{cap}"), target, Lossiness::Dropped);
                     }
-                    ToolRule::Action(ToolAction::Allow) => allowed.push(cap.to_string()),
+                    ToolRule::Action(ToolAction::Allow) => {
+                        push_unique(&mut allowed, &expand_pi_capability(cap));
+                    }
                     ToolRule::Action(ToolAction::Ask) => {
-                        allowed.push(cap.to_string());
+                        push_unique(&mut allowed, &expand_pi_capability(cap));
                         push_lossy(
                             lossy,
                             format!("tools.{cap}"),
@@ -546,11 +588,12 @@ pub fn lower_to_codex(profile: &AgentProfile, body: &str) -> LoweredOutput {
     // Effort — exact (lowered to model_reasoning_effort)
     let effort_str = eff.effort().map(|e| e.as_str());
 
-    // Sandbox — explicit policy wins; otherwise infer from tools.
-    let sandbox_str = eff
-        .sandbox()
-        .map(|s| s.as_str())
-        .or_else(|| Some(infer_codex_sandbox_from_tools(eff.tools())));
+    // Sandbox — explicit non-default policy wins; otherwise infer from tools
+    // only when tools are present. No tools + no sandbox → omit sandbox_mode.
+    let sandbox_str = match eff.sandbox() {
+        Some(s) if *s != SandboxMode::Default => Some(s.as_str()),
+        _ => eff.tools().map(|_| infer_codex_sandbox_from_tools(eff.tools())),
+    };
 
     // Approval — exact (lowered to approval_policy)
     let approval_policy = eff.approval().and_then(|a| {
@@ -1222,8 +1265,9 @@ mod tests {
         let (profile, fm, _) = profile_from(content);
         let out = lower_to_pi(&profile, fm.body());
         let text = String::from_utf8(out.bytes).unwrap();
+        // web expands to websearch, webfetch
         assert!(
-            text.contains("tools: bash, web"),
+            text.contains("tools: bash, websearch, webfetch"),
             "tools list missing: {text}"
         );
         assert!(out.lossy_fields.iter().any(|lf| {
@@ -1235,6 +1279,63 @@ mod tests {
     }
 
     // --- 3.3: Dispatch ---
+
+    #[test]
+    fn codex_no_tools_no_sandbox_omits_sandbox_mode() {
+        let content = "---\nname: r\nharness: codex\n---\n# body";
+        let (profile, fm, _) = profile_from(content);
+        let out = lower_to_codex(&profile, fm.body());
+        let text = String::from_utf8(out.bytes).unwrap();
+        assert!(
+            !text.contains("sandbox_mode"),
+            "sandbox_mode should be omitted when no tools and no sandbox: {text}"
+        );
+    }
+
+    #[test]
+    fn codex_sandbox_default_no_tools_omits_sandbox_mode() {
+        let content = "---\nname: r\nharness: codex\nsandbox: default\n---\n# body";
+        let (profile, fm, _) = profile_from(content);
+        let out = lower_to_codex(&profile, fm.body());
+        let text = String::from_utf8(out.bytes).unwrap();
+        assert!(
+            !text.contains("sandbox_mode"),
+            "sandbox: default with no tools should omit sandbox_mode: {text}"
+        );
+    }
+
+    #[test]
+    fn codex_wildcard_only_allow_no_extra_lossiness() {
+        let content = "---\nname: r\nharness: codex\ntools:\n  \"*\": allow\n---\n# body";
+        let (profile, fm, _) = profile_from(content);
+        let out = lower_to_codex(&profile, fm.body());
+        // Wildcard allow/deny maps exactly to sandbox — no Approximate entries
+        let approx: Vec<_> = out
+            .lossy_fields
+            .iter()
+            .filter(|f| matches!(f.classification, Lossiness::Approximate { .. }))
+            .collect();
+        assert!(
+            approx.is_empty(),
+            "wildcard-only allow should not produce Approximate lossiness: {approx:?}"
+        );
+    }
+
+    #[test]
+    fn pi_lowering_expands_edit_and_web_capabilities() {
+        let content = "---\nname: pi-agent\nharness: pi\ntools:\n  \"*\": deny\n  edit: allow\n  web: allow\n---\n# body";
+        let (profile, fm, _) = profile_from(content);
+        let out = lower_to_pi(&profile, fm.body());
+        let text = String::from_utf8(out.bytes).unwrap();
+        assert!(
+            text.contains("edit, write"),
+            "edit should expand to edit, write: {text}"
+        );
+        assert!(
+            text.contains("websearch, webfetch"),
+            "web should expand to websearch, webfetch: {text}"
+        );
+    }
 
     #[test]
     fn lower_for_harness_dispatches_correctly() {

--- a/src/compiler/agents/lower.rs
+++ b/src/compiler/agents/lower.rs
@@ -320,12 +320,7 @@ fn collect_codex_tools_lossiness(
                         );
                     }
                     ToolRule::Scoped(_) => {
-                        push_lossy(
-                            lossy,
-                            format!("tools.{cap}"),
-                            target,
-                            Lossiness::Dropped,
-                        );
+                        push_lossy(lossy, format!("tools.{cap}"), target, Lossiness::Dropped);
                     }
                     _ => {
                         push_lossy(
@@ -592,7 +587,9 @@ pub fn lower_to_codex(profile: &AgentProfile, body: &str) -> LoweredOutput {
     // only when tools are present. No tools + no sandbox → omit sandbox_mode.
     let sandbox_str = match eff.sandbox() {
         Some(s) if *s != SandboxMode::Default => Some(s.as_str()),
-        _ => eff.tools().map(|_| infer_codex_sandbox_from_tools(eff.tools())),
+        _ => eff
+            .tools()
+            .map(|_| infer_codex_sandbox_from_tools(eff.tools())),
     };
 
     // Approval — exact (lowered to approval_policy)

--- a/src/compiler/agents/mod.rs
+++ b/src/compiler/agents/mod.rs
@@ -7,6 +7,8 @@
 /// - Report lossiness diagnostics when fields cannot be expressed in a target format
 pub mod lower;
 
+use std::collections::BTreeMap;
+
 use serde_yaml::Value;
 
 use crate::frontmatter::{Frontmatter, FrontmatterError};
@@ -162,6 +164,43 @@ impl EffortLevel {
     }
 }
 
+/// Action for a capability entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolAction {
+    Allow,
+    Deny,
+    Ask,
+}
+
+impl ToolAction {
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "allow" => Some(Self::Allow),
+            "deny" => Some(Self::Deny),
+            "ask" => Some(Self::Ask),
+            _ => None,
+        }
+    }
+}
+
+/// A single capability rule — either a flat action or scoped patterns.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolRule {
+    /// Flat: `bash: allow`
+    Action(ToolAction),
+    /// Scoped: `read: { "*": allow, "*.env": ask }`
+    Scoped(BTreeMap<String, ToolAction>),
+}
+
+/// The abstract tools field.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolsField {
+    /// `tools: allow` or `tools: deny`
+    Shorthand(ToolAction),
+    /// `tools: { "*": deny, bash: allow, ... }`
+    Map(BTreeMap<String, ToolRule>),
+}
+
 // ---------------------------------------------------------------------------
 // Override table types
 // ---------------------------------------------------------------------------
@@ -176,8 +215,7 @@ pub struct OverrideFields {
     pub approval: Option<ApprovalMode>,
     pub sandbox: Option<SandboxMode>,
     pub skills: Option<Vec<String>>,
-    pub tools: Option<Vec<String>>,
-    pub disallowed_tools: Option<Vec<String>>,
+    pub tools: Option<ToolsField>,
     pub mcp_tools: Option<Vec<String>>,
 }
 
@@ -249,8 +287,7 @@ pub struct AgentProfile {
 
     // --- Tool fields ---
     pub skills: Vec<String>,
-    pub tools: Vec<String>,
-    pub disallowed_tools: Vec<String>,
+    pub tools: Option<ToolsField>,
     pub mcp_tools: Vec<String>,
 
     // --- Override tables ---
@@ -274,6 +311,10 @@ pub enum AgentDiagnostic {
     },
     /// Deprecated `models:` field was found (use `model-overrides:` instead).
     LegacyModelsField,
+    /// Deprecated `tools: [..]` list form was found.
+    DeprecatedToolsList,
+    /// Deprecated `disallowed-tools:` field was found.
+    DeprecatedDisallowedTools,
     /// Unknown harness name — not one of claude/codex/opencode/pi.
     UnknownHarness { value: String },
     /// Non-overridable field appears inside an override block.
@@ -296,6 +337,14 @@ impl AgentDiagnostic {
             }
             AgentDiagnostic::LegacyModelsField => {
                 "agent uses deprecated `models:` field; rename to `model-overrides:`".to_string()
+            }
+            AgentDiagnostic::DeprecatedToolsList => {
+                "agent uses deprecated `tools: [..]` list; use abstract tools map/shorthand"
+                    .to_string()
+            }
+            AgentDiagnostic::DeprecatedDisallowedTools => {
+                "agent uses deprecated `disallowed-tools:` field; use abstract tools map"
+                    .to_string()
             }
             AgentDiagnostic::UnknownHarness { value } => {
                 format!("unknown harness `{value}`; known: claude, codex, opencode, pi")
@@ -334,6 +383,185 @@ fn yaml_str_list(val: &Value) -> Vec<String> {
             .collect(),
         Value::String(s) => vec![s.clone()],
         _ => vec![],
+    }
+}
+
+const CLAUDE_TO_ABSTRACT: &[(&str, &str)] = &[
+    ("Bash", "bash"),
+    ("Read", "read"),
+    ("Edit", "edit"),
+    ("Write", "edit"),
+    ("Glob", "glob"),
+    ("Grep", "grep"),
+    ("Agent", "task"),
+    ("WebSearch", "web"),
+    ("WebFetch", "web"),
+    ("LSP", "lsp"),
+];
+
+fn map_legacy_claude_tool_name(name: &str) -> String {
+    CLAUDE_TO_ABSTRACT
+        .iter()
+        .find_map(|(legacy, mapped)| (*legacy == name).then_some((*mapped).to_string()))
+        .unwrap_or_else(|| name.to_string())
+}
+
+fn parse_tool_action(
+    val: &Value,
+    field: &str,
+    diags: &mut Vec<AgentDiagnostic>,
+) -> Option<ToolAction> {
+    let Some(s) = val.as_str() else {
+        diags.push(AgentDiagnostic::InvalidFieldValue {
+            field: field.to_string(),
+            value: format!("{val:?}"),
+            allowed: "allow, deny, ask",
+        });
+        return None;
+    };
+
+    match ToolAction::from_str(s) {
+        Some(action) => Some(action),
+        None => {
+            diags.push(AgentDiagnostic::InvalidFieldValue {
+                field: field.to_string(),
+                value: s.to_string(),
+                allowed: "allow, deny, ask",
+            });
+            None
+        }
+    }
+}
+
+fn tools_map_from_legacy_list(list: &[String]) -> ToolsField {
+    let mut map = BTreeMap::new();
+    map.insert("*".to_string(), ToolRule::Action(ToolAction::Deny));
+    for key in list.iter().map(|tool| map_legacy_claude_tool_name(tool)) {
+        map.insert(key, ToolRule::Action(ToolAction::Allow));
+    }
+    ToolsField::Map(map)
+}
+
+fn merge_disallowed_into_tools(base: Option<ToolsField>, deny_list: &[String]) -> ToolsField {
+    let mut map = match base {
+        Some(ToolsField::Map(map)) => map,
+        Some(ToolsField::Shorthand(ToolAction::Allow)) | None => {
+            let mut m = BTreeMap::new();
+            m.insert("*".to_string(), ToolRule::Action(ToolAction::Allow));
+            m
+        }
+        Some(ToolsField::Shorthand(ToolAction::Deny)) => {
+            let mut m = BTreeMap::new();
+            m.insert("*".to_string(), ToolRule::Action(ToolAction::Deny));
+            m
+        }
+        Some(ToolsField::Shorthand(ToolAction::Ask)) => {
+            let mut m = BTreeMap::new();
+            m.insert("*".to_string(), ToolRule::Action(ToolAction::Ask));
+            m
+        }
+    };
+
+    for key in deny_list
+        .iter()
+        .map(|tool| map_legacy_claude_tool_name(tool))
+    {
+        map.insert(key, ToolRule::Action(ToolAction::Deny));
+    }
+
+    ToolsField::Map(map)
+}
+
+fn parse_tools_field(
+    val: &Value,
+    field_name: &str,
+    diags: &mut Vec<AgentDiagnostic>,
+) -> Option<ToolsField> {
+    match val {
+        Value::String(s) => match ToolAction::from_str(s) {
+            Some(action @ (ToolAction::Allow | ToolAction::Deny)) => {
+                Some(ToolsField::Shorthand(action))
+            }
+            Some(ToolAction::Ask) => {
+                diags.push(AgentDiagnostic::InvalidFieldValue {
+                    field: field_name.to_string(),
+                    value: s.to_string(),
+                    allowed: "allow, deny",
+                });
+                None
+            }
+            None => {
+                diags.push(AgentDiagnostic::InvalidFieldValue {
+                    field: field_name.to_string(),
+                    value: s.to_string(),
+                    allowed: "allow, deny, or mapping",
+                });
+                None
+            }
+        },
+        Value::Sequence(seq) => {
+            diags.push(AgentDiagnostic::DeprecatedToolsList);
+            let list = seq
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_owned)
+                .collect::<Vec<_>>();
+            Some(tools_map_from_legacy_list(&list))
+        }
+        Value::Mapping(mapping) => {
+            let mut out = BTreeMap::new();
+            for (k, v) in mapping {
+                let Some(key) = k.as_str() else {
+                    continue;
+                };
+                let field_key = format!("{field_name}.{key}");
+                if let Some(action) = v.as_str() {
+                    match ToolAction::from_str(action) {
+                        Some(a) => {
+                            out.insert(key.to_string(), ToolRule::Action(a));
+                        }
+                        None => {
+                            diags.push(AgentDiagnostic::InvalidFieldValue {
+                                field: field_key,
+                                value: action.to_string(),
+                                allowed: "allow, deny, ask",
+                            });
+                        }
+                    }
+                    continue;
+                }
+
+                if let Value::Mapping(scoped) = v {
+                    let mut scoped_out = BTreeMap::new();
+                    for (pattern, action_val) in scoped {
+                        let Some(pattern_s) = pattern.as_str() else {
+                            continue;
+                        };
+                        let scoped_field = format!("{field_name}.{key}.{pattern_s}");
+                        if let Some(action) = parse_tool_action(action_val, &scoped_field, diags) {
+                            scoped_out.insert(pattern_s.to_string(), action);
+                        }
+                    }
+                    out.insert(key.to_string(), ToolRule::Scoped(scoped_out));
+                    continue;
+                }
+
+                diags.push(AgentDiagnostic::InvalidFieldValue {
+                    field: field_key,
+                    value: format!("{v:?}"),
+                    allowed: "allow, deny, ask, or scoped mapping",
+                });
+            }
+            Some(ToolsField::Map(out))
+        }
+        _ => {
+            diags.push(AgentDiagnostic::InvalidFieldValue {
+                field: field_name.to_string(),
+                value: format!("{val:?}"),
+                allowed: "allow, deny, list, or mapping",
+            });
+            None
+        }
     }
 }
 
@@ -439,10 +667,7 @@ fn parse_override_fields(
                 out.skills = Some(yaml_str_list(v));
             }
             "tools" => {
-                out.tools = Some(yaml_str_list(v));
-            }
-            "disallowed-tools" => {
-                out.disallowed_tools = Some(yaml_str_list(v));
+                out.tools = parse_tools_field(v, &format!("{table_name}.tools"), diags);
             }
             "mcp-tools" => {
                 out.mcp_tools = Some(yaml_str_list(v));
@@ -648,11 +873,14 @@ pub fn parse_agent_profile(fm: &Frontmatter, diags: &mut Vec<AgentDiagnostic>) -
 
     // skills/tools/disallowed-tools/mcp-tools:
     let skills = fm.skills();
-    let tools = fm.get("tools").map(yaml_str_list).unwrap_or_default();
-    let disallowed_tools = fm
-        .get("disallowed-tools")
-        .map(yaml_str_list)
-        .unwrap_or_default();
+    let mut tools = fm
+        .get("tools")
+        .and_then(|v| parse_tools_field(v, "tools", diags));
+    let disallowed_tools = fm.get("disallowed-tools").map(yaml_str_list);
+    if let Some(deny_list) = disallowed_tools.as_ref() {
+        diags.push(AgentDiagnostic::DeprecatedDisallowedTools);
+        tools = Some(merge_disallowed_into_tools(tools, deny_list));
+    }
     let mcp_tools = fm.get("mcp-tools").map(yaml_str_list).unwrap_or_default();
 
     // harness-overrides:
@@ -688,7 +916,6 @@ pub fn parse_agent_profile(fm: &Frontmatter, diags: &mut Vec<AgentDiagnostic>) -
         autocompact_pct,
         skills,
         tools,
-        disallowed_tools,
         mcp_tools,
         harness_overrides,
         model_policies,
@@ -891,14 +1118,113 @@ mod tests {
         );
     }
 
+    fn as_map(field: &ToolsField) -> &BTreeMap<String, ToolRule> {
+        match field {
+            ToolsField::Map(map) => map,
+            ToolsField::Shorthand(_) => panic!("expected map"),
+        }
+    }
+
     #[test]
-    fn parses_skills_tools_disallowed_mcp() {
-        let content = "---\nskills: [review, dev-principles]\ntools: [Bash, Write]\ndisallowed-tools: [Agent]\nmcp-tools: [server]\n---\n";
+    fn parses_tools_shorthand_allow_and_deny() {
+        let (allow, diags_allow) = parse("---\ntools: allow\n---\n");
+        assert!(diags_allow.is_empty());
+        assert_eq!(allow.tools, Some(ToolsField::Shorthand(ToolAction::Allow)));
+
+        let (deny, diags_deny) = parse("---\ntools: deny\n---\n");
+        assert!(diags_deny.is_empty());
+        assert_eq!(deny.tools, Some(ToolsField::Shorthand(ToolAction::Deny)));
+    }
+
+    #[test]
+    fn parses_tools_map_flat_actions() {
+        let (p, diags) = parse("---\ntools:\n  \"*\": deny\n  bash: allow\n  read: ask\n---\n");
+        assert!(diags.is_empty());
+        let map = as_map(p.tools.as_ref().expect("tools expected"));
+        assert_eq!(map.get("*"), Some(&ToolRule::Action(ToolAction::Deny)));
+        assert_eq!(map.get("bash"), Some(&ToolRule::Action(ToolAction::Allow)));
+        assert_eq!(map.get("read"), Some(&ToolRule::Action(ToolAction::Ask)));
+    }
+
+    #[test]
+    fn parses_tools_map_scoped_patterns() {
+        let (p, diags) = parse("---\ntools:\n  read:\n    \"*\": allow\n    \"*.env\": ask\n---\n");
+        assert!(diags.is_empty());
+        let map = as_map(p.tools.as_ref().expect("tools expected"));
+        let scoped = match map.get("read").expect("read rule missing") {
+            ToolRule::Scoped(scoped) => scoped,
+            ToolRule::Action(_) => panic!("expected scoped rule"),
+        };
+        assert_eq!(scoped.get("*"), Some(&ToolAction::Allow));
+        assert_eq!(scoped.get("*.env"), Some(&ToolAction::Ask));
+    }
+
+    #[test]
+    fn deprecated_tools_list_emits_warning_and_converts() {
+        let (p, diags) = parse("---\ntools: [Bash, Write, UnknownTool]\n---\n");
+        assert_eq!(diags.len(), 1);
+        assert!(matches!(diags[0], AgentDiagnostic::DeprecatedToolsList));
+        let map = as_map(p.tools.as_ref().expect("tools expected"));
+        assert_eq!(map.get("*"), Some(&ToolRule::Action(ToolAction::Deny)));
+        assert_eq!(map.get("bash"), Some(&ToolRule::Action(ToolAction::Allow)));
+        assert_eq!(map.get("edit"), Some(&ToolRule::Action(ToolAction::Allow)));
+        assert_eq!(
+            map.get("UnknownTool"),
+            Some(&ToolRule::Action(ToolAction::Allow))
+        );
+    }
+
+    #[test]
+    fn disallowed_tools_merges_into_tools_and_warns() {
+        let content = "---\ntools:\n  \"*\": deny\n  bash: allow\ndisallowed-tools: [Agent]\n---\n";
+        let (p, diags) = parse(content);
+        assert_eq!(diags.len(), 1);
+        assert!(matches!(
+            diags[0],
+            AgentDiagnostic::DeprecatedDisallowedTools
+        ));
+        let map = as_map(p.tools.as_ref().expect("tools expected"));
+        assert_eq!(map.get("*"), Some(&ToolRule::Action(ToolAction::Deny)));
+        assert_eq!(map.get("bash"), Some(&ToolRule::Action(ToolAction::Allow)));
+        assert_eq!(map.get("task"), Some(&ToolRule::Action(ToolAction::Deny)));
+    }
+
+    #[test]
+    fn disallowed_tools_without_tools_becomes_allow_default_with_denies() {
+        let (p, diags) = parse("---\ndisallowed-tools: [Agent, Unknown]\n---\n");
+        assert_eq!(diags.len(), 1);
+        assert!(matches!(
+            diags[0],
+            AgentDiagnostic::DeprecatedDisallowedTools
+        ));
+        let map = as_map(p.tools.as_ref().expect("tools expected"));
+        assert_eq!(map.get("*"), Some(&ToolRule::Action(ToolAction::Allow)));
+        assert_eq!(map.get("task"), Some(&ToolRule::Action(ToolAction::Deny)));
+        assert_eq!(
+            map.get("Unknown"),
+            Some(&ToolRule::Action(ToolAction::Deny))
+        );
+    }
+
+    #[test]
+    fn invalid_tools_action_emits_error_and_skips_entry() {
+        let (p, diags) = parse("---\ntools:\n  bash: maybe\n  read: allow\n---\n");
+        assert_eq!(diags.len(), 1);
+        assert!(matches!(
+            &diags[0],
+            AgentDiagnostic::InvalidFieldValue { field, .. } if field == "tools.bash"
+        ));
+        let map = as_map(p.tools.as_ref().expect("tools expected"));
+        assert!(!map.contains_key("bash"));
+        assert_eq!(map.get("read"), Some(&ToolRule::Action(ToolAction::Allow)));
+    }
+
+    #[test]
+    fn parses_skills_and_mcp_tools() {
+        let content = "---\nskills: [review, dev-principles]\nmcp-tools: [server]\n---\n";
         let (p, diags) = parse(content);
         assert!(diags.is_empty());
         assert_eq!(p.skills, vec!["review", "dev-principles"]);
-        assert_eq!(p.tools, vec!["Bash", "Write"]);
-        assert_eq!(p.disallowed_tools, vec!["Agent"]);
         assert_eq!(p.mcp_tools, vec!["server"]);
     }
 
@@ -926,14 +1252,35 @@ mod tests {
 
     #[test]
     fn harness_overrides_parsed_for_claude_and_codex() {
-        let content = "---\nharness-overrides:\n  claude:\n    approval: auto\n  codex:\n    sandbox: workspace-write\n    effort: high\n---\n";
+        let content = "---\nharness-overrides:\n  claude:\n    approval: auto\n    tools:\n      \"*\": deny\n      bash: allow\n  codex:\n    sandbox: workspace-write\n    effort: high\n---\n";
         let (p, diags) = parse(content);
         assert!(diags.is_empty());
         let claude = p.harness_overrides.claude.as_ref().unwrap();
         assert_eq!(claude.approval, Some(ApprovalMode::Auto));
+        let tools_map = as_map(claude.tools.as_ref().expect("tools override expected"));
+        assert_eq!(
+            tools_map.get("*"),
+            Some(&ToolRule::Action(ToolAction::Deny))
+        );
+        assert_eq!(
+            tools_map.get("bash"),
+            Some(&ToolRule::Action(ToolAction::Allow))
+        );
         let codex = p.harness_overrides.codex.as_ref().unwrap();
         assert_eq!(codex.sandbox, Some(SandboxMode::WorkspaceWrite));
         assert_eq!(codex.effort, Some(EffortLevel::High));
+    }
+
+    #[test]
+    fn harness_override_deprecated_tools_list_warns() {
+        let content = "---\nharness-overrides:\n  claude:\n    tools: [Bash]\n---\n";
+        let (p, diags) = parse(content);
+        assert_eq!(diags.len(), 1);
+        assert!(matches!(diags[0], AgentDiagnostic::DeprecatedToolsList));
+        let claude = p.harness_overrides.claude.as_ref().unwrap();
+        let map = as_map(claude.tools.as_ref().expect("tools override expected"));
+        assert_eq!(map.get("*"), Some(&ToolRule::Action(ToolAction::Deny)));
+        assert_eq!(map.get("bash"), Some(&ToolRule::Action(ToolAction::Allow)));
     }
 
     #[test]

--- a/src/compiler/agents/mod.rs
+++ b/src/compiler/agents/mod.rs
@@ -460,10 +460,7 @@ fn convert_deprecated_tools_list(list: &[String]) -> ToolsField {
 /// inserted as deny entries. If no base tools field exists, defaults to `*: allow`.
 ///
 /// DEPRECATED: Remove after deprecation period (R08)
-fn merge_deprecated_disallowed_tools(
-    base: Option<ToolsField>,
-    deny_list: &[String],
-) -> ToolsField {
+fn merge_deprecated_disallowed_tools(base: Option<ToolsField>, deny_list: &[String]) -> ToolsField {
     let mut map = match base {
         Some(ToolsField::Map(map)) => map,
         Some(ToolsField::Shorthand(ToolAction::Allow)) | None => {

--- a/src/compiler/agents/mod.rs
+++ b/src/compiler/agents/mod.rs
@@ -490,6 +490,21 @@ fn merge_deprecated_disallowed_tools(base: Option<ToolsField>, deny_list: &[Stri
     ToolsField::Map(map)
 }
 
+/// DEPRECATED: Remove after deprecation period (R08)
+fn apply_deprecated_disallowed_tools_bridge(
+    tools: Option<ToolsField>,
+    deny_list: Option<&[String]>,
+    diags: &mut Vec<AgentDiagnostic>,
+) -> Option<ToolsField> {
+    match deny_list {
+        Some(deny_list) => {
+            diags.push(AgentDiagnostic::DeprecatedDisallowedTools);
+            Some(merge_deprecated_disallowed_tools(tools, deny_list))
+        }
+        None => tools,
+    }
+}
+
 /// Parse a tools field value — shorthand string or capability mapping.
 ///
 /// Handles current abstract tools format only (string shorthand or mapping).
@@ -595,6 +610,7 @@ fn parse_override_fields(
     diags: &mut Vec<AgentDiagnostic>,
 ) -> OverrideFields {
     let mut out = OverrideFields::default();
+    let mut deprecated_disallowed_tools: Option<Vec<String>> = None;
 
     for (k, v) in mapping {
         let key = match k.as_str() {
@@ -693,6 +709,10 @@ fn parse_override_fields(
             "tools" => {
                 out.tools = parse_tools_field(v, &format!("{table_name}.tools"), diags);
             }
+            // DEPRECATED: Remove after deprecation period (R08)
+            "disallowed-tools" => {
+                deprecated_disallowed_tools = Some(yaml_str_list(v));
+            }
             "mcp-tools" => {
                 out.mcp_tools = Some(yaml_str_list(v));
             }
@@ -701,6 +721,12 @@ fn parse_override_fields(
             }
         }
     }
+
+    out.tools = apply_deprecated_disallowed_tools_bridge(
+        out.tools.take(),
+        deprecated_disallowed_tools.as_deref(),
+        diags,
+    );
 
     out
 }
@@ -902,10 +928,7 @@ pub fn parse_agent_profile(fm: &Frontmatter, diags: &mut Vec<AgentDiagnostic>) -
         .and_then(|v| parse_tools_field(v, "tools", diags));
     // DEPRECATED: Remove after deprecation period (R08)
     let disallowed_tools = fm.get("disallowed-tools").map(yaml_str_list);
-    if let Some(deny_list) = disallowed_tools.as_ref() {
-        diags.push(AgentDiagnostic::DeprecatedDisallowedTools);
-        tools = Some(merge_deprecated_disallowed_tools(tools, deny_list));
-    }
+    tools = apply_deprecated_disallowed_tools_bridge(tools, disallowed_tools.as_deref(), diags);
     let mcp_tools = fm.get("mcp-tools").map(yaml_str_list).unwrap_or_default();
 
     // harness-overrides:
@@ -962,6 +985,7 @@ pub fn parse_agent_content(
 
 #[cfg(test)]
 mod tests {
+    // qa-validated: mars-tools-abstraction
     use super::*;
     use crate::frontmatter::Frontmatter;
 
@@ -1162,6 +1186,18 @@ mod tests {
     }
 
     #[test]
+    fn tools_ask_shorthand_emits_invalid_field_value_and_returns_none() {
+        let (p, diags) = parse("---\ntools: ask\n---\n");
+        assert_eq!(p.tools, None);
+        assert_eq!(diags.len(), 1);
+        assert!(matches!(
+            &diags[0],
+            AgentDiagnostic::InvalidFieldValue { field, allowed, .. }
+            if field == "tools" && allowed.contains("allow, deny")
+        ));
+    }
+
+    #[test]
     fn parses_tools_map_flat_actions() {
         let (p, diags) = parse("---\ntools:\n  \"*\": deny\n  bash: allow\n  read: ask\n---\n");
         assert!(diags.is_empty());
@@ -1182,6 +1218,25 @@ mod tests {
         };
         assert_eq!(scoped.get("*"), Some(&ToolAction::Allow));
         assert_eq!(scoped.get("*.env"), Some(&ToolAction::Ask));
+    }
+
+    #[test]
+    fn tools_map_invalid_nested_scoped_action_emits_error() {
+        let (p, diags) =
+            parse("---\ntools:\n  read:\n    \"*\": allow\n    \"*.env\": INVALID_ACTION\n---\n");
+        let map = as_map(p.tools.as_ref().expect("tools expected"));
+        let scoped = match map.get("read").expect("read rule missing") {
+            ToolRule::Scoped(scoped) => scoped,
+            ToolRule::Action(_) => panic!("expected scoped rule"),
+        };
+        assert_eq!(scoped.get("*"), Some(&ToolAction::Allow));
+        assert!(!scoped.contains_key("*.env"));
+        assert!(diags.iter().any(|d| {
+            matches!(
+                d,
+                AgentDiagnostic::InvalidFieldValue { field, .. } if field == "tools.read.*.env"
+            )
+        }));
     }
 
     #[test]
@@ -1232,6 +1287,27 @@ mod tests {
     }
 
     #[test]
+    fn tools_disallowed_with_shorthand_deny_base() {
+        let (p, diags) = parse("---\ntools: deny\ndisallowed-tools: [Agent]\n---\n");
+        let deprecated_count = diags
+            .iter()
+            .filter(|d| matches!(d, AgentDiagnostic::DeprecatedDisallowedTools))
+            .count();
+        assert!(
+            (1..=2).contains(&deprecated_count),
+            "expected 1-2 deprecation diagnostics, got: {diags:?}"
+        );
+        assert!(
+            diags
+                .iter()
+                .all(|d| matches!(d, AgentDiagnostic::DeprecatedDisallowedTools))
+        );
+        let map = as_map(p.tools.as_ref().expect("tools expected"));
+        assert_eq!(map.get("*"), Some(&ToolRule::Action(ToolAction::Deny)));
+        assert_eq!(map.get("task"), Some(&ToolRule::Action(ToolAction::Deny)));
+    }
+
+    #[test]
     fn invalid_tools_action_emits_error_and_skips_entry() {
         let (p, diags) = parse("---\ntools:\n  bash: maybe\n  read: allow\n---\n");
         assert_eq!(diags.len(), 1);
@@ -1242,6 +1318,25 @@ mod tests {
         let map = as_map(p.tools.as_ref().expect("tools expected"));
         assert!(!map.contains_key("bash"));
         assert_eq!(map.get("read"), Some(&ToolRule::Action(ToolAction::Allow)));
+    }
+
+    #[test]
+    fn unknown_capability_key_is_preserved_without_error() {
+        let (p, diags) = parse(
+            "---\ntools:\n  \"*\": deny\n  bash: allow\n  future-capability-xyz: allow\n---\n",
+        );
+        let map = as_map(p.tools.as_ref().expect("tools expected"));
+        assert_eq!(
+            map.get("future-capability-xyz"),
+            Some(&ToolRule::Action(ToolAction::Allow))
+        );
+        assert!(!diags.iter().any(|d| {
+            matches!(
+                d,
+                AgentDiagnostic::InvalidFieldValue { field, .. }
+                if field.contains("future-capability-xyz")
+            )
+        }));
     }
 
     #[test]
@@ -1306,6 +1401,21 @@ mod tests {
         let map = as_map(claude.tools.as_ref().expect("tools override expected"));
         assert_eq!(map.get("*"), Some(&ToolRule::Action(ToolAction::Deny)));
         assert_eq!(map.get("bash"), Some(&ToolRule::Action(ToolAction::Allow)));
+    }
+
+    #[test]
+    fn harness_override_deprecated_disallowed_tools_warns_and_merges() {
+        let content = "---\nharness-overrides:\n  claude:\n    disallowed-tools: [Agent]\n---\n";
+        let (p, diags) = parse(content);
+        assert_eq!(diags.len(), 1);
+        assert!(matches!(
+            diags[0],
+            AgentDiagnostic::DeprecatedDisallowedTools
+        ));
+        let claude = p.harness_overrides.claude.as_ref().unwrap();
+        let map = as_map(claude.tools.as_ref().expect("tools override expected"));
+        assert_eq!(map.get("*"), Some(&ToolRule::Action(ToolAction::Allow)));
+        assert_eq!(map.get("task"), Some(&ToolRule::Action(ToolAction::Deny)));
     }
 
     #[test]

--- a/src/compiler/agents/mod.rs
+++ b/src/compiler/agents/mod.rs
@@ -386,6 +386,7 @@ fn yaml_str_list(val: &Value) -> Vec<String> {
     }
 }
 
+// DEPRECATED: Remove after deprecation period (R08)
 const CLAUDE_TO_ABSTRACT: &[(&str, &str)] = &[
     ("Bash", "bash"),
     ("Read", "read"),
@@ -399,6 +400,7 @@ const CLAUDE_TO_ABSTRACT: &[(&str, &str)] = &[
     ("LSP", "lsp"),
 ];
 
+/// DEPRECATED: Remove after deprecation period (R08)
 fn map_legacy_claude_tool_name(name: &str) -> String {
     CLAUDE_TO_ABSTRACT
         .iter()
@@ -433,7 +435,17 @@ fn parse_tool_action(
     }
 }
 
-fn tools_map_from_legacy_list(list: &[String]) -> ToolsField {
+// ---------------------------------------------------------------------------
+// Deprecated tools parsing — DEPRECATED: Remove after deprecation period (R08)
+// ---------------------------------------------------------------------------
+
+/// Convert a deprecated `tools: [Bash, Write, ...]` list into an abstract tools map.
+///
+/// Legacy Claude-native tool names are mapped to abstract capability names.
+/// Emits [`AgentDiagnostic::DeprecatedToolsList`] via the caller.
+///
+/// DEPRECATED: Remove after deprecation period (R08)
+fn convert_deprecated_tools_list(list: &[String]) -> ToolsField {
     let mut map = BTreeMap::new();
     map.insert("*".to_string(), ToolRule::Action(ToolAction::Deny));
     for key in list.iter().map(|tool| map_legacy_claude_tool_name(tool)) {
@@ -442,7 +454,16 @@ fn tools_map_from_legacy_list(list: &[String]) -> ToolsField {
     ToolsField::Map(map)
 }
 
-fn merge_disallowed_into_tools(base: Option<ToolsField>, deny_list: &[String]) -> ToolsField {
+/// Merge a deprecated `disallowed-tools: [Agent, ...]` list into an existing tools field.
+///
+/// Legacy Claude-native tool names are mapped to abstract capability names and
+/// inserted as deny entries. If no base tools field exists, defaults to `*: allow`.
+///
+/// DEPRECATED: Remove after deprecation period (R08)
+fn merge_deprecated_disallowed_tools(
+    base: Option<ToolsField>,
+    deny_list: &[String],
+) -> ToolsField {
     let mut map = match base {
         Some(ToolsField::Map(map)) => map,
         Some(ToolsField::Shorthand(ToolAction::Allow)) | None => {
@@ -472,6 +493,11 @@ fn merge_disallowed_into_tools(base: Option<ToolsField>, deny_list: &[String]) -
     ToolsField::Map(map)
 }
 
+/// Parse a tools field value — shorthand string or capability mapping.
+///
+/// Handles current abstract tools format only (string shorthand or mapping).
+/// Deprecated list form (`tools: [Bash, ...]`) is routed through
+/// [`convert_deprecated_tools_list`] at the call site.
 fn parse_tools_field(
     val: &Value,
     field_name: &str,
@@ -499,6 +525,7 @@ fn parse_tools_field(
                 None
             }
         },
+        // DEPRECATED: Remove after deprecation period (R08)
         Value::Sequence(seq) => {
             diags.push(AgentDiagnostic::DeprecatedToolsList);
             let list = seq
@@ -506,7 +533,7 @@ fn parse_tools_field(
                 .filter_map(Value::as_str)
                 .map(str::to_owned)
                 .collect::<Vec<_>>();
-            Some(tools_map_from_legacy_list(&list))
+            Some(convert_deprecated_tools_list(&list))
         }
         Value::Mapping(mapping) => {
             let mut out = BTreeMap::new();
@@ -876,10 +903,11 @@ pub fn parse_agent_profile(fm: &Frontmatter, diags: &mut Vec<AgentDiagnostic>) -
     let mut tools = fm
         .get("tools")
         .and_then(|v| parse_tools_field(v, "tools", diags));
+    // DEPRECATED: Remove after deprecation period (R08)
     let disallowed_tools = fm.get("disallowed-tools").map(yaml_str_list);
     if let Some(deny_list) = disallowed_tools.as_ref() {
         diags.push(AgentDiagnostic::DeprecatedDisallowedTools);
-        tools = Some(merge_disallowed_into_tools(tools, deny_list));
+        tools = Some(merge_deprecated_disallowed_tools(tools, deny_list));
     }
     let mcp_tools = fm.get("mcp-tools").map(yaml_str_list).unwrap_or_default();
 
@@ -898,7 +926,7 @@ pub fn parse_agent_profile(fm: &Frontmatter, diags: &mut Vec<AgentDiagnostic>) -
     // fanout:
     let fanout = fm.get("fanout").map(parse_fanout).unwrap_or_default();
 
-    // Legacy models: field
+    // DEPRECATED: Remove after deprecation period (R08)
     if fm.get("models").is_some() {
         diags.push(AgentDiagnostic::LegacyModelsField);
     }

--- a/src/compiler/config_entries/mod.rs
+++ b/src/compiler/config_entries/mod.rs
@@ -173,9 +173,12 @@ pub(crate) fn compile_config_entries(
             entries_with_source.push((
                 ConfigEntry::McpServer(McpServerEntry {
                     name: e.name,
+                    transport: e.transport,
                     command: e.command,
                     args: e.args,
                     env: e.env.into_iter().collect(),
+                    url: e.url,
+                    headers: e.headers,
                 }),
                 source,
             ));

--- a/src/compiler/config_entries/mod.rs
+++ b/src/compiler/config_entries/mod.rs
@@ -287,7 +287,7 @@ pub(crate) fn compile_config_entries(
         }
 
         // Emit target-specific pre-write diagnostics (runs even on dry runs).
-        adapter.emit_pre_write_diagnostics(&entries, diag);
+        adapter.emit_pre_write_diagnostics(&entries, &target_dir, diag);
 
         if dry_run {
             current_records.insert(target_root.clone(), target_records);

--- a/src/compiler/mcp/mod.rs
+++ b/src/compiler/mcp/mod.rs
@@ -361,6 +361,7 @@ pub fn lower_for_target<'a>(items: &'a [ParsedMcpItem], target_root: &str) -> Ve
 
 #[cfg(test)]
 mod tests {
+    // qa-validated: mars-tools-abstraction
     use super::*;
     use tempfile::TempDir;
 
@@ -403,6 +404,18 @@ args = ["-y", "@upstash/context7-mcp@latest"]
         std::fs::create_dir_all(tmp.path().join("mcp/no-toml")).unwrap();
         let items = discover_mcp_items(tmp.path(), "base", 0).unwrap();
         assert!(items.is_empty());
+    }
+
+    #[test]
+    fn discover_skips_hidden_directories() {
+        let tmp = TempDir::new().unwrap();
+        make_mcp_toml_dir(tmp.path(), ".hidden-server", "command = \"npx\"");
+        make_mcp_toml_dir(tmp.path(), "real-server", "command = \"node\"");
+
+        let items = discover_mcp_items(tmp.path(), "base", 0).unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].name, "real-server");
+        assert!(!items.iter().any(|item| item.name == ".hidden-server"));
     }
 
     #[test]
@@ -496,6 +509,19 @@ url = "https://example.com/mcp"
 command = "npx"
 [headers]
 X-Test = "value"
+"#,
+        );
+        assert!(discover_mcp_items(tmp.path(), "base", 0).is_err());
+    }
+
+    #[test]
+    fn discover_whitespace_only_command_fails_validation() {
+        let tmp = TempDir::new().unwrap();
+        make_mcp_toml_dir(
+            tmp.path(),
+            "bad-stdio",
+            r#"
+command = "   "
 "#,
         );
         assert!(discover_mcp_items(tmp.path(), "base", 0).is_err());

--- a/src/compiler/mcp/mod.rs
+++ b/src/compiler/mcp/mod.rs
@@ -44,6 +44,27 @@ impl EnvRef {
     }
 }
 
+/// MCP transport type.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum McpTransport {
+    /// Local stdio subprocess transport.
+    #[default]
+    Stdio,
+    /// Remote HTTP transport.
+    Http,
+}
+
+/// A header value — either an env ref or a plain string.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum HeaderValue {
+    /// Symbolic environment reference.
+    EnvRef(EnvRef),
+    /// Plain header literal.
+    Plain(String),
+}
+
 /// Parsed content of a single `mcp/<name>/mcp.toml`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct McpServerDef {
@@ -51,11 +72,19 @@ pub struct McpServerDef {
     /// overridden in the TOML file.
     #[serde(default)]
     pub name: Option<String>,
-    /// Command to launch the MCP server.
-    pub command: String,
+    /// Transport type (`stdio` default, `http` optional).
+    #[serde(default)]
+    pub r#type: McpTransport,
+    /// Command to launch the MCP server (required for stdio, forbidden for http).
+    pub command: Option<String>,
     /// Arguments to pass to the command.
     #[serde(default)]
     pub args: Vec<String>,
+    /// HTTP endpoint URL (required for http, forbidden for stdio).
+    pub url: Option<String>,
+    /// Optional HTTP headers for http transport (forbidden for stdio).
+    #[serde(default)]
+    pub headers: indexmap::IndexMap<String, HeaderValue>,
     /// Symbolic environment references.
     #[serde(default)]
     pub env: indexmap::IndexMap<String, EnvRef>,
@@ -66,6 +95,67 @@ pub struct McpServerDef {
     /// Optional target filter — if absent, applies to all targets.
     #[serde(default)]
     pub targets: Vec<String>,
+}
+
+impl McpServerDef {
+    fn validate(&self, source_path: &Path) -> Result<(), MarsError> {
+        let transport = match self.r#type {
+            McpTransport::Stdio => "stdio",
+            McpTransport::Http => "http",
+        };
+
+        let invalid = |message: String| {
+            MarsError::Config(ConfigError::Invalid {
+                message: format!("invalid MCP server in {} ({transport}): {message}", source_path.display()),
+            })
+        };
+
+        match self.r#type {
+            McpTransport::Stdio => {
+                if self
+                    .command
+                    .as_ref()
+                    .map(|cmd| cmd.trim().is_empty())
+                    .unwrap_or(true)
+                {
+                    return Err(invalid(
+                        "`command` is required and must be non-empty for stdio transport"
+                            .to_string(),
+                    ));
+                }
+                if self.url.is_some() {
+                    return Err(invalid("`url` is only allowed for http transport".to_string()));
+                }
+                if !self.headers.is_empty() {
+                    return Err(invalid(
+                        "`headers` is only allowed for http transport".to_string(),
+                    ));
+                }
+            }
+            McpTransport::Http => {
+                if self
+                    .url
+                    .as_ref()
+                    .map(|url| url.trim().is_empty())
+                    .unwrap_or(true)
+                {
+                    return Err(invalid(
+                        "`url` is required and must be non-empty for http transport".to_string(),
+                    ));
+                }
+                if self.command.is_some() {
+                    return Err(invalid(
+                        "`command` is forbidden for http transport".to_string(),
+                    ));
+                }
+                if !self.args.is_empty() {
+                    return Err(invalid("`args` is forbidden for http transport".to_string()));
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 fn default_visibility() -> String {
@@ -130,6 +220,7 @@ pub fn discover_mcp_items(
                 message: format!("failed to parse {}: {e}", toml_path.display()),
             })
         })?;
+        def.validate(&toml_path)?;
 
         // Resolved name: TOML override wins, else directory name.
         let resolved_name = def.name.as_deref().unwrap_or(&server_name).to_string();
@@ -173,6 +264,23 @@ pub fn check_env_refs(
                 diag.warn("mcp-env-missing", msg);
             }
         }
+        for (header_key, header_value) in &item.def.headers {
+            let HeaderValue::EnvRef(env_ref) = header_value else {
+                continue;
+            };
+            let var_name = env_ref.var_name();
+            if std::env::var(var_name).is_err() {
+                let msg = format!(
+                    "MCP server `{}` (from `{}`): env var `{var_name}` (referenced by header `{header_key}`) \
+                     is not set — the server may fail at runtime",
+                    item.name, item.source_name
+                );
+                if strict {
+                    return Err(MarsError::Config(ConfigError::Invalid { message: msg }));
+                }
+                diag.warn("mcp-env-missing", msg);
+            }
+        }
     }
     Ok(())
 }
@@ -186,12 +294,18 @@ pub fn check_env_refs(
 pub struct TargetMcpEntry {
     /// Server name as it appears in the target config.
     pub name: String,
-    /// Launch command.
-    pub command: String,
+    /// Transport kind.
+    pub transport: McpTransport,
+    /// Launch command (stdio only).
+    pub command: Option<String>,
     /// Launch arguments.
     pub args: Vec<String>,
     /// Env vars: key → variable name (symbolic — adapters write the native form).
     pub env: indexmap::IndexMap<String, String>,
+    /// Remote URL (http only).
+    pub url: Option<String>,
+    /// Header values (http only).
+    pub headers: indexmap::IndexMap<String, HeaderValue>,
 }
 
 impl TargetMcpEntry {
@@ -205,9 +319,12 @@ impl TargetMcpEntry {
             .collect();
         Self {
             name: item.name.clone(),
+            transport: item.def.r#type.clone(),
             command: item.def.command.clone(),
             args: item.def.args.clone(),
             env,
+            url: item.def.url.clone(),
+            headers: item.def.headers.clone(),
         }
     }
 }
@@ -261,7 +378,8 @@ args = ["-y", "@upstash/context7-mcp@latest"]
         let items = discover_mcp_items(tmp.path(), "base", 0).unwrap();
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].name, "context7");
-        assert_eq!(items[0].def.command, "npx");
+        assert_eq!(items[0].def.r#type, McpTransport::Stdio);
+        assert_eq!(items[0].def.command.as_deref(), Some("npx"));
         assert_eq!(items[0].def.args, &["-y", "@upstash/context7-mcp@latest"]);
     }
 
@@ -314,6 +432,97 @@ API_KEY = { from = "env", var = "MY_API_KEY" }
     }
 
     #[test]
+    fn discover_http_requires_url_and_forbids_command_and_args() {
+        let tmp = TempDir::new().unwrap();
+        make_mcp_toml_dir(
+            tmp.path(),
+            "missing-url",
+            r#"
+type = "http"
+"#,
+        );
+        assert!(discover_mcp_items(tmp.path(), "base", 0).is_err());
+
+        let tmp = TempDir::new().unwrap();
+        make_mcp_toml_dir(
+            tmp.path(),
+            "forbidden-command",
+            r#"
+type = "http"
+url = "https://example.com/mcp"
+command = "npx"
+"#,
+        );
+        assert!(discover_mcp_items(tmp.path(), "base", 0).is_err());
+
+        let tmp = TempDir::new().unwrap();
+        make_mcp_toml_dir(
+            tmp.path(),
+            "forbidden-args",
+            r#"
+type = "http"
+url = "https://example.com/mcp"
+args = ["--bad"]
+"#,
+        );
+        assert!(discover_mcp_items(tmp.path(), "base", 0).is_err());
+    }
+
+    #[test]
+    fn discover_stdio_forbids_url_and_headers() {
+        let tmp = TempDir::new().unwrap();
+        make_mcp_toml_dir(
+            tmp.path(),
+            "stdio-with-url",
+            r#"
+command = "npx"
+url = "https://example.com/mcp"
+"#,
+        );
+        assert!(discover_mcp_items(tmp.path(), "base", 0).is_err());
+
+        let tmp = TempDir::new().unwrap();
+        make_mcp_toml_dir(
+            tmp.path(),
+            "stdio-with-headers",
+            r#"
+command = "npx"
+[headers]
+X-Test = "value"
+"#,
+        );
+        assert!(discover_mcp_items(tmp.path(), "base", 0).is_err());
+    }
+
+    #[test]
+    fn discover_http_parses_plain_and_env_header_values() {
+        let tmp = TempDir::new().unwrap();
+        make_mcp_toml_dir(
+            tmp.path(),
+            "remote",
+            r#"
+type = "http"
+url = "https://example.com/mcp"
+[headers]
+Authorization = { from = "env", var = "API_TOKEN" }
+X-Custom = "literal"
+"#,
+        );
+        let items = discover_mcp_items(tmp.path(), "base", 0).unwrap();
+        let item = &items[0];
+        assert_eq!(item.def.r#type, McpTransport::Http);
+        assert_eq!(item.def.url.as_deref(), Some("https://example.com/mcp"));
+        assert!(matches!(
+            item.def.headers.get("Authorization"),
+            Some(HeaderValue::EnvRef(EnvRef::Env { var })) if var == "API_TOKEN"
+        ));
+        assert!(matches!(
+            item.def.headers.get("X-Custom"),
+            Some(HeaderValue::Plain(v)) if v == "literal"
+        ));
+    }
+
+    #[test]
     fn check_env_refs_warns_when_missing() {
         let tmp = TempDir::new().unwrap();
         make_mcp_toml_dir(
@@ -334,6 +543,31 @@ KEY = { from = "env", var = "MARS_TEST_DEFINITELY_NOT_SET_XYZ123" }
             collected[0]
                 .message
                 .contains("MARS_TEST_DEFINITELY_NOT_SET_XYZ123")
+        );
+    }
+
+    #[test]
+    fn check_env_refs_warns_when_header_env_missing() {
+        let tmp = TempDir::new().unwrap();
+        make_mcp_toml_dir(
+            tmp.path(),
+            "server",
+            r#"
+type = "http"
+url = "https://example.com/mcp"
+[headers]
+Authorization = { from = "env", var = "MARS_TEST_DEFINITELY_NOT_SET_HEADER_ABC999" }
+"#,
+        );
+        let items = discover_mcp_items(tmp.path(), "base", 0).unwrap();
+        let mut diag = DiagnosticCollector::new();
+        check_env_refs(&items, false, &mut diag).unwrap();
+        let collected = diag.drain();
+        assert_eq!(collected.len(), 1);
+        assert!(
+            collected[0]
+                .message
+                .contains("MARS_TEST_DEFINITELY_NOT_SET_HEADER_ABC999")
         );
     }
 
@@ -391,5 +625,35 @@ TOKEN = { from = "env", var = "SECRET_TOKEN" }
         let entry = TargetMcpEntry::from_parsed(&items[0]);
         // The env map carries the variable name, not the resolved value.
         assert_eq!(entry.env["TOKEN"], "SECRET_TOKEN");
+        assert_eq!(entry.transport, McpTransport::Stdio);
+        assert_eq!(entry.command.as_deref(), Some("npx"));
+    }
+
+    #[test]
+    fn target_entry_preserves_http_fields() {
+        let tmp = TempDir::new().unwrap();
+        make_mcp_toml_dir(
+            tmp.path(),
+            "remote",
+            r#"
+type = "http"
+url = "https://example.com/mcp"
+[headers]
+Authorization = { from = "env", var = "API_TOKEN" }
+X-Custom = "literal"
+[env]
+EXTRA = { from = "env", var = "EXTRA_VAR" }
+"#,
+        );
+        let items = discover_mcp_items(tmp.path(), "base", 0).unwrap();
+        let entry = TargetMcpEntry::from_parsed(&items[0]);
+        assert_eq!(entry.transport, McpTransport::Http);
+        assert_eq!(entry.command, None);
+        assert_eq!(entry.url.as_deref(), Some("https://example.com/mcp"));
+        assert_eq!(entry.env["EXTRA"], "EXTRA_VAR");
+        assert!(matches!(
+            entry.headers.get("Authorization"),
+            Some(HeaderValue::EnvRef(EnvRef::Env { var })) if var == "API_TOKEN"
+        ));
     }
 }

--- a/src/compiler/mcp/mod.rs
+++ b/src/compiler/mcp/mod.rs
@@ -106,7 +106,10 @@ impl McpServerDef {
 
         let invalid = |message: String| {
             MarsError::Config(ConfigError::Invalid {
-                message: format!("invalid MCP server in {} ({transport}): {message}", source_path.display()),
+                message: format!(
+                    "invalid MCP server in {} ({transport}): {message}",
+                    source_path.display()
+                ),
             })
         };
 
@@ -124,7 +127,9 @@ impl McpServerDef {
                     ));
                 }
                 if self.url.is_some() {
-                    return Err(invalid("`url` is only allowed for http transport".to_string()));
+                    return Err(invalid(
+                        "`url` is only allowed for http transport".to_string(),
+                    ));
                 }
                 if !self.headers.is_empty() {
                     return Err(invalid(
@@ -149,7 +154,9 @@ impl McpServerDef {
                     ));
                 }
                 if !self.args.is_empty() {
-                    return Err(invalid("`args` is forbidden for http transport".to_string()));
+                    return Err(invalid(
+                        "`args` is forbidden for http transport".to_string(),
+                    ));
                 }
             }
         }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -339,8 +339,20 @@ fn dual_surface_compile(
         for lf in &lowered.lossy_fields {
             use crate::compiler::agents::lower::Lossiness;
             match &lf.classification {
-                // Dropped/MeridianOnly fields are expected target-format gaps — not actionable.
-                Lossiness::Dropped | Lossiness::MeridianOnly => {}
+                Lossiness::Dropped => {
+                    // Tools-field drops are actionable under strict validation.
+                    if lf.field == "tools" || lf.field.starts_with("tools.") {
+                        diag.warn(
+                            "agent-field-dropped",
+                            format!(
+                                "agent `{agent_name}`: field `{}` dropped in {}",
+                                lf.field, lf.target
+                            ),
+                        );
+                    }
+                }
+                // MeridianOnly fields are expected target-format gaps — not actionable.
+                Lossiness::MeridianOnly => {}
                 Lossiness::Approximate { note } => {
                     diag.warn(
                         "agent-field-approximate",
@@ -536,5 +548,48 @@ mod skill_surface_tests {
 
         // Native artifact should still exist
         assert!(dir.path().join(".claude/agents/coder.md").exists());
+    }
+
+    #[test]
+    fn dual_surface_keeps_canonical_tools_for_opencode() {
+        let dir = TempDir::new().unwrap();
+        let mars_agents = dir.path().join(".mars").join("agents");
+        std::fs::create_dir_all(&mars_agents).unwrap();
+        let canonical = mars_agents.join("coder.md");
+        let content = "---\nname: coder\nharness: opencode\ntools:\n  \"*\": deny\n  bash: allow\n---\n# body\n";
+        std::fs::write(&canonical, content).unwrap();
+
+        let mut diag = DiagnosticCollector::new();
+        dual_surface_compile(dir.path(), &dir.path().join(".mars"), false, &mut diag);
+
+        let canonical_after = std::fs::read_to_string(&canonical).unwrap();
+        assert_eq!(canonical_after, content);
+
+        let native = std::fs::read_to_string(dir.path().join(".opencode/agents/coder.md")).unwrap();
+        assert!(
+            !native.contains("tools:"),
+            "opencode artifact must omit tools"
+        );
+    }
+
+    #[test]
+    fn dual_surface_emits_warning_for_dropped_tools_field() {
+        let dir = TempDir::new().unwrap();
+        let mars_agents = dir.path().join(".mars").join("agents");
+        std::fs::create_dir_all(&mars_agents).unwrap();
+        std::fs::write(
+            mars_agents.join("coder.md"),
+            "---\nname: coder\nharness: claude\ntools:\n  read:\n    \"*.env\": allow\n---\n# body\n",
+        )
+        .unwrap();
+
+        let mut diag = DiagnosticCollector::new();
+        dual_surface_compile(dir.path(), &dir.path().join(".mars"), true, &mut diag);
+        let diagnostics = diag.drain();
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.code == "agent-field-dropped" && d.message.contains("tools.read"))
+        );
     }
 }

--- a/src/target/claude.rs
+++ b/src/target/claude.rs
@@ -9,6 +9,7 @@
 /// - Env references: rendered as `${VAR_NAME}` for Claude Desktop config compat
 use std::path::{Path, PathBuf};
 
+use crate::compiler::mcp::{HeaderValue, McpTransport};
 use crate::error::{ConfigError, MarsError};
 use crate::lock::ItemKind;
 use crate::types::DestPath;
@@ -137,10 +138,35 @@ fn write_mcp_json(target_dir: &Path, servers: &[&McpServerEntry]) -> Result<Path
     })?;
 
     for server in servers {
-        let mut entry = serde_json::json!({
-            "command": server.command,
-            "args": server.args,
-        });
+        let mut entry = match server.transport {
+            McpTransport::Stdio => serde_json::json!({
+                "command": server.command,
+                "args": server.args,
+            }),
+            McpTransport::Http => {
+                let mut http_entry = serde_json::json!({
+                    "type": "http",
+                    "url": server.url,
+                });
+                if !server.headers.is_empty() {
+                    let headers_obj: serde_json::Map<String, serde_json::Value> = server
+                        .headers
+                        .iter()
+                        .map(|(k, v)| {
+                            let value = match v {
+                                HeaderValue::EnvRef(env_ref) => {
+                                    serde_json::Value::String(format!("${{{}}}", env_ref.var_name()))
+                                }
+                                HeaderValue::Plain(plain) => serde_json::Value::String(plain.clone()),
+                            };
+                            (k.clone(), value)
+                        })
+                        .collect();
+                    http_entry["headers"] = serde_json::Value::Object(headers_obj);
+                }
+                http_entry
+            }
+        };
 
         if !server.env.is_empty() {
             let env_obj: serde_json::Map<String, serde_json::Value> = server
@@ -389,9 +415,12 @@ mod tests {
     fn make_mcp_entry(name: &str) -> ConfigEntry {
         ConfigEntry::McpServer(McpServerEntry {
             name: name.to_string(),
-            command: "npx".to_string(),
+            transport: McpTransport::Stdio,
+            command: Some("npx".to_string()),
             args: vec!["-y".to_string(), "some-mcp@latest".to_string()],
             env: IndexMap::new(),
+            url: None,
+            headers: IndexMap::new(),
         })
     }
 
@@ -400,9 +429,36 @@ mod tests {
         env.insert(env_key.to_string(), env_var.to_string());
         ConfigEntry::McpServer(McpServerEntry {
             name: name.to_string(),
-            command: "npx".to_string(),
+            transport: McpTransport::Stdio,
+            command: Some("npx".to_string()),
             args: vec![],
             env,
+            url: None,
+            headers: IndexMap::new(),
+        })
+    }
+
+    fn make_http_mcp_entry(name: &str) -> ConfigEntry {
+        let mut headers = IndexMap::new();
+        headers.insert(
+            "Authorization".to_string(),
+            HeaderValue::EnvRef(crate::compiler::mcp::EnvRef::Env {
+                var: "API_TOKEN".to_string(),
+            }),
+        );
+        headers.insert(
+            "X-Custom".to_string(),
+            HeaderValue::Plain("static-value".to_string()),
+        );
+
+        ConfigEntry::McpServer(McpServerEntry {
+            name: name.to_string(),
+            transport: McpTransport::Http,
+            command: None,
+            args: vec![],
+            env: IndexMap::new(),
+            url: Some("https://api.example.com/mcp".to_string()),
+            headers,
         })
     }
 
@@ -484,6 +540,24 @@ mod tests {
             json["mcpServers"]["server"]["env"]["API_KEY"],
             "${MY_SECRET}"
         );
+    }
+
+    #[test]
+    fn write_mcp_http_renders_type_url_and_headers() {
+        let tmp = TempDir::new().unwrap();
+        let adapter = ClaudeAdapter;
+        adapter
+            .write_config_entries(&[make_http_mcp_entry("remote-server")], tmp.path())
+            .unwrap();
+
+        let raw = std::fs::read_to_string(tmp.path().join(".mcp.json")).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let server = &json["mcpServers"]["remote-server"];
+        assert_eq!(server["type"], "http");
+        assert_eq!(server["url"], "https://api.example.com/mcp");
+        assert_eq!(server["headers"]["Authorization"], "${API_TOKEN}");
+        assert_eq!(server["headers"]["X-Custom"], "static-value");
+        assert!(server["command"].is_null());
     }
 
     #[test]

--- a/src/target/claude.rs
+++ b/src/target/claude.rs
@@ -154,10 +154,13 @@ fn write_mcp_json(target_dir: &Path, servers: &[&McpServerEntry]) -> Result<Path
                         .iter()
                         .map(|(k, v)| {
                             let value = match v {
-                                HeaderValue::EnvRef(env_ref) => {
-                                    serde_json::Value::String(format!("${{{}}}", env_ref.var_name()))
+                                HeaderValue::EnvRef(env_ref) => serde_json::Value::String(format!(
+                                    "${{{}}}",
+                                    env_ref.var_name()
+                                )),
+                                HeaderValue::Plain(plain) => {
+                                    serde_json::Value::String(plain.clone())
                                 }
-                                HeaderValue::Plain(plain) => serde_json::Value::String(plain.clone()),
                             };
                             (k.clone(), value)
                         })

--- a/src/target/codex.rs
+++ b/src/target/codex.rs
@@ -7,6 +7,7 @@
 /// - Hooks: writes to `codex_hooks.json` with structural hook entries
 use std::path::{Path, PathBuf};
 
+use crate::compiler::mcp::{HeaderValue, McpTransport};
 use crate::error::MarsError;
 use crate::lock::ItemKind;
 use crate::types::DestPath;
@@ -138,8 +139,43 @@ fn write_codex_mcp_toml(
 
     for server in servers {
         let mut server_table = Table::new();
-        server_table["command"] = value(server.command.as_str());
-        server_table["args"] = toml_string_array(server.args.clone());
+        match server.transport {
+            McpTransport::Stdio => {
+                if let Some(command) = server.command.as_ref() {
+                    server_table["command"] = value(command.as_str());
+                }
+                server_table["args"] = toml_string_array(server.args.clone());
+            }
+            McpTransport::Http => {
+                if let Some(url) = server.url.as_ref() {
+                    server_table["url"] = value(url.as_str());
+                }
+
+                let mut bearer_token_env_var: Option<String> = None;
+                let mut http_headers = Table::new();
+                for (header, value_ref) in &server.headers {
+                    match value_ref {
+                        HeaderValue::Plain(plain_value) => {
+                            http_headers[header.as_str()] = value(plain_value.as_str());
+                        }
+                        HeaderValue::EnvRef(env_ref) => {
+                            if header.eq_ignore_ascii_case("Authorization") {
+                                bearer_token_env_var = Some(env_ref.var_name().to_string());
+                            } else {
+                                http_headers[header.as_str()] = value(env_ref.var_name());
+                            }
+                        }
+                    }
+                }
+
+                if let Some(token_var) = bearer_token_env_var {
+                    server_table["bearer_token_env_var"] = value(token_var);
+                }
+                if !http_headers.is_empty() {
+                    server_table["http_headers"] = Item::Table(http_headers);
+                }
+            }
+        }
 
         // Codex env: list of variable names (not a map with values).
         if !server.env.is_empty() {
@@ -376,9 +412,12 @@ mod tests {
     fn make_mcp_entry(name: &str) -> ConfigEntry {
         ConfigEntry::McpServer(McpServerEntry {
             name: name.to_string(),
-            command: "npx".to_string(),
+            transport: McpTransport::Stdio,
+            command: Some("npx".to_string()),
             args: vec!["-y".to_string(), "some-mcp@latest".to_string()],
             env: IndexMap::new(),
+            url: None,
+            headers: IndexMap::new(),
         })
     }
 
@@ -387,9 +426,36 @@ mod tests {
         env.insert("API_KEY".to_string(), "MY_SECRET".to_string());
         ConfigEntry::McpServer(McpServerEntry {
             name: name.to_string(),
-            command: "npx".to_string(),
+            transport: McpTransport::Stdio,
+            command: Some("npx".to_string()),
             args: vec![],
             env,
+            url: None,
+            headers: IndexMap::new(),
+        })
+    }
+
+    fn make_http_mcp_entry(name: &str) -> ConfigEntry {
+        let mut headers = IndexMap::new();
+        headers.insert(
+            "Authorization".to_string(),
+            HeaderValue::EnvRef(crate::compiler::mcp::EnvRef::Env {
+                var: "API_TOKEN".to_string(),
+            }),
+        );
+        headers.insert(
+            "X-Custom".to_string(),
+            HeaderValue::Plain("static-value".to_string()),
+        );
+
+        ConfigEntry::McpServer(McpServerEntry {
+            name: name.to_string(),
+            transport: McpTransport::Http,
+            command: None,
+            args: vec![],
+            env: IndexMap::new(),
+            url: Some("https://api.example.com/mcp".to_string()),
+            headers,
         })
     }
 
@@ -466,6 +532,33 @@ theme = "dark"
             toml["mcp"]["servers"]["context7"]["command"].as_str(),
             Some("npx")
         );
+    }
+
+    #[test]
+    fn write_http_mcp_uses_url_bearer_token_and_http_headers() {
+        let tmp = TempDir::new().unwrap();
+        let adapter = CodexAdapter;
+        adapter
+            .write_config_entries(&[make_http_mcp_entry("remote-server")], tmp.path())
+            .unwrap();
+
+        let raw = std::fs::read_to_string(tmp.path().join(CODEX_CONFIG_TOML)).unwrap();
+        let toml: TomlValue = toml::from_str(&raw).unwrap();
+        let server = &toml["mcp"]["servers"]["remote-server"];
+        assert_eq!(
+            server["url"].as_str(),
+            Some("https://api.example.com/mcp")
+        );
+        assert_eq!(
+            server["bearer_token_env_var"].as_str(),
+            Some("API_TOKEN")
+        );
+        assert_eq!(
+            server["http_headers"]["X-Custom"].as_str(),
+            Some("static-value")
+        );
+        assert!(server.get("command").is_none());
+        assert!(server.get("args").is_none());
     }
 
     #[test]

--- a/src/target/codex.rs
+++ b/src/target/codex.rs
@@ -102,6 +102,19 @@ impl TargetAdapter for CodexAdapter {
                 ),
             );
         }
+
+        let config_path = target_dir.join(CODEX_CONFIG_TOML);
+        if config_path.is_file()
+            && let Err(err) = parse_existing_toml_document(&config_path)
+        {
+            diag.warn(
+                "codex-config-parse-error",
+                format!(
+                    "target `.codex`: cannot parse `{}`; skipping Codex MCP writes/removals until fixed: {err}",
+                    config_path.display()
+                ),
+            );
+        }
     }
 
     fn remove_config_entries(
@@ -214,10 +227,19 @@ fn load_or_new_toml_document(path: &Path) -> Result<DocumentMut, MarsError> {
         return Ok(DocumentMut::new());
     }
 
+    parse_existing_toml_document(path)
+}
+
+fn parse_existing_toml_document(path: &Path) -> Result<DocumentMut, MarsError> {
     let raw = std::fs::read_to_string(path).map_err(MarsError::from)?;
-    Ok(raw
-        .parse::<DocumentMut>()
-        .unwrap_or_else(|_| DocumentMut::new()))
+    raw.parse::<DocumentMut>().map_err(|e| {
+        MarsError::Config(crate::error::ConfigError::Invalid {
+            message: format!(
+                "{}: failed to parse TOML; refusing to overwrite existing config: {e}",
+                path.display()
+            ),
+        })
+    })
 }
 
 fn toml_string_array(values: impl IntoIterator<Item = String>) -> Item {
@@ -584,6 +606,37 @@ theme = "dark"
     }
 
     #[test]
+    fn emit_pre_write_diagnostics_warns_about_invalid_codex_config_toml() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join(CODEX_CONFIG_TOML), "[ui\n").unwrap();
+        let adapter = CodexAdapter;
+        let mut diag = DiagnosticCollector::new();
+
+        adapter.emit_pre_write_diagnostics(&[make_mcp_entry("context7")], tmp.path(), &mut diag);
+
+        let diagnostics = diag.drain();
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, "codex-config-parse-error");
+        assert!(diagnostics[0].message.contains(CODEX_CONFIG_TOML));
+    }
+
+    #[test]
+    fn write_mcp_invalid_toml_returns_error_without_clobbering_existing_file() {
+        let tmp = TempDir::new().unwrap();
+        let original = "[ui]\ntheme = \"dark\"\ninvalid =\n";
+        std::fs::write(tmp.path().join(CODEX_CONFIG_TOML), original).unwrap();
+
+        let adapter = CodexAdapter;
+        let err = adapter
+            .write_config_entries(&[make_mcp_entry("context7")], tmp.path())
+            .expect_err("invalid TOML should fail and not be overwritten");
+        assert!(err.to_string().contains("failed to parse TOML"));
+
+        let after = std::fs::read_to_string(tmp.path().join(CODEX_CONFIG_TOML)).unwrap();
+        assert_eq!(after, original);
+    }
+
+    #[test]
     fn write_hooks_creates_codex_hooks_json() {
         let tmp = TempDir::new().unwrap();
         let adapter = CodexAdapter;
@@ -642,6 +695,22 @@ theme = "dark"
         let toml: TomlValue = toml::from_str(&raw).unwrap();
         assert!(toml["mcp"]["servers"].get("to-remove").is_none());
         assert!(toml["mcp"]["servers"]["to-keep"].is_table());
+    }
+
+    #[test]
+    fn remove_mcp_entries_invalid_toml_returns_error_without_clobbering_existing_file() {
+        let tmp = TempDir::new().unwrap();
+        let original = "[ui]\ntheme = \"dark\"\ninvalid =\n";
+        std::fs::write(tmp.path().join(CODEX_CONFIG_TOML), original).unwrap();
+
+        let adapter = CodexAdapter;
+        let err = adapter
+            .remove_config_entries(&["mcp:context7".to_string()], tmp.path())
+            .expect_err("invalid TOML should fail and not be overwritten");
+        assert!(err.to_string().contains("failed to parse TOML"));
+
+        let after = std::fs::read_to_string(tmp.path().join(CODEX_CONFIG_TOML)).unwrap();
+        assert_eq!(after, original);
     }
 
     #[test]

--- a/src/target/codex.rs
+++ b/src/target/codex.rs
@@ -545,14 +545,8 @@ theme = "dark"
         let raw = std::fs::read_to_string(tmp.path().join(CODEX_CONFIG_TOML)).unwrap();
         let toml: TomlValue = toml::from_str(&raw).unwrap();
         let server = &toml["mcp"]["servers"]["remote-server"];
-        assert_eq!(
-            server["url"].as_str(),
-            Some("https://api.example.com/mcp")
-        );
-        assert_eq!(
-            server["bearer_token_env_var"].as_str(),
-            Some("API_TOKEN")
-        );
+        assert_eq!(server["url"].as_str(), Some("https://api.example.com/mcp"));
+        assert_eq!(server["bearer_token_env_var"].as_str(), Some("API_TOKEN"));
         assert_eq!(
             server["http_headers"]["X-Custom"].as_str(),
             Some("static-value")

--- a/src/target/codex.rs
+++ b/src/target/codex.rs
@@ -3,18 +3,22 @@
 /// Handles MCP server registration and hook binding for the Codex harness.
 ///
 /// Codex-native lowering:
-/// - MCP: writes to `codex_mcp.json` (mcpServers section), env vars as plain names
+/// - MCP: writes to `config.toml` (`[mcp.servers.*]`), env vars as plain names
 /// - Hooks: writes to `codex_hooks.json` with structural hook entries
 use std::path::{Path, PathBuf};
 
 use crate::error::MarsError;
 use crate::lock::ItemKind;
 use crate::types::DestPath;
+use toml_edit::{Array, DocumentMut, Item, Table, Value, value};
 
 use super::{ConfigEntry, HookEntry, McpServerEntry, TargetAdapter, hook_command};
 
 #[derive(Debug)]
 pub struct CodexAdapter;
+
+const CODEX_CONFIG_TOML: &str = "config.toml";
+const LEGACY_CODEX_MCP_JSON: &str = "codex_mcp.json";
 
 impl TargetAdapter for CodexAdapter {
     fn name(&self) -> &str {
@@ -62,7 +66,7 @@ impl TargetAdapter for CodexAdapter {
             .collect();
 
         if !mcp_servers.is_empty() {
-            let path = write_codex_mcp_json(target_dir, &mcp_servers)?;
+            let path = write_codex_mcp_toml(target_dir, &mcp_servers)?;
             written.push(path);
         }
 
@@ -74,11 +78,37 @@ impl TargetAdapter for CodexAdapter {
         Ok(written)
     }
 
+    fn emit_pre_write_diagnostics(
+        &self,
+        entries: &[ConfigEntry],
+        target_dir: &Path,
+        diag: &mut crate::diagnostic::DiagnosticCollector,
+    ) {
+        let has_mcp_entries = entries
+            .iter()
+            .any(|entry| matches!(entry, ConfigEntry::McpServer(_)));
+        if !has_mcp_entries {
+            return;
+        }
+
+        let legacy_path = target_dir.join(LEGACY_CODEX_MCP_JSON);
+        if legacy_path.is_file() {
+            diag.info(
+                "legacy-config-cleanup",
+                format!(
+                    "target `.codex`: removing legacy MCP config `{}` during sync",
+                    legacy_path.display()
+                ),
+            );
+        }
+    }
+
     fn remove_config_entries(
         &self,
         entry_keys: &[String],
         target_dir: &Path,
     ) -> Result<(), MarsError> {
+        remove_legacy_codex_mcp_json(target_dir)?;
         remove_codex_mcp_entries(entry_keys, target_dir)?;
         remove_codex_hook_entries(entry_keys, target_dir)?;
         Ok(())
@@ -86,108 +116,114 @@ impl TargetAdapter for CodexAdapter {
 }
 
 // ---------------------------------------------------------------------------
-// Codex MCP — `codex_mcp.json` format
+// Codex MCP — `config.toml` format
 // ---------------------------------------------------------------------------
 //
 // Codex uses plain environment variable names (no interpolation syntax).
 // Format:
-// {
-//   "mcpServers": {
-//     "server-name": {
-//       "command": "...",
-//       "args": [...],
-//       "env": ["ENV_VAR_NAME", ...]   ← list of var names, not map
-//     }
-//   }
-// }
+// [mcp.servers.my-server]
+// command = "npx"
+// args = ["-y", "my-server@latest"]
+// env = ["MY_API_KEY"]
 
-fn write_codex_mcp_json(
+fn write_codex_mcp_toml(
     target_dir: &Path,
     servers: &[&McpServerEntry],
 ) -> Result<PathBuf, MarsError> {
-    let path = target_dir.join("codex_mcp.json");
+    let path = target_dir.join(CODEX_CONFIG_TOML);
+    remove_legacy_codex_mcp_json(target_dir)?;
 
-    let mut root: serde_json::Value = if path.is_file() {
-        let raw = std::fs::read_to_string(&path).map_err(MarsError::from)?;
-        serde_json::from_str(&raw).unwrap_or_else(|_| serde_json::json!({}))
-    } else {
-        serde_json::json!({})
-    };
-
-    let mcp_obj = root
-        .as_object_mut()
-        .ok_or_else(|| {
-            MarsError::Config(crate::error::ConfigError::Invalid {
-                message: format!("{} is not a JSON object", path.display()),
-            })
-        })?
-        .entry("mcpServers")
-        .or_insert_with(|| serde_json::json!({}));
-
-    let mcp_map = mcp_obj.as_object_mut().ok_or_else(|| {
-        MarsError::Config(crate::error::ConfigError::Invalid {
-            message: format!("{}: mcpServers is not an object", path.display()),
-        })
-    })?;
+    let mut doc = load_or_new_toml_document(&path)?;
+    let mcp_servers = ensure_mcp_servers_table(&mut doc, &path)?;
 
     for server in servers {
-        let mut entry = serde_json::json!({
-            "command": server.command,
-            "args": server.args,
-        });
+        let mut server_table = Table::new();
+        server_table["command"] = value(server.command.as_str());
+        server_table["args"] = toml_string_array(server.args.clone());
 
         // Codex env: list of variable names (not a map with values).
         if !server.env.is_empty() {
-            let env_list: Vec<serde_json::Value> = server
-                .env
-                .values()
-                .map(|v| serde_json::Value::String(v.clone()))
-                .collect();
-            entry["env"] = serde_json::Value::Array(env_list);
+            let env_vars: Vec<String> = server.env.values().cloned().collect();
+            server_table["env"] = toml_string_array(env_vars);
         }
 
-        mcp_map.insert(server.name.clone(), entry);
+        mcp_servers.insert(server.name.as_str(), Item::Table(server_table));
     }
 
-    let content = serde_json::to_string_pretty(&root).map_err(|e| {
-        MarsError::Config(crate::error::ConfigError::Invalid {
-            message: format!("failed to serialize {}: {e}", path.display()),
-        })
-    })?;
-    crate::fs::atomic_write(&path, content.as_bytes())?;
-
+    crate::fs::atomic_write(&path, doc.to_string().as_bytes())?;
     Ok(path)
 }
 
 fn remove_codex_mcp_entries(entry_keys: &[String], target_dir: &Path) -> Result<(), MarsError> {
-    let path = target_dir.join("codex_mcp.json");
+    let path = target_dir.join(CODEX_CONFIG_TOML);
     if !path.is_file() {
         return Ok(());
     }
 
-    let raw = std::fs::read_to_string(&path).map_err(MarsError::from)?;
-    let mut root: serde_json::Value =
-        serde_json::from_str(&raw).unwrap_or_else(|_| serde_json::json!({}));
+    let mut doc = load_or_new_toml_document(&path)?;
+    let mcp_servers = ensure_mcp_servers_table(&mut doc, &path)?;
 
-    if let Some(mcp_map) = root
-        .as_object_mut()
-        .and_then(|o| o.get_mut("mcpServers"))
-        .and_then(|v| v.as_object_mut())
-    {
-        for key in entry_keys {
-            if let Some(name) = key.strip_prefix("mcp:") {
-                mcp_map.remove(name);
-            }
+    for key in entry_keys {
+        if let Some(name) = key.strip_prefix("mcp:") {
+            mcp_servers.remove(name);
         }
     }
 
-    let content = serde_json::to_string_pretty(&root).map_err(|e| {
+    crate::fs::atomic_write(&path, doc.to_string().as_bytes())?;
+    Ok(())
+}
+
+fn load_or_new_toml_document(path: &Path) -> Result<DocumentMut, MarsError> {
+    if !path.is_file() {
+        return Ok(DocumentMut::new());
+    }
+
+    let raw = std::fs::read_to_string(path).map_err(MarsError::from)?;
+    Ok(raw
+        .parse::<DocumentMut>()
+        .unwrap_or_else(|_| DocumentMut::new()))
+}
+
+fn toml_string_array(values: impl IntoIterator<Item = String>) -> Item {
+    let mut array = Array::new();
+    for value in values {
+        array.push(value);
+    }
+    Item::Value(Value::Array(array))
+}
+
+fn ensure_mcp_servers_table<'a>(
+    doc: &'a mut DocumentMut,
+    path: &Path,
+) -> Result<&'a mut Table, MarsError> {
+    let root = doc.as_table_mut();
+
+    let mcp_item = root
+        .entry("mcp")
+        .or_insert_with(|| Item::Table(Table::new()));
+    let mcp_table = mcp_item.as_table_mut().ok_or_else(|| {
         MarsError::Config(crate::error::ConfigError::Invalid {
-            message: format!("failed to serialize {}: {e}", path.display()),
+            message: format!("{}: mcp is not a table", path.display()),
         })
     })?;
-    crate::fs::atomic_write(&path, content.as_bytes())?;
-    Ok(())
+
+    let servers_item = mcp_table
+        .entry("servers")
+        .or_insert_with(|| Item::Table(Table::new()));
+    servers_item.as_table_mut().ok_or_else(|| {
+        MarsError::Config(crate::error::ConfigError::Invalid {
+            message: format!("{}: mcp.servers is not a table", path.display()),
+        })
+    })
+}
+
+fn remove_legacy_codex_mcp_json(target_dir: &Path) -> Result<(), MarsError> {
+    let legacy_path = target_dir.join(LEGACY_CODEX_MCP_JSON);
+    if !legacy_path.is_file() {
+        return Ok(());
+    }
+
+    std::fs::remove_file(&legacy_path).map_err(MarsError::from)
 }
 
 // ---------------------------------------------------------------------------
@@ -332,8 +368,10 @@ fn codex_hook_event(event: &str) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::diagnostic::DiagnosticCollector;
     use indexmap::IndexMap;
     use tempfile::TempDir;
+    use toml::Value as TomlValue;
 
     fn make_mcp_entry(name: &str) -> ConfigEntry {
         ConfigEntry::McpServer(McpServerEntry {
@@ -376,17 +414,17 @@ mod tests {
     }
 
     #[test]
-    fn write_mcp_creates_codex_mcp_json() {
+    fn write_mcp_creates_codex_config_toml() {
         let tmp = TempDir::new().unwrap();
         let adapter = CodexAdapter;
         let entries = vec![make_mcp_entry("context7")];
         let written = adapter.write_config_entries(&entries, tmp.path()).unwrap();
         assert_eq!(written.len(), 1);
-        assert!(tmp.path().join("codex_mcp.json").exists());
+        assert!(tmp.path().join(CODEX_CONFIG_TOML).exists());
 
-        let raw = std::fs::read_to_string(tmp.path().join("codex_mcp.json")).unwrap();
-        let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
-        assert!(json["mcpServers"]["context7"].is_object());
+        let raw = std::fs::read_to_string(tmp.path().join(CODEX_CONFIG_TOML)).unwrap();
+        let toml: TomlValue = toml::from_str(&raw).unwrap();
+        assert!(toml["mcp"]["servers"]["context7"].is_table());
     }
 
     #[test]
@@ -396,12 +434,66 @@ mod tests {
         let entries = vec![make_mcp_entry_with_env("server")];
         adapter.write_config_entries(&entries, tmp.path()).unwrap();
 
-        let raw = std::fs::read_to_string(tmp.path().join("codex_mcp.json")).unwrap();
-        let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let raw = std::fs::read_to_string(tmp.path().join(CODEX_CONFIG_TOML)).unwrap();
+        let toml: TomlValue = toml::from_str(&raw).unwrap();
         // Codex: env is a list of variable names, not a map with values.
-        assert!(json["mcpServers"]["server"]["env"].is_array());
-        let env_arr = json["mcpServers"]["server"]["env"].as_array().unwrap();
+        assert!(toml["mcp"]["servers"]["server"]["env"].is_array());
+        let env_arr = toml["mcp"]["servers"]["server"]["env"].as_array().unwrap();
         assert!(env_arr.iter().any(|v| v.as_str() == Some("MY_SECRET")));
+    }
+
+    #[test]
+    fn write_mcp_preserves_non_mcp_toml_content() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join(CODEX_CONFIG_TOML),
+            r#"
+[ui]
+theme = "dark"
+"#,
+        )
+        .unwrap();
+
+        let adapter = CodexAdapter;
+        adapter
+            .write_config_entries(&[make_mcp_entry("context7")], tmp.path())
+            .unwrap();
+
+        let raw = std::fs::read_to_string(tmp.path().join(CODEX_CONFIG_TOML)).unwrap();
+        let toml: TomlValue = toml::from_str(&raw).unwrap();
+        assert_eq!(toml["ui"]["theme"].as_str(), Some("dark"));
+        assert_eq!(
+            toml["mcp"]["servers"]["context7"]["command"].as_str(),
+            Some("npx")
+        );
+    }
+
+    #[test]
+    fn write_mcp_removes_legacy_codex_mcp_json() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join(LEGACY_CODEX_MCP_JSON), "{}").unwrap();
+        let adapter = CodexAdapter;
+
+        adapter
+            .write_config_entries(&[make_mcp_entry("context7")], tmp.path())
+            .unwrap();
+
+        assert!(!tmp.path().join(LEGACY_CODEX_MCP_JSON).exists());
+    }
+
+    #[test]
+    fn emit_pre_write_diagnostics_warns_about_legacy_codex_mcp_json() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join(LEGACY_CODEX_MCP_JSON), "{}").unwrap();
+        let adapter = CodexAdapter;
+        let mut diag = DiagnosticCollector::new();
+
+        adapter.emit_pre_write_diagnostics(&[make_mcp_entry("context7")], tmp.path(), &mut diag);
+
+        let diagnostics = diag.drain();
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, "legacy-config-cleanup");
+        assert!(diagnostics[0].message.contains(LEGACY_CODEX_MCP_JSON));
     }
 
     #[test]
@@ -459,10 +551,10 @@ mod tests {
             .remove_config_entries(&["mcp:to-remove".to_string()], tmp.path())
             .unwrap();
 
-        let raw = std::fs::read_to_string(tmp.path().join("codex_mcp.json")).unwrap();
-        let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
-        assert!(json["mcpServers"]["to-remove"].is_null());
-        assert!(json["mcpServers"]["to-keep"].is_object());
+        let raw = std::fs::read_to_string(tmp.path().join(CODEX_CONFIG_TOML)).unwrap();
+        let toml: TomlValue = toml::from_str(&raw).unwrap();
+        assert!(toml["mcp"]["servers"].get("to-remove").is_none());
+        assert!(toml["mcp"]["servers"]["to-keep"].is_table());
     }
 
     #[test]

--- a/src/target/cursor.rs
+++ b/src/target/cursor.rs
@@ -164,10 +164,13 @@ fn write_cursor_mcp_json(
                         .iter()
                         .map(|(k, v)| {
                             let value = match v {
-                                HeaderValue::EnvRef(env_ref) => {
-                                    serde_json::Value::String(format!("${{env:{}}}", env_ref.var_name()))
+                                HeaderValue::EnvRef(env_ref) => serde_json::Value::String(format!(
+                                    "${{env:{}}}",
+                                    env_ref.var_name()
+                                )),
+                                HeaderValue::Plain(plain) => {
+                                    serde_json::Value::String(plain.clone())
                                 }
-                                HeaderValue::Plain(plain) => serde_json::Value::String(plain.clone()),
                             };
                             (k.clone(), value)
                         })

--- a/src/target/cursor.rs
+++ b/src/target/cursor.rs
@@ -36,6 +36,7 @@ impl TargetAdapter for CursorAdapter {
     fn emit_pre_write_diagnostics(
         &self,
         entries: &[ConfigEntry],
+        _target_dir: &Path,
         diag: &mut crate::diagnostic::DiagnosticCollector,
     ) {
         CursorAdapter::emit_hook_lossiness_diagnostics(entries, diag);

--- a/src/target/cursor.rs
+++ b/src/target/cursor.rs
@@ -7,6 +7,7 @@
 /// - Hooks: dropped — Cursor has limited/undocumented hook surface (lossiness: dropped)
 use std::path::{Path, PathBuf};
 
+use crate::compiler::mcp::{HeaderValue, McpTransport};
 use crate::diagnostic::DiagnosticCollector;
 use crate::error::MarsError;
 use crate::lock::ItemKind;
@@ -147,10 +148,35 @@ fn write_cursor_mcp_json(
     })?;
 
     for server in servers {
-        let mut entry = serde_json::json!({
-            "command": server.command,
-            "args": server.args,
-        });
+        let mut entry = match server.transport {
+            McpTransport::Stdio => serde_json::json!({
+                "command": server.command,
+                "args": server.args,
+            }),
+            McpTransport::Http => {
+                let mut http_entry = serde_json::json!({
+                    "type": "http",
+                    "url": server.url,
+                });
+                if !server.headers.is_empty() {
+                    let headers_obj: serde_json::Map<String, serde_json::Value> = server
+                        .headers
+                        .iter()
+                        .map(|(k, v)| {
+                            let value = match v {
+                                HeaderValue::EnvRef(env_ref) => {
+                                    serde_json::Value::String(format!("${{env:{}}}", env_ref.var_name()))
+                                }
+                                HeaderValue::Plain(plain) => serde_json::Value::String(plain.clone()),
+                            };
+                            (k.clone(), value)
+                        })
+                        .collect();
+                    http_entry["headers"] = serde_json::Value::Object(headers_obj);
+                }
+                http_entry
+            }
+        };
 
         // Cursor env: `${env:VAR_NAME}` interpolation syntax.
         if !server.env.is_empty() {
@@ -229,9 +255,12 @@ mod tests {
         }
         ConfigEntry::McpServer(McpServerEntry {
             name: name.to_string(),
-            command: "npx".to_string(),
+            transport: McpTransport::Stdio,
+            command: Some("npx".to_string()),
             args: vec![],
             env,
+            url: None,
+            headers: IndexMap::new(),
         })
     }
 

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -138,6 +138,7 @@ pub trait TargetAdapter: std::fmt::Debug + Send + Sync {
     fn emit_pre_write_diagnostics(
         &self,
         _entries: &[ConfigEntry],
+        _target_dir: &Path,
         _diag: &mut crate::diagnostic::DiagnosticCollector,
     ) {
     }

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -20,6 +20,7 @@ use std::path::{Path, PathBuf};
 
 use indexmap::IndexMap;
 
+use crate::compiler::mcp::{HeaderValue, McpTransport};
 use crate::error::MarsError;
 use crate::lock::ItemKind;
 use crate::types::DestPath;
@@ -56,12 +57,18 @@ impl ConfigEntry {
 pub struct McpServerEntry {
     /// Server name as it appears in the target config.
     pub name: String,
-    /// Launch command.
-    pub command: String,
+    /// Transport kind.
+    pub transport: McpTransport,
+    /// Launch command (stdio only).
+    pub command: Option<String>,
     /// Launch arguments.
     pub args: Vec<String>,
     /// Env vars: config key → environment variable name (symbolic, never resolved).
     pub env: IndexMap<String, String>,
+    /// Remote URL (http only).
+    pub url: Option<String>,
+    /// HTTP headers (http only).
+    pub headers: IndexMap<String, HeaderValue>,
 }
 
 /// A hook binding entry ready to be written into a target config file.

--- a/src/target/opencode.rs
+++ b/src/target/opencode.rs
@@ -248,6 +248,7 @@ fn remove_opencode_entries(entry_keys: &[String], target_dir: &Path) -> Result<(
         Some(o) => o,
         None => return Ok(()),
     };
+    migrate_legacy_mcp_servers(root_obj);
 
     // Remove MCP entries
     if let Some(mcp_map) = root_obj.get_mut("mcp").and_then(|v| v.as_object_mut()) {
@@ -544,6 +545,39 @@ mod tests {
 
         let raw = std::fs::read_to_string(tmp.path().join("opencode.json")).unwrap();
         let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert!(json["mcp"]["to-remove"].is_null());
+        assert!(json["mcp"]["to-keep"].is_object());
+    }
+
+    #[test]
+    fn remove_entries_migrates_legacy_mcp_servers_before_cleanup() {
+        let tmp = TempDir::new().unwrap();
+        let legacy = serde_json::json!({
+            "mcpServers": {
+                "to-remove": {
+                    "command": "npx",
+                    "args": ["-y", "legacy-mcp@latest"]
+                },
+                "to-keep": {
+                    "command": "npx",
+                    "args": ["-y", "keep-mcp@latest"]
+                }
+            }
+        });
+        std::fs::write(
+            tmp.path().join("opencode.json"),
+            serde_json::to_string_pretty(&legacy).unwrap(),
+        )
+        .unwrap();
+
+        let adapter = OpencodeAdapter;
+        adapter
+            .remove_config_entries(&["mcp:to-remove".to_string()], tmp.path())
+            .unwrap();
+
+        let raw = std::fs::read_to_string(tmp.path().join("opencode.json")).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert!(json["mcpServers"].is_null());
         assert!(json["mcp"]["to-remove"].is_null());
         assert!(json["mcp"]["to-keep"].is_object());
     }

--- a/src/target/opencode.rs
+++ b/src/target/opencode.rs
@@ -7,6 +7,7 @@
 /// - Hooks: writes to `opencode.json` (hooks section with plugin hook format)
 use std::path::{Path, PathBuf};
 
+use crate::compiler::mcp::{HeaderValue, McpTransport};
 use crate::error::MarsError;
 use crate::lock::ItemKind;
 use crate::types::DestPath;
@@ -130,14 +131,23 @@ fn write_opencode_config(
         })?;
 
         for server in servers {
-            let mut command = Vec::with_capacity(server.args.len() + 1);
-            command.push(serde_json::Value::String(server.command.clone()));
-            command.extend(server.args.iter().cloned().map(serde_json::Value::String));
-
-            let mut entry = serde_json::json!({
-                "type": "local",
-                "command": command,
-            });
+            let mut entry = match server.transport {
+                McpTransport::Stdio => {
+                    let mut command = Vec::with_capacity(server.args.len() + 1);
+                    if let Some(command_name) = server.command.as_ref() {
+                        command.push(serde_json::Value::String(command_name.clone()));
+                    }
+                    command.extend(server.args.iter().cloned().map(serde_json::Value::String));
+                    serde_json::json!({
+                        "type": "local",
+                        "command": command,
+                    })
+                }
+                McpTransport::Http => serde_json::json!({
+                    "type": "remote",
+                    "url": server.url,
+                }),
+            };
 
             // OpenCode: env as plain name map (no interpolation)
             if !server.env.is_empty() {
@@ -147,6 +157,23 @@ fn write_opencode_config(
                     .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
                     .collect();
                 entry["environment"] = serde_json::Value::Object(env_obj);
+            }
+
+            if !server.headers.is_empty() {
+                let headers_obj: serde_json::Map<String, serde_json::Value> = server
+                    .headers
+                    .iter()
+                    .map(|(k, v)| {
+                        let value = match v {
+                            HeaderValue::EnvRef(env_ref) => {
+                                serde_json::Value::String(env_ref.var_name().to_string())
+                            }
+                            HeaderValue::Plain(plain) => serde_json::Value::String(plain.clone()),
+                        };
+                        (k.clone(), value)
+                    })
+                    .collect();
+                entry["headers"] = serde_json::Value::Object(headers_obj);
             }
 
             mcp_map.insert(server.name.clone(), entry);
@@ -341,9 +368,35 @@ mod tests {
         env.insert("TOKEN".to_string(), "MY_TOKEN".to_string());
         ConfigEntry::McpServer(McpServerEntry {
             name: name.to_string(),
-            command: "node".to_string(),
+            transport: McpTransport::Stdio,
+            command: Some("node".to_string()),
             args: vec!["server.js".to_string()],
             env,
+            url: None,
+            headers: IndexMap::new(),
+        })
+    }
+
+    fn make_http_mcp_entry(name: &str) -> ConfigEntry {
+        let mut headers = IndexMap::new();
+        headers.insert(
+            "Authorization".to_string(),
+            HeaderValue::EnvRef(crate::compiler::mcp::EnvRef::Env {
+                var: "API_TOKEN".to_string(),
+            }),
+        );
+        headers.insert(
+            "X-Custom".to_string(),
+            HeaderValue::Plain("static-value".to_string()),
+        );
+        ConfigEntry::McpServer(McpServerEntry {
+            name: name.to_string(),
+            transport: McpTransport::Http,
+            command: None,
+            args: vec![],
+            env: IndexMap::new(),
+            url: Some("https://api.example.com/mcp".to_string()),
+            headers,
         })
     }
 
@@ -408,6 +461,24 @@ mod tests {
         let command = json["mcp"]["server"]["command"].as_array().unwrap();
         assert_eq!(command[0], "node");
         assert_eq!(command[1], "server.js");
+    }
+
+    #[test]
+    fn write_http_mcp_uses_remote_type_url_and_plain_headers() {
+        let tmp = TempDir::new().unwrap();
+        let adapter = OpencodeAdapter;
+        adapter
+            .write_config_entries(&[make_http_mcp_entry("remote-server")], tmp.path())
+            .unwrap();
+
+        let raw = std::fs::read_to_string(tmp.path().join("opencode.json")).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let server = &json["mcp"]["remote-server"];
+        assert_eq!(server["type"], "remote");
+        assert_eq!(server["url"], "https://api.example.com/mcp");
+        assert_eq!(server["headers"]["Authorization"], "API_TOKEN");
+        assert_eq!(server["headers"]["X-Custom"], "static-value");
+        assert!(server["command"].is_null());
     }
 
     #[test]

--- a/src/target/opencode.rs
+++ b/src/target/opencode.rs
@@ -3,7 +3,7 @@
 /// Handles MCP server registration and hook binding for the OpenCode harness.
 ///
 /// OpenCode-native lowering:
-/// - MCP: writes to `opencode.json` (mcpServers section), env vars as plain name map
+/// - MCP: writes to `opencode.json` (`mcp` section), env vars as plain name map
 /// - Hooks: writes to `opencode.json` (hooks section with plugin hook format)
 use std::path::{Path, PathBuf};
 
@@ -83,11 +83,11 @@ impl TargetAdapter for OpencodeAdapter {
 //
 // OpenCode uses a single config file with both MCP and hooks:
 // {
-//   "mcpServers": {
+//   "mcp": {
 //     "server-name": {
-//       "command": "...",
-//       "args": [...],
-//       "env": { "KEY": "VAR_NAME" }   ← plain var name, no interpolation
+//       "type": "local",
+//       "command": ["npx", "-y", "server-package"],
+//       "environment": { "KEY": "VAR_NAME" }   ← plain var name, no interpolation
 //     }
 //   },
 //   "hooks": {
@@ -116,21 +116,27 @@ fn write_opencode_config(
         })
     })?;
 
+    migrate_legacy_mcp_servers(root_obj);
+
     // MCP servers
     if !servers.is_empty() {
         let mcp_obj = root_obj
-            .entry("mcpServers")
+            .entry("mcp")
             .or_insert_with(|| serde_json::json!({}));
         let mcp_map = mcp_obj.as_object_mut().ok_or_else(|| {
             MarsError::Config(crate::error::ConfigError::Invalid {
-                message: format!("{}: mcpServers is not an object", path.display()),
+                message: format!("{}: mcp is not an object", path.display()),
             })
         })?;
 
         for server in servers {
+            let mut command = Vec::with_capacity(server.args.len() + 1);
+            command.push(serde_json::Value::String(server.command.clone()));
+            command.extend(server.args.iter().cloned().map(serde_json::Value::String));
+
             let mut entry = serde_json::json!({
-                "command": server.command,
-                "args": server.args,
+                "type": "local",
+                "command": command,
             });
 
             // OpenCode: env as plain name map (no interpolation)
@@ -140,7 +146,7 @@ fn write_opencode_config(
                     .iter()
                     .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
                     .collect();
-                entry["env"] = serde_json::Value::Object(env_obj);
+                entry["environment"] = serde_json::Value::Object(env_obj);
             }
 
             mcp_map.insert(server.name.clone(), entry);
@@ -217,10 +223,7 @@ fn remove_opencode_entries(entry_keys: &[String], target_dir: &Path) -> Result<(
     };
 
     // Remove MCP entries
-    if let Some(mcp_map) = root_obj
-        .get_mut("mcpServers")
-        .and_then(|v| v.as_object_mut())
-    {
+    if let Some(mcp_map) = root_obj.get_mut("mcp").and_then(|v| v.as_object_mut()) {
         for key in entry_keys {
             if let Some(name) = key.strip_prefix("mcp:") {
                 mcp_map.remove(name);
@@ -261,6 +264,58 @@ fn remove_opencode_entries(entry_keys: &[String], target_dir: &Path) -> Result<(
     Ok(())
 }
 
+fn migrate_legacy_mcp_servers(root_obj: &mut serde_json::Map<String, serde_json::Value>) {
+    if root_obj.contains_key("mcp") {
+        return;
+    }
+
+    let Some(serde_json::Value::Object(legacy_mcp)) = root_obj.remove("mcpServers") else {
+        return;
+    };
+
+    let migrated = legacy_mcp
+        .iter()
+        .map(|(name, entry)| (name.clone(), migrate_legacy_server_entry(entry)))
+        .collect();
+    root_obj.insert("mcp".to_string(), serde_json::Value::Object(migrated));
+}
+
+fn migrate_legacy_server_entry(entry: &serde_json::Value) -> serde_json::Value {
+    let Some(obj) = entry.as_object() else {
+        return serde_json::json!({
+            "type": "local",
+            "command": [],
+        });
+    };
+
+    let mut command = Vec::new();
+    if let Some(cmd) = obj.get("command").and_then(|v| v.as_str()) {
+        command.push(serde_json::Value::String(cmd.to_string()));
+    }
+    if let Some(args) = obj.get("args").and_then(|v| v.as_array()) {
+        command.extend(
+            args.iter()
+                .filter_map(|v| v.as_str().map(|s| serde_json::Value::String(s.to_string()))),
+        );
+    }
+
+    let mut migrated = serde_json::Map::new();
+    migrated.insert(
+        "type".to_string(),
+        serde_json::Value::String("local".to_string()),
+    );
+    migrated.insert("command".to_string(), serde_json::Value::Array(command));
+
+    if let Some(env_obj) = obj.get("env").and_then(|v| v.as_object()) {
+        migrated.insert(
+            "environment".to_string(),
+            serde_json::Value::Object(env_obj.clone()),
+        );
+    }
+
+    serde_json::Value::Object(migrated)
+}
+
 fn opencode_hook_event(event: &str) -> Option<&'static str> {
     match event {
         "session.start" => Some("session:start"),
@@ -287,7 +342,7 @@ mod tests {
         ConfigEntry::McpServer(McpServerEntry {
             name: name.to_string(),
             command: "node".to_string(),
-            args: vec![],
+            args: vec!["server.js".to_string()],
             env,
         })
     }
@@ -323,7 +378,8 @@ mod tests {
 
         let raw = std::fs::read_to_string(tmp.path().join("opencode.json")).unwrap();
         let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
-        assert!(json["mcpServers"]["context7"].is_object());
+        assert!(json["mcp"]["context7"].is_object());
+        assert_eq!(json["mcp"]["context7"]["type"], "local");
     }
 
     #[test]
@@ -336,7 +392,22 @@ mod tests {
         let raw = std::fs::read_to_string(tmp.path().join("opencode.json")).unwrap();
         let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
         // OpenCode: env is a plain name map (not interpolated)
-        assert_eq!(json["mcpServers"]["server"]["env"]["TOKEN"], "MY_TOKEN");
+        assert_eq!(json["mcp"]["server"]["environment"]["TOKEN"], "MY_TOKEN");
+    }
+
+    #[test]
+    fn write_mcp_command_merges_command_and_args() {
+        let tmp = TempDir::new().unwrap();
+        let adapter = OpencodeAdapter;
+        adapter
+            .write_config_entries(&[make_mcp_entry("server")], tmp.path())
+            .unwrap();
+
+        let raw = std::fs::read_to_string(tmp.path().join("opencode.json")).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let command = json["mcp"]["server"]["command"].as_array().unwrap();
+        assert_eq!(command[0], "node");
+        assert_eq!(command[1], "server.js");
     }
 
     #[test]
@@ -353,7 +424,7 @@ mod tests {
 
         let raw = std::fs::read_to_string(tmp.path().join("opencode.json")).unwrap();
         let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
-        assert!(json["mcpServers"]["ctx"].is_object());
+        assert!(json["mcp"]["ctx"].is_object());
         assert!(json["hooks"]["tool:before"].is_array());
     }
 
@@ -402,7 +473,45 @@ mod tests {
 
         let raw = std::fs::read_to_string(tmp.path().join("opencode.json")).unwrap();
         let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
-        assert!(json["mcpServers"]["to-remove"].is_null());
-        assert!(json["mcpServers"]["to-keep"].is_object());
+        assert!(json["mcp"]["to-remove"].is_null());
+        assert!(json["mcp"]["to-keep"].is_object());
+    }
+
+    #[test]
+    fn write_migrates_legacy_mcp_servers_when_mcp_missing() {
+        let tmp = TempDir::new().unwrap();
+        let existing = serde_json::json!({
+            "mcpServers": {
+                "legacy": {
+                    "command": "npx",
+                    "args": ["-y", "legacy-mcp@latest"],
+                    "env": { "TOKEN": "LEGACY_TOKEN" }
+                }
+            },
+            "hooks": {
+                "tool:before": ["bash \"/hooks/audit/run.sh\""]
+            }
+        });
+        std::fs::write(
+            tmp.path().join("opencode.json"),
+            serde_json::to_string_pretty(&existing).unwrap(),
+        )
+        .unwrap();
+
+        let adapter = OpencodeAdapter;
+        adapter
+            .write_config_entries(&[make_hook_entry("audit", "tool:before")], tmp.path())
+            .unwrap();
+
+        let raw = std::fs::read_to_string(tmp.path().join("opencode.json")).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert!(json["mcpServers"].is_null());
+        assert_eq!(json["mcp"]["legacy"]["type"], "local");
+        assert_eq!(json["mcp"]["legacy"]["command"][0], "npx");
+        assert_eq!(json["mcp"]["legacy"]["command"][1], "-y");
+        assert_eq!(
+            json["mcp"]["legacy"]["environment"]["TOKEN"],
+            "LEGACY_TOKEN"
+        );
     }
 }

--- a/tests/mcp_sync.rs
+++ b/tests/mcp_sync.rs
@@ -1,0 +1,174 @@
+// qa-validated: mars-tools-abstraction
+
+mod common;
+
+use assert_fs::TempDir;
+use assert_fs::prelude::*;
+use std::fs;
+
+use common::*;
+
+#[test]
+fn sync_http_mcp_wires_into_all_targets() {
+    let dir = TempDir::new().unwrap();
+
+    let source = dir.child("base");
+    source.create_dir_all().unwrap();
+
+    let mcp_dir = source.child("mcp").child("remote-api");
+    mcp_dir.create_dir_all().unwrap();
+    mcp_dir
+        .child("mcp.toml")
+        .write_str(
+            r#"type = "http"
+url = "https://example.com/mcp"
+visibility = "exported"
+
+[headers]
+Authorization = { from = "env", var = "API_TOKEN" }
+X-Tenant = "acme"
+"#,
+        )
+        .unwrap();
+
+    let project = dir.child("project");
+    project.create_dir_all().unwrap();
+    project
+        .child("mars.toml")
+        .write_str(&format!(
+            r#"[settings]
+targets = [".claude", ".codex", ".opencode", ".cursor"]
+
+[dependencies.base]
+path = "{}"
+"#,
+            source.path().display().to_string().replace('\\', "/")
+        ))
+        .unwrap();
+
+    mars()
+        .args(["sync", "--root", project.path().to_str().unwrap()])
+        .assert()
+        .success();
+
+    let claude_json: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(project.child(".claude/.mcp.json").path()).unwrap(),
+    )
+    .unwrap();
+    let claude_server = &claude_json["mcpServers"]["remote-api"];
+    assert_eq!(claude_server["type"].as_str(), Some("http"));
+    assert_eq!(
+        claude_server["url"].as_str(),
+        Some("https://example.com/mcp")
+    );
+    assert!(
+        claude_server["headers"]["Authorization"]
+            .as_str()
+            .map(|s| s.contains("API_TOKEN"))
+            .unwrap_or(false)
+    );
+    assert_eq!(claude_server["headers"]["X-Tenant"].as_str(), Some("acme"));
+
+    let codex_toml = fs::read_to_string(project.child(".codex/config.toml").path()).unwrap();
+    let codex_config: toml::Value = toml::from_str(&codex_toml).unwrap();
+    let codex_server = &codex_config["mcp"]["servers"]["remote-api"];
+    assert_eq!(
+        codex_server["url"].as_str(),
+        Some("https://example.com/mcp")
+    );
+    assert_eq!(
+        codex_server["bearer_token_env_var"].as_str(),
+        Some("API_TOKEN")
+    );
+    assert_eq!(
+        codex_server["http_headers"]["X-Tenant"].as_str(),
+        Some("acme")
+    );
+
+    let opencode_json: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(project.child(".opencode/opencode.json").path()).unwrap(),
+    )
+    .unwrap();
+    let opencode_server = &opencode_json["mcp"]["remote-api"];
+    assert_eq!(opencode_server["type"].as_str(), Some("remote"));
+    assert_eq!(
+        opencode_server["url"].as_str(),
+        Some("https://example.com/mcp")
+    );
+    assert_eq!(
+        opencode_server["headers"]["X-Tenant"].as_str(),
+        Some("acme")
+    );
+
+    let cursor_json: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(project.child(".cursor/mcp.json").path()).unwrap(),
+    )
+    .unwrap();
+    let cursor_server = &cursor_json["mcpServers"]["remote-api"];
+    assert!(
+        cursor_server.is_object(),
+        "remote-api should be present in cursor mcp.json"
+    );
+    assert_eq!(
+        cursor_server["url"].as_str(),
+        Some("https://example.com/mcp")
+    );
+}
+
+#[test]
+fn sync_cursor_hook_drops_emit_warning() {
+    let dir = TempDir::new().unwrap();
+
+    let source = dir.child("base");
+    source.create_dir_all().unwrap();
+
+    let hook_dir = source.child("hooks").child("audit-log");
+    hook_dir.create_dir_all().unwrap();
+    hook_dir
+        .child("hook.toml")
+        .write_str(
+            r#"name = "audit-log"
+event = "session.start"
+visibility = "exported"
+
+[action]
+kind = "script"
+path = "run.sh"
+"#,
+        )
+        .unwrap();
+    hook_dir.child("run.sh").write_str("#!/bin/sh\n").unwrap();
+
+    let project = dir.child("project");
+    project.create_dir_all().unwrap();
+    project
+        .child("mars.toml")
+        .write_str(&format!(
+            r#"[settings]
+targets = [".cursor"]
+
+[dependencies.base]
+path = "{}"
+"#,
+            source.path().display().to_string().replace('\\', "/")
+        ))
+        .unwrap();
+
+    let output = mars()
+        .args(["sync", "--root", project.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "sync should succeed for cursor");
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("hook-dropped")
+            || ((stderr.contains("hook") || stderr.contains("dropped"))
+                && stderr.contains("cursor")),
+        "expected cursor hook-drop warning in stderr: {stderr}"
+    );
+
+    assert!(!project.child(".cursor/hooks.json").exists());
+    assert!(!project.child(".cursor/settings.json").exists());
+    assert!(!project.child(".cursor/codex_hooks.json").exists());
+}

--- a/tests/tools_sync.rs
+++ b/tests/tools_sync.rs
@@ -1,0 +1,212 @@
+// qa-validated: mars-tools-abstraction
+
+mod common;
+
+use assert_fs::TempDir;
+use assert_fs::prelude::*;
+use std::fs;
+use std::path::PathBuf;
+
+use common::*;
+
+fn setup_project_with_source(
+    dir: &TempDir,
+    targets: &[&str],
+    agents: &[(&str, &str)],
+) -> std::path::PathBuf {
+    let source = create_source(dir, "base", agents, &[]);
+    let project = dir.child("project");
+    project.create_dir_all().unwrap();
+
+    let targets_str = targets
+        .iter()
+        .map(|target| format!("\"{target}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    project
+        .child("mars.toml")
+        .write_str(&format!(
+            "[settings]\ntargets = [{targets_str}]\nagent_emission = \"always\"\n\n[dependencies.base]\npath = \"{}\"\n",
+            source.display().to_string().replace('\\', "/")
+        ))
+        .unwrap();
+
+    project.to_path_buf()
+}
+
+fn scoped_tools_agent() -> (&'static str, &'static str) {
+    (
+        "scoped-tools-agent",
+        "---\nname: scoped-tools-agent\ndescription: agent with scoped tools (dropped for claude)\nharness: claude\nmodel: claude-opus-4-6\ntools:\n  \"*\": deny\n  read:\n    \"*\": allow\n    \"*.env\": deny\n---\n# Scoped tools agent\n",
+    )
+}
+
+#[test]
+fn sync_abstract_tools_map_lowered_to_claude_disallowed_tools() {
+    let dir = TempDir::new().unwrap();
+    let project = setup_project_with_source(
+        &dir,
+        &[".claude"],
+        &[(
+            "restricted-agent",
+            "---\nname: restricted-agent\ndescription: agent with tools restriction\nharness: claude\nmodel: claude-opus-4-6\ntools:\n  \"*\": allow\n  task: deny\n---\n# Restricted agent\n",
+        )],
+    );
+
+    mars()
+        .args(["sync", "--root", project.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let canonical = fs::read_to_string(
+        PathBuf::from(&project)
+            .join(".mars")
+            .join("agents")
+            .join("restricted-agent.md"),
+    )
+    .unwrap();
+    assert!(canonical.contains("task"));
+    assert!(canonical.contains("deny"));
+
+    let native = fs::read_to_string(
+        PathBuf::from(&project)
+            .join(".claude")
+            .join("agents")
+            .join("restricted-agent.md"),
+    )
+    .unwrap();
+    assert!(native.contains("disallowed-tools"));
+    assert!(native.contains("Agent"));
+    assert!(!native.contains("task:"));
+}
+
+#[test]
+fn sync_abstract_tools_map_infers_codex_sandbox_mode() {
+    let dir = TempDir::new().unwrap();
+    let project = setup_project_with_source(
+        &dir,
+        &[".codex"],
+        &[(
+            "workspace-coder",
+            "---\nname: workspace-coder\ndescription: agent that can edit files\nharness: codex\nmodel: gpt-5.3-codex\ntools:\n  \"*\": deny\n  bash: allow\n  edit: allow\n---\n# Workspace coder\n",
+        )],
+    );
+
+    mars()
+        .args(["sync", "--root", project.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let toml_str = fs::read_to_string(
+        PathBuf::from(&project)
+            .join(".codex")
+            .join("agents")
+            .join("workspace-coder.toml"),
+    )
+    .unwrap();
+    let parsed: toml::Value = toml::from_str(&toml_str).unwrap();
+    assert_eq!(
+        parsed.get("sandbox_mode").and_then(|v| v.as_str()),
+        Some("workspace-write"),
+        "bash+edit allow with default deny should infer workspace-write"
+    );
+}
+
+#[test]
+fn sync_deprecated_tools_list_preserved_as_abstract_in_canonical() {
+    let dir = TempDir::new().unwrap();
+    let project = setup_project_with_source(
+        &dir,
+        &[".claude"],
+        &[(
+            "old-coder",
+            "---\nname: old-coder\ndescription: uses old tools syntax\nharness: claude\nmodel: claude-opus-4-6\ntools: [Bash, Write, Edit]\n---\n# Old coder\n",
+        )],
+    );
+
+    mars()
+        .args(["sync", "--root", project.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let canonical = fs::read_to_string(
+        PathBuf::from(&project)
+            .join(".mars")
+            .join("agents")
+            .join("old-coder.md"),
+    )
+    .unwrap();
+    assert!(
+        canonical.contains("tools: [Bash, Write, Edit]"),
+        "canonical artifact should preserve deprecated list form for now"
+    );
+
+    let native = fs::read_to_string(
+        PathBuf::from(&project)
+            .join(".claude")
+            .join("agents")
+            .join("old-coder.md"),
+    )
+    .unwrap();
+    assert!(native.contains("Bash") || native.contains("bash"));
+}
+
+#[test]
+fn sync_tools_lossiness_surfaced_in_sync_output() {
+    let dir = TempDir::new().unwrap();
+    let project = setup_project_with_source(&dir, &[".claude"], &[scoped_tools_agent()]);
+
+    let output = mars()
+        .args(["sync", "--root", project.to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "sync should succeed even with lossiness"
+    );
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("agent-field-dropped") || stderr.contains("dropped"),
+        "sync should warn about dropped scoped tools field: {stderr}"
+    );
+}
+
+#[test]
+fn sync_tools_lossiness_strict_fails() {
+    let dir = TempDir::new().unwrap();
+    let project = setup_project_with_source(&dir, &[".claude"], &[scoped_tools_agent()]);
+
+    mars()
+        .args(["sync", "--root", project.to_str().unwrap()])
+        .assert()
+        .success();
+
+    mars()
+        .args(["validate", "--strict", "--root", project.to_str().unwrap()])
+        .assert()
+        .failure();
+
+    let output = mars()
+        .args([
+            "validate",
+            "--json",
+            "--strict",
+            "--root",
+            project.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    let json: serde_json::Value =
+        serde_json::from_str(&String::from_utf8(output.stdout).unwrap()).unwrap();
+    assert_eq!(json["clean"].as_bool(), Some(false));
+    let diagnostics = json["diagnostics"].as_array().unwrap();
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diag| diag["code"].as_str() == Some("agent-field-dropped")),
+        "should have agent-field-dropped diagnostic: {json}"
+    );
+}


### PR DESCRIPTION
## Summary

- **Abstract tools field**: Replace Claude-specific `tools: Vec<String>` / `disallowed_tools: Vec<String>` with `ToolAction`/`ToolRule`/`ToolsField` types. Parse shorthand, mapping, and scoped patterns. Deprecation bridge for old list-form and `disallowed-tools:` with warnings. Per-harness lowering with lossiness diagnostics. Deprecated code paths cleanly isolated with R08 comments.
- **MCP native projection**: Codex writes native TOML `[mcp.servers.*]` to `.codex/config.toml` (replacing `codex_mcp.json`). OpenCode writes native `"mcp"` entries with `"type": "local"` (replacing wrong `"mcpServers"` key). Non-MCP config preserved, stale cleanup scoped to managed entries.
- **HTTP MCP transport**: `mcp.toml` accepts `type`, `url`, and `[headers]` with parse-time validation. Claude/Codex/OpenCode emit correct HTTP-native records. Stdio paths unchanged.

## Review fixes (post-review)

- **Codex sandbox inference**: Fixed over-granting `danger-full-access` for mixed wildcard-allow + explicit deny maps
- **Codex config.toml clobber**: Parse failure now emits diagnostic and skips writes instead of silently replacing with empty doc
- **Override `disallowed-tools` bridge**: Added deprecation bridge for `harness-overrides.<target>.disallowed-tools` (was silently dropped)
- **OpenCode stale cleanup**: Legacy `mcpServers` entries now cleaned in removal path, not just write path

## Test plan

- [x] 1164 tests pass (`cargo test`) — 1064 unit + 100 integration
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] 14 new integration/unit tests for tools field and MCP sync
- [x] End-to-end `mars sync` smoke test with all three deliverables
- [x] Structural review: all 4 findings addressed
- [x] Pre-push hook GIT_DIR leak fixed (#36)

Closes #33, Closes #34, Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)