### PR TITLE
tests: prune redundant tools abstraction coverage

### DIFF
--- a/src/compiler/agents/lower.rs
+++ b/src/compiler/agents/lower.rs
@@ -985,249 +985,138 @@ mod tests {
         (profile, fm, diags)
     }
 
-    // --- 3.3: Claude lowering ---
-
     #[test]
-    fn claude_lowering_preserves_name_description_model_skills_tools_body() {
-        let content = "---\nname: coder\ndescription: Code impl agent\nmodel: gpt55\nharness: claude\nskills: [dev-principles]\ntools:\n  \"*\": deny\n  bash: allow\n  edit: allow\n---\n# Coder\nYou write code.";
-        let (profile, fm, _) = profile_from(content);
-        let body = fm.body();
-        let out = lower_to_claude(&profile, &fm, body);
-        let text = String::from_utf8(out.bytes).unwrap();
-        assert!(text.contains("name: coder"), "name missing: {text}");
-        assert!(
-            text.contains("description: Code impl agent"),
-            "desc missing"
-        );
-        assert!(text.contains("model: gpt55"), "model missing");
-        assert!(text.contains("skills"), "skills missing");
-        assert!(text.contains("tools"), "tools missing");
-        assert!(text.contains("Bash"), "bash missing");
-        assert!(text.contains("Edit"), "edit missing");
-        assert!(text.contains("Write"), "write missing");
-        assert!(text.contains("# Coder"), "body missing");
-    }
-
-    #[test]
-    fn claude_tools_ask_is_approximate_and_scoped_is_dropped() {
-        let content = "---\nname: coder\nharness: claude\ntools:\n  \"*\": deny\n  bash: ask\n  read:\n    \"*.env\": allow\n---\n# Body";
+    fn claude_lowering_preserves_supported_fields_and_maps_tools() {
+        let content = r#"---
+name: coder
+description: Code impl agent
+model: gpt55
+harness: claude
+skills: [dev-principles]
+tools:
+  "*": deny
+  bash: allow
+  edit: allow
+---
+# Coder
+You write code."#;
         let (profile, fm, _) = profile_from(content);
         let out = lower_to_claude(&profile, &fm, fm.body());
         let text = String::from_utf8(out.bytes).unwrap();
-        assert!(text.contains("Bash"), "ask should lower to allow");
-        assert!(!text.contains("*.env"), "scoped rule should be dropped");
+        assert!(text.contains("name: coder"));
+        assert!(text.contains("description: Code impl agent"));
+        assert!(text.contains("model: gpt55"));
+        assert!(text.contains("skills"));
+        assert!(text.contains("Bash"));
+        assert!(text.contains("Edit"));
+        assert!(text.contains("Write"));
+        assert!(text.contains("# Coder"));
+    }
+
+    #[test]
+    fn claude_lowering_drops_non_native_fields_and_reports_lossiness() {
+        let content = r#"---
+name: coder
+harness: claude
+approval: auto
+sandbox: read-only
+mode: subagent
+autocompact: 50
+autocompact-pct: 80
+tools:
+  "*": deny
+  bash: ask
+  read:
+    "*.env": allow
+model-policies:
+  - match:
+      model: gpt55
+    override:
+      harness: codex
+fanout:
+  - alias: opus
+---
+# Body"#;
+        let (profile, fm, _) = profile_from(content);
+        let out = lower_to_claude(&profile, &fm, fm.body());
+        let text = String::from_utf8(out.bytes).unwrap();
+        assert!(!text.contains("approval:"));
+        assert!(!text.contains("sandbox:"));
+        assert!(!text.contains("autocompact:"));
+        assert!(!text.contains("model-policies:"));
+        assert!(!text.contains("fanout:"));
         assert!(out.lossy_fields.iter().any(|lf| {
             lf.field == "tools.bash" && matches!(lf.classification, Lossiness::Approximate { .. })
         }));
         assert!(out.lossy_fields.iter().any(|lf| {
             lf.field == "tools.read" && matches!(lf.classification, Lossiness::Dropped)
         }));
-    }
-
-    #[test]
-    fn claude_tools_map_default_allow_emits_disallowed_tools() {
-        let content =
-            "---\nname: r\nharness: claude\ntools:\n  \"*\": allow\n  task: deny\n---\n# body";
-        let (profile, fm, _) = profile_from(content);
-        let out = lower_to_claude(&profile, &fm, fm.body());
-        let text = String::from_utf8(out.bytes).unwrap();
-        assert!(!text.contains("tools: []"), "should not emit allowlist");
-        assert!(
-            text.contains("disallowed-tools"),
-            "deny list should be emitted"
-        );
-        assert!(text.contains("Agent"), "task deny should map to Agent");
-    }
-
-    #[test]
-    fn claude_lowering_drops_approval_sandbox_mode_autocompact() {
-        let content = "---\nname: coder\nharness: claude\napproval: auto\nsandbox: read-only\nmode: subagent\nautocompact: 50\nautocompact-pct: 80\n---\n# Body";
-        let (profile, fm, _) = profile_from(content);
-        let out = lower_to_claude(&profile, &fm, fm.body());
-        let text = String::from_utf8(out.bytes).unwrap();
-        assert!(!text.contains("approval:"), "approval leaked: {text}");
-        assert!(!text.contains("sandbox:"), "sandbox leaked: {text}");
-        assert!(!text.contains("autocompact:"), "autocompact leaked: {text}");
-        // Lossiness should report dropped fields
-        let dropped: Vec<_> = out.lossy_fields.iter().map(|f| f.field.as_str()).collect();
-        assert!(
-            dropped.contains(&"approval"),
-            "approval not in lossy: {dropped:?}"
-        );
-        assert!(
-            dropped.contains(&"sandbox"),
-            "sandbox not in lossy: {dropped:?}"
-        );
-        assert!(
-            dropped.contains(&"autocompact"),
-            "autocompact not in lossy: {dropped:?}"
-        );
-        assert!(
-            dropped.contains(&"autocompact-pct"),
-            "autocompact-pct not in lossy: {dropped:?}"
-        );
+        for field in [
+            "approval",
+            "sandbox",
+            "mode",
+            "autocompact",
+            "autocompact-pct",
+            "model-policies",
+            "fanout",
+        ] {
+            assert!(out.lossy_fields.iter().any(|lf| lf.field == field));
+        }
     }
 
     #[test]
     fn claude_harness_override_applied_before_lowering() {
-        let content = "---\nname: r\nharness: claude\nskills: [base-skill]\nharness-overrides:\n  claude:\n    skills: [override-skill]\n---\n# body";
+        let content = r#"---
+name: r
+harness: claude
+skills: [base-skill]
+harness-overrides:
+  claude:
+    skills: [override-skill]
+---
+# body"#;
         let (profile, fm, _) = profile_from(content);
         let out = lower_to_claude(&profile, &fm, fm.body());
         let text = String::from_utf8(out.bytes).unwrap();
-        assert!(
-            text.contains("override-skill"),
-            "override not applied: {text}"
-        );
-        assert!(
-            !text.contains("base-skill"),
-            "base skill not overridden: {text}"
-        );
+        assert!(text.contains("override-skill"));
+        assert!(!text.contains("base-skill"));
     }
 
     #[test]
-    fn claude_meridian_only_fields_dropped() {
-        let content = "---\nname: r\nharness: claude\nmodel-policies:\n  - match:\n      model: gpt55\n    override:\n      harness: codex\nfanout:\n  - alias: opus\n---\n# body";
-        let (profile, fm, _) = profile_from(content);
-        let out = lower_to_claude(&profile, &fm, fm.body());
-        let text = String::from_utf8(out.bytes).unwrap();
-        assert!(
-            !text.contains("model-policies:"),
-            "model-policies leaked: {text}"
-        );
-        assert!(!text.contains("fanout:"), "fanout leaked: {text}");
-        let meridian_only: Vec<_> = out
-            .lossy_fields
-            .iter()
-            .filter(|f| matches!(f.classification, Lossiness::MeridianOnly))
-            .map(|f| f.field.as_str())
-            .collect();
-        assert!(meridian_only.contains(&"model-policies"));
-        assert!(meridian_only.contains(&"fanout"));
-    }
-
-    // --- 3.3: Codex lowering ---
-
-    #[test]
-    fn codex_lowering_produces_top_level_toml() {
-        let content = "---\nname: coder\ndescription: Code agent\nmodel: gpt55\nharness: codex\neffort: high\nsandbox: workspace-write\napproval: auto\n---\n# Coder\nYou code.";
-        let (profile, fm, _) = profile_from(content);
-        let out = lower_to_codex(&profile, fm.body());
-        let text = String::from_utf8(out.bytes).unwrap();
-        assert!(
-            !text.contains("[agent]"),
-            "legacy [agent] table leaked: {text}"
-        );
-        assert!(text.contains("name = \"coder\""), "name missing");
-        assert!(text.contains("model = \"gpt55\""), "model missing");
-        assert!(
-            text.contains("model_reasoning_effort = \"high\""),
-            "effort missing"
-        );
-        assert!(
-            text.contains("sandbox_mode = \"workspace-write\""),
-            "sandbox missing"
-        );
-        assert!(
-            text.contains("approval_policy = \"on-request\""),
-            "approval missing"
-        );
-        assert!(
-            text.contains("developer_instructions ="),
-            "developer instructions missing"
-        );
-
-        let parsed: toml::Value = toml::from_str(&text).expect("lowered TOML should parse");
-        assert!(
-            parsed.get("agent").is_none(),
-            "nested [agent] table present"
-        );
-        assert_eq!(parsed.get("name").and_then(|v| v.as_str()), Some("coder"));
-    }
-
-    #[test]
-    fn codex_lowering_drops_skills_and_inferrs_sandbox_from_tools() {
-        let content = "---\nname: r\nharness: codex\nskills: [review]\ntools:\n  \"*\": deny\n  bash: allow\n---\n# body";
-        let (profile, fm, _) = profile_from(content);
-        let out = lower_to_codex(&profile, fm.body());
-        let approx: Vec<_> = out
-            .lossy_fields
-            .iter()
-            .filter(|f| matches!(f.classification, Lossiness::Approximate { .. }))
-            .map(|f| f.field.as_str())
-            .collect();
-        assert!(approx.contains(&"tools.bash"));
-        assert!(
-            out.lossy_fields
-                .iter()
-                .any(|f| { f.field == "skills" && matches!(f.classification, Lossiness::Dropped) })
-        );
-
-        let text = String::from_utf8(out.bytes).unwrap();
-        assert!(
-            text.contains("sandbox_mode = \"workspace-write\""),
-            "sandbox should be inferred from bash allow: {text}"
-        );
-    }
-
-    #[test]
-    fn codex_harness_override_applied() {
-        let content = "---\nname: r\nharness: codex\ntools:\n  \"*\": deny\n  bash: allow\nharness-overrides:\n  codex:\n    effort: high\n    sandbox: read-only\n    tools:\n      \"*\": deny\n      read: allow\n---\n# body";
-        let (profile, fm, _) = profile_from(content);
-        let out = lower_to_codex(&profile, fm.body());
-        let text = String::from_utf8(out.bytes).unwrap();
-        assert!(
-            text.contains("model_reasoning_effort = \"high\""),
-            "override not applied: {text}"
-        );
-        assert!(
-            text.contains("sandbox_mode = \"read-only\""),
-            "sandbox override not applied: {text}"
-        );
-        assert!(
-            out.lossy_fields.iter().any(|lf| lf.field == "tools.read"
-                && matches!(lf.classification, Lossiness::Approximate { .. })),
-            "override tools should replace top-level tools"
-        );
-        assert!(
-            !out.lossy_fields.iter().any(|lf| lf.field == "tools.bash"),
-            "top-level tools should be replaced by override tools"
-        );
-    }
-
-    #[test]
-    fn codex_infers_danger_full_access_when_default_allow_and_no_write_denies() {
-        let content = "---\nname: r\nharness: codex\ntools:\n  \"*\": allow\n---\n# body";
-        let (profile, fm, _) = profile_from(content);
-        let out = lower_to_codex(&profile, fm.body());
-        let text = String::from_utf8(out.bytes).unwrap();
-        assert!(
-            text.contains("sandbox_mode = \"danger-full-access\""),
-            "sandbox should infer danger-full-access: {text}"
-        );
-    }
-
-    #[test]
-    fn codex_wildcard_allow_with_explicit_bash_deny_does_not_infer_danger_full_access() {
-        let content =
-            "---\nname: r\nharness: codex\ntools:\n  \"*\": allow\n  bash: deny\n---\n# body";
-        let (profile, fm, _) = profile_from(content);
-        let out = lower_to_codex(&profile, fm.body());
-        let text = String::from_utf8(out.bytes).unwrap();
-        assert!(
-            text.contains("sandbox_mode = \"workspace-write\""),
-            "sandbox should not infer danger-full-access when bash is explicitly denied: {text}"
-        );
-        assert!(!text.contains("danger-full-access"));
-    }
-
-    #[test]
-    fn codex_lowering_multiline_instructions_are_parseable() {
-        let content = "---\nname: explorer\ndescription: \"Line one\\nLine two\"\nharness: codex\napproval: yolo\n---\n# Explore\nUse \"quotes\" and backslashes \\\\\nKeep going.";
+    fn codex_lowering_produces_parseable_top_level_toml() {
+        let content = r#"---
+name: explorer
+description: "Line one
+Line two"
+model: gpt55
+harness: codex
+effort: high
+sandbox: workspace-write
+approval: yolo
+---
+# Explore
+Use "quotes" and backslashes \
+Keep going."#;
         let (profile, fm, _) = profile_from(content);
         let out = lower_to_codex(&profile, fm.body());
         let text = String::from_utf8(out.bytes).unwrap();
         let parsed: toml::Value = toml::from_str(&text).expect("lowered TOML should parse");
 
+        assert!(parsed.get("agent").is_none());
+        assert_eq!(
+            parsed.get("name").and_then(|v| v.as_str()),
+            Some("explorer")
+        );
+        assert_eq!(
+            parsed
+                .get("model_reasoning_effort")
+                .and_then(|v| v.as_str()),
+            Some("high")
+        );
+        assert_eq!(
+            parsed.get("sandbox_mode").and_then(|v| v.as_str()),
+            Some("workspace-write")
+        );
         assert_eq!(
             parsed.get("approval_policy").and_then(|v| v.as_str()),
             Some("never")
@@ -1237,105 +1126,140 @@ mod tests {
                 .get("developer_instructions")
                 .and_then(|v| v.as_str())
                 .unwrap_or_default(),
-            "# Explore\nUse \"quotes\" and backslashes \\\\\nKeep going."
+            "# Explore\nUse \"quotes\" and backslashes \\\nKeep going."
         );
     }
 
     #[test]
-    fn codex_ask_tool_is_compiled_as_allow_with_approximate_lossiness() {
-        let mut tools = std::collections::BTreeMap::new();
-        tools.insert("*".to_string(), ToolRule::Action(ToolAction::Deny));
-        tools.insert("bash".to_string(), ToolRule::Action(ToolAction::Ask));
-        let profile = AgentProfile {
-            name: Some("coder".to_string()),
-            description: None,
-            harness: Some(HarnessKind::Codex),
-            model: None,
-            mode: None,
-            approval: None,
-            sandbox: None,
-            effort: None,
-            autocompact: None,
-            autocompact_pct: None,
-            skills: Vec::new(),
-            tools: Some(ToolsField::Map(tools)),
-            mcp_tools: Vec::new(),
-            harness_overrides: crate::compiler::agents::HarnessOverrides::default(),
-            model_policies: Vec::new(),
-            fanout: Vec::new(),
-        };
+    fn codex_sandbox_inference_matches_behavioral_cases() {
+        let cases = [
+            ("---\nname: r\nharness: codex\n---\n# body", None),
+            (
+                "---\nname: r\nharness: codex\ntools:\n  \"*\": allow\n---\n# body",
+                Some("danger-full-access"),
+            ),
+            (
+                "---\nname: r\nharness: codex\ntools:\n  \"*\": allow\n  bash: deny\n---\n# body",
+                Some("workspace-write"),
+            ),
+            (
+                "---\nname: r\nharness: codex\nsandbox: default\n---\n# body",
+                None,
+            ),
+        ];
 
-        let out = lower_to_codex(&profile, "# body");
+        for (content, expected_sandbox) in cases {
+            let (profile, fm, _) = profile_from(content);
+            let out = lower_to_codex(&profile, fm.body());
+            let text = String::from_utf8(out.bytes).unwrap();
+            let parsed: toml::Value = toml::from_str(&text).expect("lowered TOML should parse");
+            assert_eq!(
+                parsed.get("sandbox_mode").and_then(|v| v.as_str()),
+                expected_sandbox,
+                "unexpected sandbox inference for content:
+{content}
+{text}"
+            );
+        }
+    }
+
+    #[test]
+    fn codex_harness_override_replaces_top_level_tools_and_fields() {
+        let content = r#"---
+name: r
+harness: codex
+tools:
+  "*": deny
+  bash: allow
+harness-overrides:
+  codex:
+    effort: high
+    sandbox: read-only
+    tools:
+      "*": deny
+      read: allow
+---
+# body"#;
+        let (profile, fm, _) = profile_from(content);
+        let out = lower_to_codex(&profile, fm.body());
         let text = String::from_utf8(out.bytes).unwrap();
-        let parsed: toml::Value = toml::from_str(&text).expect("lowered TOML should parse");
-        assert!(
-            text.contains("sandbox_mode ="),
-            "sandbox_mode should be present: {text}"
-        );
-        assert!(
-            parsed
-                .get("sandbox_mode")
-                .and_then(|v| v.as_str())
-                .is_some(),
-            "parsed TOML should include sandbox_mode: {parsed:?}"
-        );
+        assert!(text.contains("model_reasoning_effort = \"high\""));
+        assert!(text.contains("sandbox_mode = \"read-only\""));
         assert!(out.lossy_fields.iter().any(|lf| {
-            matches!(lf.classification, Lossiness::Approximate { .. })
-                && (lf.field.contains("tools") || lf.field.contains("bash"))
+            lf.field == "tools.read" && matches!(lf.classification, Lossiness::Approximate { .. })
+        }));
+        assert!(!out.lossy_fields.iter().any(|lf| lf.field == "tools.bash"));
+    }
+
+    #[test]
+    fn codex_tools_lossiness_includes_ask_and_scoped_rules() {
+        let content = r#"---
+name: r
+harness: codex
+tools:
+  "*": deny
+  bash: ask
+  read:
+    "*.env": allow
+---
+# body"#;
+        let (profile, fm, _) = profile_from(content);
+        let out = lower_to_codex(&profile, fm.body());
+        assert!(out.lossy_fields.iter().any(|lf| {
+            lf.field == "tools.bash" && matches!(lf.classification, Lossiness::Approximate { .. })
+        }));
+        assert!(out.lossy_fields.iter().any(|lf| {
+            lf.field == "tools.read" && matches!(lf.classification, Lossiness::Dropped)
         }));
     }
 
-    // --- 3.3: OpenCode lowering ---
-
     #[test]
-    fn opencode_lowering_preserves_name_description_model_mode() {
-        let content = "---\nname: r\ndescription: Reviewer\nmodel: gpt55\nmode: primary\nharness: opencode\n---\n# Reviewer\nbody";
+    fn opencode_lowering_preserves_supported_fields_and_omits_tools() {
+        let content = r#"---
+name: r
+description: Reviewer
+model: gpt55
+mode: primary
+harness: opencode
+tools:
+  "*": deny
+  bash: allow
+---
+# Reviewer
+body"#;
         let (profile, fm, _) = profile_from(content);
         let out = lower_to_opencode(&profile, fm.body());
         let text = String::from_utf8(out.bytes).unwrap();
-        assert!(text.contains("name: r"), "name missing");
-        assert!(text.contains("description: Reviewer"), "desc missing");
-        assert!(text.contains("model: gpt55"), "model missing");
-        assert!(text.contains("mode: primary"), "mode missing");
+        assert!(text.contains("name: r"));
+        assert!(text.contains("description: Reviewer"));
+        assert!(text.contains("model: gpt55"));
+        assert!(text.contains("mode: primary"));
+        assert!(!text.contains("tools:"));
+        assert!(!text.contains("disallowed-tools"));
     }
 
     #[test]
-    fn opencode_lowering_omits_tools_fields() {
-        let content =
-            "---\nname: r\nharness: opencode\ntools:\n  \"*\": deny\n  bash: allow\n---\n# body";
-        let (profile, fm, _) = profile_from(content);
-        let out = lower_to_opencode(&profile, fm.body());
-        let text = String::from_utf8(out.bytes).unwrap();
-        assert!(!text.contains("tools:"), "tools must not be emitted");
-        assert!(
-            !text.contains("disallowed-tools"),
-            "legacy field must not appear"
-        );
-    }
-
-    // --- 3.3: Pi lowering ---
-
-    #[test]
-    fn pi_lowering_preserves_name_description_model() {
-        let content = "---\nname: pi-agent\ndescription: Pi agent\nmodel: gpt55\nharness: pi\n---\n# Pi\nbody";
-        let (profile, fm, _) = profile_from(content);
-        let out = lower_to_pi(&profile, fm.body());
-        let text = String::from_utf8(out.bytes).unwrap();
-        assert!(text.contains("name: pi-agent"), "name missing");
-        assert!(text.contains("description: Pi agent"), "desc missing");
-    }
-
-    #[test]
-    fn pi_lowering_emits_tools_and_flags_ask_and_scoped() {
-        let content = "---\nname: pi-agent\nharness: pi\ntools:\n  \"*\": deny\n  bash: allow\n  web: ask\n  read:\n    \"*.env\": allow\n---\n# body";
+    fn pi_lowering_expands_tools_and_reports_lossiness() {
+        let content = r#"---
+name: pi-agent
+description: Pi agent
+model: gpt55
+mode: subagent
+harness: pi
+tools:
+  "*": deny
+  edit: allow
+  web: ask
+  read:
+    "*.env": allow
+---
+# body"#;
         let (profile, fm, _) = profile_from(content);
         let out = lower_to_pi(&profile, fm.body());
         let text = String::from_utf8(out.bytes).unwrap();
-        // web expands to websearch, webfetch
-        assert!(
-            text.contains("tools: bash, websearch, webfetch"),
-            "tools list missing: {text}"
-        );
+        assert!(text.contains("description: Pi agent"));
+        assert!(text.contains("mode: subagent"));
+        assert!(text.contains("tools: edit, write, websearch, webfetch"));
         assert!(out.lossy_fields.iter().any(|lf| {
             lf.field == "tools.web" && matches!(lf.classification, Lossiness::Approximate { .. })
         }));
@@ -1344,83 +1268,41 @@ mod tests {
         }));
     }
 
-    // --- 3.3: Dispatch ---
-
     #[test]
-    fn codex_no_tools_no_sandbox_omits_sandbox_mode() {
-        let content = "---\nname: r\nharness: codex\n---\n# body";
-        let (profile, fm, _) = profile_from(content);
-        let out = lower_to_codex(&profile, fm.body());
-        let text = String::from_utf8(out.bytes).unwrap();
-        assert!(
-            !text.contains("sandbox_mode"),
-            "sandbox_mode should be omitted when no tools and no sandbox: {text}"
+    fn lower_for_harness_dispatches_to_native_formats() {
+        let (claude_profile, claude_fm, _) = profile_from(
+            "---
+name: coder
+model: gpt55
+harness: claude
+---
+# body",
         );
-    }
+        let claude = lower_for_harness(
+            &HarnessKind::Claude,
+            &claude_profile,
+            &claude_fm,
+            claude_fm.body(),
+        );
+        let claude_text = String::from_utf8(claude.bytes).unwrap();
+        assert!(claude_text.contains("---"));
 
-    #[test]
-    fn codex_sandbox_default_no_tools_omits_sandbox_mode() {
-        let content = "---\nname: r\nharness: codex\nsandbox: default\n---\n# body";
-        let (profile, fm, _) = profile_from(content);
-        let out = lower_to_codex(&profile, fm.body());
-        let text = String::from_utf8(out.bytes).unwrap();
-        assert!(
-            !text.contains("sandbox_mode"),
-            "sandbox: default with no tools should omit sandbox_mode: {text}"
+        let (codex_profile, codex_fm, _) = profile_from(
+            "---
+name: coder
+model: gpt55
+harness: codex
+---
+# body",
         );
-    }
-
-    #[test]
-    fn codex_wildcard_only_allow_no_extra_lossiness() {
-        let content = "---\nname: r\nharness: codex\ntools:\n  \"*\": allow\n---\n# body";
-        let (profile, fm, _) = profile_from(content);
-        let out = lower_to_codex(&profile, fm.body());
-        // Wildcard allow/deny maps exactly to sandbox — no Approximate entries
-        let approx: Vec<_> = out
-            .lossy_fields
-            .iter()
-            .filter(|f| matches!(f.classification, Lossiness::Approximate { .. }))
-            .collect();
-        assert!(
-            approx.is_empty(),
-            "wildcard-only allow should not produce Approximate lossiness: {approx:?}"
+        let codex = lower_for_harness(
+            &HarnessKind::Codex,
+            &codex_profile,
+            &codex_fm,
+            codex_fm.body(),
         );
-    }
-
-    #[test]
-    fn pi_lowering_expands_edit_and_web_capabilities() {
-        let content = "---\nname: pi-agent\nharness: pi\ntools:\n  \"*\": deny\n  edit: allow\n  web: allow\n---\n# body";
-        let (profile, fm, _) = profile_from(content);
-        let out = lower_to_pi(&profile, fm.body());
-        let text = String::from_utf8(out.bytes).unwrap();
-        assert!(
-            text.contains("edit, write"),
-            "edit should expand to edit, write: {text}"
-        );
-        assert!(
-            text.contains("websearch, webfetch"),
-            "web should expand to websearch, webfetch: {text}"
-        );
-    }
-
-    #[test]
-    fn lower_for_harness_dispatches_correctly() {
-        let content = "---\nname: coder\nmodel: gpt55\nharness: claude\n---\n# body";
-        let (profile, fm, _) = profile_from(content);
-        let body = fm.body().to_string();
-        let out = lower_for_harness(&HarnessKind::Claude, &profile, &fm, &body);
-        let text = String::from_utf8(out.bytes).unwrap();
-        assert!(text.contains("---"), "not markdown format");
-
-        let content2 = "---\nname: coder\nmodel: gpt55\nharness: codex\n---\n# body";
-        let (profile2, fm2, _) = profile_from(content2);
-        let body2 = fm2.body().to_string();
-        let out2 = lower_for_harness(&HarnessKind::Codex, &profile2, &fm2, &body2);
-        let text2 = String::from_utf8(out2.bytes).unwrap();
-        assert!(text2.contains("name = \"coder\""), "not TOML format");
-        assert!(
-            !text2.contains("[agent]"),
-            "legacy nested agent table emitted"
-        );
+        let codex_text = String::from_utf8(codex.bytes).unwrap();
+        assert!(codex_text.contains("name = \"coder\""));
+        assert!(!codex_text.contains("[agent]"));
     }
 }

--- a/src/compiler/agents/mod.rs
+++ b/src/compiler/agents/mod.rs
@@ -996,177 +996,6 @@ mod tests {
         (profile, diags)
     }
 
-    // --- 3.1: Basic field parsing ---
-
-    #[test]
-    fn parses_name_and_description() {
-        let (p, diags) = parse("---\nname: coder\ndescription: Code agent\n---\n# Body");
-        assert!(diags.is_empty());
-        assert_eq!(p.name.as_deref(), Some("coder"));
-        assert_eq!(p.description.as_deref(), Some("Code agent"));
-    }
-
-    #[test]
-    fn parses_mode_primary() {
-        let (p, diags) = parse("---\nmode: primary\n---\n");
-        assert!(diags.is_empty());
-        assert_eq!(p.mode, Some(AgentMode::Primary));
-    }
-
-    #[test]
-    fn parses_mode_subagent() {
-        let (p, diags) = parse("---\nmode: subagent\n---\n");
-        assert!(diags.is_empty());
-        assert_eq!(p.mode, Some(AgentMode::Subagent));
-    }
-
-    #[test]
-    fn invalid_mode_produces_diagnostic() {
-        let (p, diags) = parse("---\nmode: invalid\n---\n");
-        assert_eq!(p.mode, None);
-        assert_eq!(diags.len(), 1);
-        assert!(
-            matches!(&diags[0], AgentDiagnostic::InvalidFieldValue { field, .. } if field == "mode")
-        );
-    }
-
-    #[test]
-    fn parses_harness_claude() {
-        let (p, diags) = parse("---\nharness: claude\n---\n");
-        assert!(diags.is_empty());
-        assert_eq!(p.harness, Some(HarnessKind::Claude));
-    }
-
-    #[test]
-    fn parses_harness_codex() {
-        let (p, diags) = parse("---\nharness: codex\n---\n");
-        assert!(diags.is_empty());
-        assert_eq!(p.harness, Some(HarnessKind::Codex));
-    }
-
-    #[test]
-    fn parses_harness_opencode() {
-        let (p, diags) = parse("---\nharness: opencode\n---\n");
-        assert!(diags.is_empty());
-        assert_eq!(p.harness, Some(HarnessKind::OpenCode));
-    }
-
-    #[test]
-    fn unknown_harness_produces_diagnostic() {
-        let (p, diags) = parse("---\nharness: unknown\n---\n");
-        assert_eq!(p.harness, None);
-        assert_eq!(diags.len(), 1);
-        assert!(
-            matches!(&diags[0], AgentDiagnostic::UnknownHarness { value } if value == "unknown")
-        );
-    }
-
-    #[test]
-    fn parses_effort_all_values() {
-        for (s, expected) in [
-            ("low", EffortLevel::Low),
-            ("medium", EffortLevel::Medium),
-            ("high", EffortLevel::High),
-            ("xhigh", EffortLevel::XHigh),
-        ] {
-            let content = format!("---\neffort: {s}\n---\n");
-            let (p, diags) = parse(&content);
-            assert!(
-                diags.is_empty(),
-                "unexpected diags for effort={s}: {diags:?}"
-            );
-            assert_eq!(p.effort, Some(expected));
-        }
-    }
-
-    #[test]
-    fn parses_approval_all_values() {
-        for s in ["default", "auto", "confirm", "yolo"] {
-            let content = format!("---\napproval: {s}\n---\n");
-            let (p, diags) = parse(&content);
-            assert!(diags.is_empty(), "unexpected diags for approval={s}");
-            assert!(p.approval.is_some());
-        }
-    }
-
-    #[test]
-    fn parses_sandbox_all_values() {
-        for s in [
-            "default",
-            "read-only",
-            "workspace-write",
-            "danger-full-access",
-        ] {
-            let content = format!("---\nsandbox: {s}\n---\n");
-            let (p, diags) = parse(&content);
-            assert!(diags.is_empty(), "unexpected diags for sandbox={s}");
-            assert!(p.sandbox.is_some());
-        }
-    }
-
-    #[test]
-    fn parses_autocompact() {
-        let (p, diags) = parse("---\nautocompact: 50\n---\n");
-        assert!(diags.is_empty());
-        assert_eq!(p.autocompact, Some(50));
-    }
-
-    #[test]
-    fn parses_autocompact_pct() {
-        let (p, diags) = parse("---\nautocompact-pct: 80\n---\n");
-        assert!(diags.is_empty());
-        assert_eq!(p.autocompact_pct, Some(80));
-    }
-
-    #[test]
-    fn autocompact_pct_out_of_range() {
-        let (p, diags) = parse("---\nautocompact-pct: 101\n---\n");
-        assert_eq!(p.autocompact_pct, None);
-        assert_eq!(diags.len(), 1);
-        assert!(
-            matches!(&diags[0], AgentDiagnostic::InvalidFieldValue { field, .. } if field == "autocompact-pct")
-        );
-    }
-
-    #[test]
-    fn autocompact_pct_zero_out_of_range() {
-        let (p, diags) = parse("---\nautocompact-pct: 0\n---\n");
-        assert_eq!(p.autocompact_pct, None);
-        assert_eq!(diags.len(), 1);
-        assert!(
-            matches!(&diags[0], AgentDiagnostic::InvalidFieldValue { field, .. } if field == "autocompact-pct")
-        );
-    }
-
-    #[test]
-    fn autocompact_pct_in_override() {
-        let content = "---\nharness-overrides:\n  claude:\n    autocompact-pct: 75\n---\n";
-        let (p, diags) = parse(content);
-        assert!(diags.is_empty());
-        let claude = p.harness_overrides.claude.as_ref().unwrap();
-        assert_eq!(claude.autocompact_pct, Some(75));
-    }
-
-    #[test]
-    fn autocompact_string_produces_diagnostic() {
-        let (p, diags) = parse("---\nautocompact: \"50\"\n---\n");
-        assert_eq!(p.autocompact, None);
-        assert_eq!(diags.len(), 1);
-        assert!(
-            matches!(&diags[0], AgentDiagnostic::InvalidFieldValue { field, .. } if field == "autocompact")
-        );
-    }
-
-    #[test]
-    fn autocompact_pct_string_produces_diagnostic() {
-        let (p, diags) = parse("---\nautocompact-pct: \"80\"\n---\n");
-        assert_eq!(p.autocompact_pct, None);
-        assert_eq!(diags.len(), 1);
-        assert!(
-            matches!(&diags[0], AgentDiagnostic::InvalidFieldValue { field, .. } if field == "autocompact-pct")
-        );
-    }
-
     fn as_map(field: &ToolsField) -> &BTreeMap<String, ToolRule> {
         match field {
             ToolsField::Map(map) => map,
@@ -1175,73 +1004,172 @@ mod tests {
     }
 
     #[test]
+    fn parses_core_profile_fields() {
+        let content = r#"---
+name: coder
+description: Code agent
+harness: codex
+model: gpt55
+mode: subagent
+approval: auto
+sandbox: workspace-write
+effort: high
+autocompact: 50
+autocompact-pct: 80
+skills: [review, dev-principles]
+mcp-tools: [server]
+---
+# Body"#;
+        let (p, diags) = parse(content);
+        assert!(diags.is_empty());
+        assert_eq!(p.name.as_deref(), Some("coder"));
+        assert_eq!(p.description.as_deref(), Some("Code agent"));
+        assert_eq!(p.harness, Some(HarnessKind::Codex));
+        assert_eq!(p.model.as_deref(), Some("gpt55"));
+        assert_eq!(p.mode, Some(AgentMode::Subagent));
+        assert_eq!(p.approval, Some(ApprovalMode::Auto));
+        assert_eq!(p.sandbox, Some(SandboxMode::WorkspaceWrite));
+        assert_eq!(p.effort, Some(EffortLevel::High));
+        assert_eq!(p.autocompact, Some(50));
+        assert_eq!(p.autocompact_pct, Some(80));
+        assert_eq!(p.skills, vec!["review", "dev-principles"]);
+        assert_eq!(p.mcp_tools, vec!["server"]);
+    }
+
+    #[test]
+    fn parses_all_known_harness_values() {
+        for (value, expected) in [
+            ("claude", HarnessKind::Claude),
+            ("codex", HarnessKind::Codex),
+            ("opencode", HarnessKind::OpenCode),
+            ("pi", HarnessKind::Pi),
+        ] {
+            let (p, diags) = parse(&format!("---\nharness: {value}\n---\n"));
+            assert!(
+                diags.is_empty(),
+                "unexpected diagnostics for harness={value}: {diags:?}"
+            );
+            assert_eq!(p.harness, Some(expected));
+        }
+    }
+
+    #[test]
+    fn invalid_scalar_fields_emit_diagnostics_and_are_skipped() {
+        let content = r#"---
+mode: invalid
+autocompact: "50"
+autocompact-pct: 101
+---
+"#;
+        let (p, diags) = parse(content);
+        assert!(p.mode.is_none());
+        assert!(p.autocompact.is_none());
+        assert!(p.autocompact_pct.is_none());
+        assert!(diags.iter().any(|d| {
+            matches!(d, AgentDiagnostic::InvalidFieldValue { field, .. } if field == "mode")
+        }));
+        assert!(diags.iter().any(|d| {
+            matches!(d, AgentDiagnostic::InvalidFieldValue { field, .. } if field == "autocompact")
+        }));
+        assert!(diags.iter().any(|d| {
+            matches!(d, AgentDiagnostic::InvalidFieldValue { field, .. } if field == "autocompact-pct")
+        }));
+    }
+
+    #[test]
+    fn unknown_harness_produces_diagnostic() {
+        let (p, diags) = parse(
+            "---
+harness: unknown
+---
+",
+        );
+        assert_eq!(p.harness, None);
+        assert_eq!(diags.len(), 1);
+        assert!(matches!(
+            &diags[0],
+            AgentDiagnostic::UnknownHarness { value } if value == "unknown"
+        ));
+    }
+
+    #[test]
     fn parses_tools_shorthand_allow_and_deny() {
-        let (allow, diags_allow) = parse("---\ntools: allow\n---\n");
+        let (allow, diags_allow) = parse(
+            "---
+tools: allow
+---
+",
+        );
         assert!(diags_allow.is_empty());
         assert_eq!(allow.tools, Some(ToolsField::Shorthand(ToolAction::Allow)));
 
-        let (deny, diags_deny) = parse("---\ntools: deny\n---\n");
+        let (deny, diags_deny) = parse(
+            "---
+tools: deny
+---
+",
+        );
         assert!(diags_deny.is_empty());
         assert_eq!(deny.tools, Some(ToolsField::Shorthand(ToolAction::Deny)));
     }
 
     #[test]
-    fn tools_ask_shorthand_emits_invalid_field_value_and_returns_none() {
-        let (p, diags) = parse("---\ntools: ask\n---\n");
+    fn tools_shorthand_ask_is_rejected() {
+        let (p, diags) = parse(
+            "---
+tools: ask
+---
+",
+        );
         assert_eq!(p.tools, None);
-        assert_eq!(diags.len(), 1);
-        assert!(matches!(
-            &diags[0],
-            AgentDiagnostic::InvalidFieldValue { field, allowed, .. }
-            if field == "tools" && allowed.contains("allow, deny")
-        ));
+        assert!(diags.iter().any(|d| {
+            matches!(
+                d,
+                AgentDiagnostic::InvalidFieldValue { field, allowed, .. }
+                if field == "tools" && allowed.contains("allow, deny")
+            )
+        }));
     }
 
     #[test]
-    fn parses_tools_map_flat_actions() {
-        let (p, diags) = parse("---\ntools:\n  \"*\": deny\n  bash: allow\n  read: ask\n---\n");
-        assert!(diags.is_empty());
+    fn parses_tools_map_and_reports_invalid_entries() {
+        let content = r#"---
+tools:
+  "*": deny
+  bash: allow
+  read:
+    "*": allow
+    "*.env": INVALID_ACTION
+  bad: maybe
+---
+"#;
+        let (p, diags) = parse(content);
         let map = as_map(p.tools.as_ref().expect("tools expected"));
         assert_eq!(map.get("*"), Some(&ToolRule::Action(ToolAction::Deny)));
         assert_eq!(map.get("bash"), Some(&ToolRule::Action(ToolAction::Allow)));
-        assert_eq!(map.get("read"), Some(&ToolRule::Action(ToolAction::Ask)));
-    }
-
-    #[test]
-    fn parses_tools_map_scoped_patterns() {
-        let (p, diags) = parse("---\ntools:\n  read:\n    \"*\": allow\n    \"*.env\": ask\n---\n");
-        assert!(diags.is_empty());
-        let map = as_map(p.tools.as_ref().expect("tools expected"));
-        let scoped = match map.get("read").expect("read rule missing") {
-            ToolRule::Scoped(scoped) => scoped,
-            ToolRule::Action(_) => panic!("expected scoped rule"),
-        };
-        assert_eq!(scoped.get("*"), Some(&ToolAction::Allow));
-        assert_eq!(scoped.get("*.env"), Some(&ToolAction::Ask));
-    }
-
-    #[test]
-    fn tools_map_invalid_nested_scoped_action_emits_error() {
-        let (p, diags) =
-            parse("---\ntools:\n  read:\n    \"*\": allow\n    \"*.env\": INVALID_ACTION\n---\n");
-        let map = as_map(p.tools.as_ref().expect("tools expected"));
         let scoped = match map.get("read").expect("read rule missing") {
             ToolRule::Scoped(scoped) => scoped,
             ToolRule::Action(_) => panic!("expected scoped rule"),
         };
         assert_eq!(scoped.get("*"), Some(&ToolAction::Allow));
         assert!(!scoped.contains_key("*.env"));
+        assert!(!map.contains_key("bad"));
         assert!(diags.iter().any(|d| {
-            matches!(
-                d,
-                AgentDiagnostic::InvalidFieldValue { field, .. } if field == "tools.read.*.env"
-            )
+            matches!(d, AgentDiagnostic::InvalidFieldValue { field, .. } if field == "tools.read.*.env")
+        }));
+        assert!(diags.iter().any(|d| {
+            matches!(d, AgentDiagnostic::InvalidFieldValue { field, .. } if field == "tools.bad")
         }));
     }
 
     #[test]
     fn deprecated_tools_list_emits_warning_and_converts() {
-        let (p, diags) = parse("---\ntools: [Bash, Write, UnknownTool]\n---\n");
+        let (p, diags) = parse(
+            "---
+tools: [Bash, Write, UnknownTool]
+---
+",
+        );
         assert_eq!(diags.len(), 1);
         assert!(matches!(diags[0], AgentDiagnostic::DeprecatedToolsList));
         let map = as_map(p.tools.as_ref().expect("tools expected"));
@@ -1255,75 +1183,51 @@ mod tests {
     }
 
     #[test]
-    fn disallowed_tools_merges_into_tools_and_warns() {
-        let content = "---\ntools:\n  \"*\": deny\n  bash: allow\ndisallowed-tools: [Agent]\n---\n";
-        let (p, diags) = parse(content);
-        assert_eq!(diags.len(), 1);
-        assert!(matches!(
-            diags[0],
-            AgentDiagnostic::DeprecatedDisallowedTools
-        ));
-        let map = as_map(p.tools.as_ref().expect("tools expected"));
+    fn deprecated_disallowed_tools_merge_defaults_and_existing_policies() {
+        let (with_base, diags_with_base) = parse(
+            r#"---
+tools:
+  "*": deny
+  bash: allow
+disallowed-tools: [Agent]
+---
+"#,
+        );
+        assert!(
+            diags_with_base
+                .iter()
+                .any(|d| matches!(d, AgentDiagnostic::DeprecatedDisallowedTools))
+        );
+        let map = as_map(with_base.tools.as_ref().expect("tools expected"));
         assert_eq!(map.get("*"), Some(&ToolRule::Action(ToolAction::Deny)));
-        assert_eq!(map.get("bash"), Some(&ToolRule::Action(ToolAction::Allow)));
         assert_eq!(map.get("task"), Some(&ToolRule::Action(ToolAction::Deny)));
-    }
 
-    #[test]
-    fn disallowed_tools_without_tools_becomes_allow_default_with_denies() {
-        let (p, diags) = parse("---\ndisallowed-tools: [Agent, Unknown]\n---\n");
-        assert_eq!(diags.len(), 1);
-        assert!(matches!(
-            diags[0],
-            AgentDiagnostic::DeprecatedDisallowedTools
-        ));
-        let map = as_map(p.tools.as_ref().expect("tools expected"));
+        let (without_base, diags_without_base) = parse(
+            "---
+disallowed-tools: [Agent]
+---
+",
+        );
+        assert!(
+            diags_without_base
+                .iter()
+                .any(|d| matches!(d, AgentDiagnostic::DeprecatedDisallowedTools))
+        );
+        let map = as_map(without_base.tools.as_ref().expect("tools expected"));
         assert_eq!(map.get("*"), Some(&ToolRule::Action(ToolAction::Allow)));
         assert_eq!(map.get("task"), Some(&ToolRule::Action(ToolAction::Deny)));
-        assert_eq!(
-            map.get("Unknown"),
-            Some(&ToolRule::Action(ToolAction::Deny))
-        );
-    }
-
-    #[test]
-    fn tools_disallowed_with_shorthand_deny_base() {
-        let (p, diags) = parse("---\ntools: deny\ndisallowed-tools: [Agent]\n---\n");
-        let deprecated_count = diags
-            .iter()
-            .filter(|d| matches!(d, AgentDiagnostic::DeprecatedDisallowedTools))
-            .count();
-        assert!(
-            (1..=2).contains(&deprecated_count),
-            "expected 1-2 deprecation diagnostics, got: {diags:?}"
-        );
-        assert!(
-            diags
-                .iter()
-                .all(|d| matches!(d, AgentDiagnostic::DeprecatedDisallowedTools))
-        );
-        let map = as_map(p.tools.as_ref().expect("tools expected"));
-        assert_eq!(map.get("*"), Some(&ToolRule::Action(ToolAction::Deny)));
-        assert_eq!(map.get("task"), Some(&ToolRule::Action(ToolAction::Deny)));
-    }
-
-    #[test]
-    fn invalid_tools_action_emits_error_and_skips_entry() {
-        let (p, diags) = parse("---\ntools:\n  bash: maybe\n  read: allow\n---\n");
-        assert_eq!(diags.len(), 1);
-        assert!(matches!(
-            &diags[0],
-            AgentDiagnostic::InvalidFieldValue { field, .. } if field == "tools.bash"
-        ));
-        let map = as_map(p.tools.as_ref().expect("tools expected"));
-        assert!(!map.contains_key("bash"));
-        assert_eq!(map.get("read"), Some(&ToolRule::Action(ToolAction::Allow)));
     }
 
     #[test]
     fn unknown_capability_key_is_preserved_without_error() {
         let (p, diags) = parse(
-            "---\ntools:\n  \"*\": deny\n  bash: allow\n  future-capability-xyz: allow\n---\n",
+            r#"---
+tools:
+  "*": deny
+  bash: allow
+  future-capability-xyz: allow
+---
+"#,
         );
         let map = as_map(p.tools.as_ref().expect("tools expected"));
         assert_eq!(
@@ -1340,117 +1244,103 @@ mod tests {
     }
 
     #[test]
-    fn parses_skills_and_mcp_tools() {
-        let content = "---\nskills: [review, dev-principles]\nmcp-tools: [server]\n---\n";
+    fn parses_harness_overrides_and_reports_non_overridable_fields() {
+        let content = r#"---
+harness-overrides:
+  claude:
+    approval: auto
+    autocompact-pct: 75
+    tools:
+      "*": deny
+      bash: allow
+    name: forbidden
+  codex:
+    sandbox: workspace-write
+    effort: high
+---
+"#;
         let (p, diags) = parse(content);
-        assert!(diags.is_empty());
-        assert_eq!(p.skills, vec!["review", "dev-principles"]);
-        assert_eq!(p.mcp_tools, vec!["server"]);
-    }
 
-    // --- 3.1: model-policies ---
-
-    #[test]
-    fn model_policies_are_parsed_as_raw_entries() {
-        let content = "---\nmodel-policies:\n  - match:\n      model: gpt-5.5\n    override:\n      harness: codex\n---\n";
-        let (p, diags) = parse(content);
-        assert!(diags.is_empty());
-        assert_eq!(p.model_policies.len(), 1);
-    }
-
-    // --- 3.1: fanout ---
-
-    #[test]
-    fn fanout_entries_are_parsed_as_raw() {
-        let content = "---\nfanout:\n  - alias: opus\n  - model: gpt-5.5\n---\n";
-        let (p, diags) = parse(content);
-        assert!(diags.is_empty());
-        assert_eq!(p.fanout.len(), 2);
-    }
-
-    // --- 3.1: harness-overrides ---
-
-    #[test]
-    fn harness_overrides_parsed_for_claude_and_codex() {
-        let content = "---\nharness-overrides:\n  claude:\n    approval: auto\n    tools:\n      \"*\": deny\n      bash: allow\n  codex:\n    sandbox: workspace-write\n    effort: high\n---\n";
-        let (p, diags) = parse(content);
-        assert!(diags.is_empty());
         let claude = p.harness_overrides.claude.as_ref().unwrap();
         assert_eq!(claude.approval, Some(ApprovalMode::Auto));
+        assert_eq!(claude.autocompact_pct, Some(75));
         let tools_map = as_map(claude.tools.as_ref().expect("tools override expected"));
-        assert_eq!(
-            tools_map.get("*"),
-            Some(&ToolRule::Action(ToolAction::Deny))
-        );
         assert_eq!(
             tools_map.get("bash"),
             Some(&ToolRule::Action(ToolAction::Allow))
         );
+
         let codex = p.harness_overrides.codex.as_ref().unwrap();
         assert_eq!(codex.sandbox, Some(SandboxMode::WorkspaceWrite));
         assert_eq!(codex.effort, Some(EffortLevel::High));
+
+        assert!(diags.iter().any(|d| {
+            matches!(
+                d,
+                AgentDiagnostic::NonOverridableFieldInOverride { field, .. } if field == "name"
+            )
+        }));
     }
 
     #[test]
-    fn harness_override_deprecated_tools_list_warns() {
-        let content = "---\nharness-overrides:\n  claude:\n    tools: [Bash]\n---\n";
+    fn harness_override_legacy_tools_bridges_still_warn() {
+        let content = r#"---
+harness-overrides:
+  claude:
+    tools: [Bash]
+    disallowed-tools: [Agent]
+---
+"#;
         let (p, diags) = parse(content);
-        assert_eq!(diags.len(), 1);
-        assert!(matches!(diags[0], AgentDiagnostic::DeprecatedToolsList));
+        assert!(
+            diags
+                .iter()
+                .any(|d| matches!(d, AgentDiagnostic::DeprecatedToolsList))
+        );
+        assert!(
+            diags
+                .iter()
+                .any(|d| matches!(d, AgentDiagnostic::DeprecatedDisallowedTools))
+        );
         let claude = p.harness_overrides.claude.as_ref().unwrap();
         let map = as_map(claude.tools.as_ref().expect("tools override expected"));
-        assert_eq!(map.get("*"), Some(&ToolRule::Action(ToolAction::Deny)));
         assert_eq!(map.get("bash"), Some(&ToolRule::Action(ToolAction::Allow)));
-    }
-
-    #[test]
-    fn harness_override_deprecated_disallowed_tools_warns_and_merges() {
-        let content = "---\nharness-overrides:\n  claude:\n    disallowed-tools: [Agent]\n---\n";
-        let (p, diags) = parse(content);
-        assert_eq!(diags.len(), 1);
-        assert!(matches!(
-            diags[0],
-            AgentDiagnostic::DeprecatedDisallowedTools
-        ));
-        let claude = p.harness_overrides.claude.as_ref().unwrap();
-        let map = as_map(claude.tools.as_ref().expect("tools override expected"));
-        assert_eq!(map.get("*"), Some(&ToolRule::Action(ToolAction::Allow)));
         assert_eq!(map.get("task"), Some(&ToolRule::Action(ToolAction::Deny)));
     }
 
     #[test]
-    fn harness_override_with_non_overridable_field_produces_diagnostic() {
-        let content = "---\nharness-overrides:\n  claude:\n    name: bad\n---\n";
-        let (_p, diags) = parse(content);
-        assert_eq!(diags.len(), 1);
+    fn parses_metadata_only_fields_and_legacy_models_warning() {
+        let content = r#"---
+models:
+  opus:
+    effort: high
+model-policies:
+  - match:
+      model: gpt-5.5
+    override:
+      harness: codex
+fanout:
+  - alias: opus
+---
+"#;
+        let (p, diags) = parse(content);
+        assert_eq!(p.model_policies.len(), 1);
+        assert_eq!(p.fanout.len(), 1);
         assert!(
-            matches!(&diags[0], AgentDiagnostic::NonOverridableFieldInOverride { field, .. } if field == "name")
+            diags
+                .iter()
+                .any(|d| matches!(d, AgentDiagnostic::LegacyModelsField))
         );
     }
 
-    // --- 3.1: legacy models field ---
-
-    #[test]
-    fn legacy_models_field_produces_deprecation_warning() {
-        let content = "---\nmodels:\n  opus:\n    effort: high\n---\n";
-        let (_p, diags) = parse(content);
-        assert_eq!(diags.len(), 1);
-        assert!(matches!(&diags[0], AgentDiagnostic::LegacyModelsField));
-    }
-
-    // --- Empty agent ---
-
     #[test]
     fn empty_agent_has_no_diagnostics() {
-        let (p, diags) = parse("# Minimal agent\nno frontmatter");
+        let (p, diags) = parse(
+            "# Minimal agent
+no frontmatter",
+        );
         assert!(diags.is_empty());
         assert!(p.name.is_none());
-        assert!(p.harness.is_none());
-    }
-
-    #[test]
-    fn agent_without_harness_is_universal() {
-        let (p, _) = parse("---\nname: planner\nmodel: gpt55\n---\n# Planner");
         assert!(p.harness.is_none());
     }
 }

--- a/src/compiler/mcp/mod.rs
+++ b/src/compiler/mcp/mod.rs
@@ -372,163 +372,46 @@ mod tests {
     }
 
     #[test]
-    fn discover_finds_mcp_items() {
+    fn discover_returns_empty_without_mcp_directory() {
+        let tmp = TempDir::new().unwrap();
+        let items = discover_mcp_items(tmp.path(), "base", 0).unwrap();
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn discover_parses_stdio_with_name_override_and_env_refs() {
         let tmp = TempDir::new().unwrap();
         make_mcp_toml_dir(
             tmp.path(),
-            "context7",
+            ".hidden-server",
             r#"
 command = "npx"
-args = ["-y", "@upstash/context7-mcp@latest"]
 "#,
         );
-
-        let items = discover_mcp_items(tmp.path(), "base", 0).unwrap();
-        assert_eq!(items.len(), 1);
-        assert_eq!(items[0].name, "context7");
-        assert_eq!(items[0].def.r#type, McpTransport::Stdio);
-        assert_eq!(items[0].def.command.as_deref(), Some("npx"));
-        assert_eq!(items[0].def.args, &["-y", "@upstash/context7-mcp@latest"]);
-    }
-
-    #[test]
-    fn discover_empty_when_no_mcp_dir() {
-        let tmp = TempDir::new().unwrap();
-        let items = discover_mcp_items(tmp.path(), "base", 0).unwrap();
-        assert!(items.is_empty());
-    }
-
-    #[test]
-    fn discover_skips_dir_without_mcp_toml() {
-        let tmp = TempDir::new().unwrap();
-        std::fs::create_dir_all(tmp.path().join("mcp/no-toml")).unwrap();
-        let items = discover_mcp_items(tmp.path(), "base", 0).unwrap();
-        assert!(items.is_empty());
-    }
-
-    #[test]
-    fn discover_skips_hidden_directories() {
-        let tmp = TempDir::new().unwrap();
-        make_mcp_toml_dir(tmp.path(), ".hidden-server", "command = \"npx\"");
-        make_mcp_toml_dir(tmp.path(), "real-server", "command = \"node\"");
-
-        let items = discover_mcp_items(tmp.path(), "base", 0).unwrap();
-        assert_eq!(items.len(), 1);
-        assert_eq!(items[0].name, "real-server");
-        assert!(!items.iter().any(|item| item.name == ".hidden-server"));
-    }
-
-    #[test]
-    fn discover_respects_name_override() {
-        let tmp = TempDir::new().unwrap();
         make_mcp_toml_dir(
             tmp.path(),
             "dir-name",
             r#"
 name = "custom-name"
 command = "node"
-"#,
-        );
-        let items = discover_mcp_items(tmp.path(), "base", 0).unwrap();
-        assert_eq!(items[0].name, "custom-name");
-    }
-
-    #[test]
-    fn discover_parses_env_refs() {
-        let tmp = TempDir::new().unwrap();
-        make_mcp_toml_dir(
-            tmp.path(),
-            "api-server",
-            r#"
-command = "npx"
+args = ["server.js"]
 [env]
 API_KEY = { from = "env", var = "MY_API_KEY" }
 "#,
         );
+
         let items = discover_mcp_items(tmp.path(), "base", 0).unwrap();
-        assert_eq!(items[0].def.env.len(), 1);
-        let env_ref = &items[0].def.env["API_KEY"];
-        assert_eq!(env_ref.var_name(), "MY_API_KEY");
+        assert_eq!(items.len(), 1);
+        let item = &items[0];
+        assert_eq!(item.name, "custom-name");
+        assert_eq!(item.def.r#type, McpTransport::Stdio);
+        assert_eq!(item.def.command.as_deref(), Some("node"));
+        assert_eq!(item.def.args, ["server.js"]);
+        assert_eq!(item.def.env["API_KEY"].var_name(), "MY_API_KEY");
     }
 
     #[test]
-    fn discover_http_requires_url_and_forbids_command_and_args() {
-        let tmp = TempDir::new().unwrap();
-        make_mcp_toml_dir(
-            tmp.path(),
-            "missing-url",
-            r#"
-type = "http"
-"#,
-        );
-        assert!(discover_mcp_items(tmp.path(), "base", 0).is_err());
-
-        let tmp = TempDir::new().unwrap();
-        make_mcp_toml_dir(
-            tmp.path(),
-            "forbidden-command",
-            r#"
-type = "http"
-url = "https://example.com/mcp"
-command = "npx"
-"#,
-        );
-        assert!(discover_mcp_items(tmp.path(), "base", 0).is_err());
-
-        let tmp = TempDir::new().unwrap();
-        make_mcp_toml_dir(
-            tmp.path(),
-            "forbidden-args",
-            r#"
-type = "http"
-url = "https://example.com/mcp"
-args = ["--bad"]
-"#,
-        );
-        assert!(discover_mcp_items(tmp.path(), "base", 0).is_err());
-    }
-
-    #[test]
-    fn discover_stdio_forbids_url_and_headers() {
-        let tmp = TempDir::new().unwrap();
-        make_mcp_toml_dir(
-            tmp.path(),
-            "stdio-with-url",
-            r#"
-command = "npx"
-url = "https://example.com/mcp"
-"#,
-        );
-        assert!(discover_mcp_items(tmp.path(), "base", 0).is_err());
-
-        let tmp = TempDir::new().unwrap();
-        make_mcp_toml_dir(
-            tmp.path(),
-            "stdio-with-headers",
-            r#"
-command = "npx"
-[headers]
-X-Test = "value"
-"#,
-        );
-        assert!(discover_mcp_items(tmp.path(), "base", 0).is_err());
-    }
-
-    #[test]
-    fn discover_whitespace_only_command_fails_validation() {
-        let tmp = TempDir::new().unwrap();
-        make_mcp_toml_dir(
-            tmp.path(),
-            "bad-stdio",
-            r#"
-command = "   "
-"#,
-        );
-        assert!(discover_mcp_items(tmp.path(), "base", 0).is_err());
-    }
-
-    #[test]
-    fn discover_http_parses_plain_and_env_header_values() {
+    fn discover_parses_http_url_and_headers() {
         let tmp = TempDir::new().unwrap();
         make_mcp_toml_dir(
             tmp.path(),
@@ -542,6 +425,7 @@ X-Custom = "literal"
 "#,
         );
         let items = discover_mcp_items(tmp.path(), "base", 0).unwrap();
+        assert_eq!(items.len(), 1);
         let item = &items[0];
         assert_eq!(item.def.r#type, McpTransport::Http);
         assert_eq!(item.def.url.as_deref(), Some("https://example.com/mcp"));
@@ -556,31 +440,47 @@ X-Custom = "literal"
     }
 
     #[test]
-    fn check_env_refs_warns_when_missing() {
-        let tmp = TempDir::new().unwrap();
-        make_mcp_toml_dir(
-            tmp.path(),
-            "server",
-            r#"
-command = "npx"
-[env]
-KEY = { from = "env", var = "MARS_TEST_DEFINITELY_NOT_SET_XYZ123" }
-"#,
-        );
-        let items = discover_mcp_items(tmp.path(), "base", 0).unwrap();
-        let mut diag = DiagnosticCollector::new();
-        check_env_refs(&items, false, &mut diag).unwrap();
-        let collected = diag.drain();
-        assert_eq!(collected.len(), 1);
-        assert!(
-            collected[0]
-                .message
-                .contains("MARS_TEST_DEFINITELY_NOT_SET_XYZ123")
-        );
+    fn discover_rejects_invalid_transport_field_combinations() {
+        let cases = [
+            ("missing-url", r#"type = "http""#),
+            (
+                "http-with-command",
+                r#"type = "http"
+url = "https://example.com/mcp"
+command = "npx""#,
+            ),
+            (
+                "http-with-args",
+                r#"type = "http"
+url = "https://example.com/mcp"
+args = ["--bad"]"#,
+            ),
+            (
+                "stdio-with-url",
+                r#"command = "npx"
+url = "https://example.com/mcp""#,
+            ),
+            (
+                "stdio-with-headers",
+                r#"command = "npx"
+[headers]
+X-Test = "value""#,
+            ),
+            ("stdio-whitespace-command", r#"command = "   ""#),
+        ];
+
+        for (name, toml) in cases {
+            let tmp = TempDir::new().unwrap();
+            make_mcp_toml_dir(tmp.path(), name, toml);
+            assert!(
+                discover_mcp_items(tmp.path(), "base", 0).is_err(),
+                "expected invalid config to fail: {name}"
+            );
+        }
     }
 
     #[test]
-    fn check_env_refs_warns_when_header_env_missing() {
+    fn check_env_refs_warns_in_non_strict_mode_and_errors_in_strict_mode() {
         let tmp = TempDir::new().unwrap();
         make_mcp_toml_dir(
             tmp.path(),
@@ -588,49 +488,39 @@ KEY = { from = "env", var = "MARS_TEST_DEFINITELY_NOT_SET_XYZ123" }
             r#"
 type = "http"
 url = "https://example.com/mcp"
+[env]
+KEY = { from = "env", var = "MARS_TEST_DEFINITELY_NOT_SET_ENV_XYZ123" }
 [headers]
 Authorization = { from = "env", var = "MARS_TEST_DEFINITELY_NOT_SET_HEADER_ABC999" }
 "#,
         );
         let items = discover_mcp_items(tmp.path(), "base", 0).unwrap();
-        let mut diag = DiagnosticCollector::new();
-        check_env_refs(&items, false, &mut diag).unwrap();
-        let collected = diag.drain();
-        assert_eq!(collected.len(), 1);
+
+        let mut non_strict = DiagnosticCollector::new();
+        check_env_refs(&items, false, &mut non_strict).unwrap();
+        let warnings = non_strict.drain();
+        assert_eq!(warnings.len(), 2);
+        assert!(warnings.iter().any(|d| d.message.contains("_ENV_XYZ123")));
         assert!(
-            collected[0]
-                .message
-                .contains("MARS_TEST_DEFINITELY_NOT_SET_HEADER_ABC999")
+            warnings
+                .iter()
+                .any(|d| d.message.contains("_HEADER_ABC999"))
         );
+
+        let mut strict = DiagnosticCollector::new();
+        assert!(check_env_refs(&items, true, &mut strict).is_err());
     }
 
     #[test]
-    fn check_env_refs_strict_errors_when_missing() {
-        let tmp = TempDir::new().unwrap();
-        make_mcp_toml_dir(
-            tmp.path(),
-            "server",
-            r#"
-command = "npx"
-[env]
-KEY = { from = "env", var = "MARS_TEST_DEFINITELY_NOT_SET_XYZ456" }
-"#,
-        );
-        let items = discover_mcp_items(tmp.path(), "base", 0).unwrap();
-        let mut diag = DiagnosticCollector::new();
-        let result = check_env_refs(&items, true, &mut diag);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn lower_for_target_filters_by_target() {
+    fn lower_for_target_filters_entries_by_target() {
         let tmp = TempDir::new().unwrap();
         make_mcp_toml_dir(
             tmp.path(),
             "claude-only",
-            "command = \"npx\"\ntargets = [\".claude\"]",
+            r#"command = "npx"
+targets = [".claude"]"#,
         );
-        make_mcp_toml_dir(tmp.path(), "all-targets", "command = \"node\"");
+        make_mcp_toml_dir(tmp.path(), "all-targets", r#"command = "node""#);
 
         let items = discover_mcp_items(tmp.path(), "base", 0).unwrap();
 
@@ -643,49 +533,41 @@ KEY = { from = "env", var = "MARS_TEST_DEFINITELY_NOT_SET_XYZ456" }
     }
 
     #[test]
-    fn env_ref_preserves_symbolic_var_name() {
-        let tmp = TempDir::new().unwrap();
+    fn target_entry_preserves_symbolic_values_for_stdio_and_http() {
+        let stdio_tmp = TempDir::new().unwrap();
         make_mcp_toml_dir(
-            tmp.path(),
-            "server",
+            stdio_tmp.path(),
+            "stdio",
             r#"
 command = "npx"
 [env]
 TOKEN = { from = "env", var = "SECRET_TOKEN" }
 "#,
         );
-        let items = discover_mcp_items(tmp.path(), "base", 0).unwrap();
-        let entry = TargetMcpEntry::from_parsed(&items[0]);
-        // The env map carries the variable name, not the resolved value.
-        assert_eq!(entry.env["TOKEN"], "SECRET_TOKEN");
-        assert_eq!(entry.transport, McpTransport::Stdio);
-        assert_eq!(entry.command.as_deref(), Some("npx"));
-    }
+        let stdio_items = discover_mcp_items(stdio_tmp.path(), "base", 0).unwrap();
+        let stdio_entry = TargetMcpEntry::from_parsed(&stdio_items[0]);
+        assert_eq!(stdio_entry.transport, McpTransport::Stdio);
+        assert_eq!(stdio_entry.command.as_deref(), Some("npx"));
+        assert_eq!(stdio_entry.env["TOKEN"], "SECRET_TOKEN");
 
-    #[test]
-    fn target_entry_preserves_http_fields() {
-        let tmp = TempDir::new().unwrap();
+        let http_tmp = TempDir::new().unwrap();
         make_mcp_toml_dir(
-            tmp.path(),
+            http_tmp.path(),
             "remote",
             r#"
 type = "http"
 url = "https://example.com/mcp"
 [headers]
 Authorization = { from = "env", var = "API_TOKEN" }
-X-Custom = "literal"
-[env]
-EXTRA = { from = "env", var = "EXTRA_VAR" }
 "#,
         );
-        let items = discover_mcp_items(tmp.path(), "base", 0).unwrap();
-        let entry = TargetMcpEntry::from_parsed(&items[0]);
-        assert_eq!(entry.transport, McpTransport::Http);
-        assert_eq!(entry.command, None);
-        assert_eq!(entry.url.as_deref(), Some("https://example.com/mcp"));
-        assert_eq!(entry.env["EXTRA"], "EXTRA_VAR");
+        let http_items = discover_mcp_items(http_tmp.path(), "base", 0).unwrap();
+        let http_entry = TargetMcpEntry::from_parsed(&http_items[0]);
+        assert_eq!(http_entry.transport, McpTransport::Http);
+        assert_eq!(http_entry.command, None);
+        assert_eq!(http_entry.url.as_deref(), Some("https://example.com/mcp"));
         assert!(matches!(
-            entry.headers.get("Authorization"),
+            http_entry.headers.get("Authorization"),
             Some(HeaderValue::EnvRef(EnvRef::Env { var })) if var == "API_TOKEN"
         ));
     }

--- a/src/target/codex.rs
+++ b/src/target/codex.rs
@@ -431,26 +431,14 @@ mod tests {
     use tempfile::TempDir;
     use toml::Value as TomlValue;
 
-    fn make_mcp_entry(name: &str) -> ConfigEntry {
-        ConfigEntry::McpServer(McpServerEntry {
-            name: name.to_string(),
-            transport: McpTransport::Stdio,
-            command: Some("npx".to_string()),
-            args: vec!["-y".to_string(), "some-mcp@latest".to_string()],
-            env: IndexMap::new(),
-            url: None,
-            headers: IndexMap::new(),
-        })
-    }
-
-    fn make_mcp_entry_with_env(name: &str) -> ConfigEntry {
+    fn make_stdio_mcp_entry(name: &str) -> ConfigEntry {
         let mut env = IndexMap::new();
         env.insert("API_KEY".to_string(), "MY_SECRET".to_string());
         ConfigEntry::McpServer(McpServerEntry {
             name: name.to_string(),
             transport: McpTransport::Stdio,
             command: Some("npx".to_string()),
-            args: vec![],
+            args: vec!["-y".to_string(), "some-mcp@latest".to_string()],
             env,
             url: None,
             headers: IndexMap::new(),
@@ -481,16 +469,6 @@ mod tests {
         })
     }
 
-    fn make_hook_entry(name: &str, native: &str) -> ConfigEntry {
-        ConfigEntry::Hook(HookEntry {
-            name: name.to_string(),
-            event: "tool.pre".to_string(),
-            native_event: native.to_string(),
-            script_path: format!("/hooks/{name}/run.sh"),
-            order: 0,
-        })
-    }
-
     fn make_hook_entry_with_path(name: &str, native: &str, script_path: &str) -> ConfigEntry {
         ConfigEntry::Hook(HookEntry {
             name: name.to_string(),
@@ -502,36 +480,7 @@ mod tests {
     }
 
     #[test]
-    fn write_mcp_creates_codex_config_toml() {
-        let tmp = TempDir::new().unwrap();
-        let adapter = CodexAdapter;
-        let entries = vec![make_mcp_entry("context7")];
-        let written = adapter.write_config_entries(&entries, tmp.path()).unwrap();
-        assert_eq!(written.len(), 1);
-        assert!(tmp.path().join(CODEX_CONFIG_TOML).exists());
-
-        let raw = std::fs::read_to_string(tmp.path().join(CODEX_CONFIG_TOML)).unwrap();
-        let toml: TomlValue = toml::from_str(&raw).unwrap();
-        assert!(toml["mcp"]["servers"]["context7"].is_table());
-    }
-
-    #[test]
-    fn write_mcp_env_as_list_of_var_names() {
-        let tmp = TempDir::new().unwrap();
-        let adapter = CodexAdapter;
-        let entries = vec![make_mcp_entry_with_env("server")];
-        adapter.write_config_entries(&entries, tmp.path()).unwrap();
-
-        let raw = std::fs::read_to_string(tmp.path().join(CODEX_CONFIG_TOML)).unwrap();
-        let toml: TomlValue = toml::from_str(&raw).unwrap();
-        // Codex: env is a list of variable names, not a map with values.
-        assert!(toml["mcp"]["servers"]["server"]["env"].is_array());
-        let env_arr = toml["mcp"]["servers"]["server"]["env"].as_array().unwrap();
-        assert!(env_arr.iter().any(|v| v.as_str() == Some("MY_SECRET")));
-    }
-
-    #[test]
-    fn write_mcp_preserves_non_mcp_toml_content() {
+    fn write_mcp_uses_config_toml_schema_and_preserves_non_mcp_content() {
         let tmp = TempDir::new().unwrap();
         std::fs::write(
             tmp.path().join(CODEX_CONFIG_TOML),
@@ -541,115 +490,108 @@ theme = "dark"
 "#,
         )
         .unwrap();
+        std::fs::write(tmp.path().join(LEGACY_CODEX_MCP_JSON), "{}").unwrap();
 
         let adapter = CodexAdapter;
         adapter
-            .write_config_entries(&[make_mcp_entry("context7")], tmp.path())
+            .write_config_entries(
+                &[
+                    make_stdio_mcp_entry("stdio-server"),
+                    make_http_mcp_entry("http-server"),
+                ],
+                tmp.path(),
+            )
             .unwrap();
+
+        assert!(!tmp.path().join(LEGACY_CODEX_MCP_JSON).exists());
 
         let raw = std::fs::read_to_string(tmp.path().join(CODEX_CONFIG_TOML)).unwrap();
         let toml: TomlValue = toml::from_str(&raw).unwrap();
         assert_eq!(toml["ui"]["theme"].as_str(), Some("dark"));
-        assert_eq!(
-            toml["mcp"]["servers"]["context7"]["command"].as_str(),
-            Some("npx")
-        );
-    }
 
-    #[test]
-    fn write_http_mcp_uses_url_bearer_token_and_http_headers() {
-        let tmp = TempDir::new().unwrap();
-        let adapter = CodexAdapter;
-        adapter
-            .write_config_entries(&[make_http_mcp_entry("remote-server")], tmp.path())
-            .unwrap();
+        let stdio = &toml["mcp"]["servers"]["stdio-server"];
+        assert_eq!(stdio["command"].as_str(), Some("npx"));
+        assert_eq!(stdio["args"][0].as_str(), Some("-y"));
+        let env_arr = stdio["env"].as_array().unwrap();
+        assert!(env_arr.iter().any(|v| v.as_str() == Some("MY_SECRET")));
 
-        let raw = std::fs::read_to_string(tmp.path().join(CODEX_CONFIG_TOML)).unwrap();
-        let toml: TomlValue = toml::from_str(&raw).unwrap();
-        let server = &toml["mcp"]["servers"]["remote-server"];
-        assert_eq!(server["url"].as_str(), Some("https://api.example.com/mcp"));
-        assert_eq!(server["bearer_token_env_var"].as_str(), Some("API_TOKEN"));
+        let http = &toml["mcp"]["servers"]["http-server"];
+        assert_eq!(http["url"].as_str(), Some("https://api.example.com/mcp"));
+        assert_eq!(http["bearer_token_env_var"].as_str(), Some("API_TOKEN"));
         assert_eq!(
-            server["http_headers"]["X-Custom"].as_str(),
+            http["http_headers"]["X-Custom"].as_str(),
             Some("static-value")
         );
-        assert!(server.get("command").is_none());
-        assert!(server.get("args").is_none());
+        assert!(http.get("command").is_none());
     }
 
     #[test]
-    fn write_mcp_removes_legacy_codex_mcp_json() {
-        let tmp = TempDir::new().unwrap();
-        std::fs::write(tmp.path().join(LEGACY_CODEX_MCP_JSON), "{}").unwrap();
+    fn emit_pre_write_diagnostics_flags_legacy_cleanup_and_toml_parse_errors() {
         let adapter = CodexAdapter;
 
-        adapter
-            .write_config_entries(&[make_mcp_entry("context7")], tmp.path())
-            .unwrap();
+        let legacy_tmp = TempDir::new().unwrap();
+        std::fs::write(legacy_tmp.path().join(LEGACY_CODEX_MCP_JSON), "{}").unwrap();
+        let mut legacy_diag = DiagnosticCollector::new();
+        adapter.emit_pre_write_diagnostics(
+            &[make_stdio_mcp_entry("context7")],
+            legacy_tmp.path(),
+            &mut legacy_diag,
+        );
+        let legacy_messages = legacy_diag.drain();
+        assert_eq!(legacy_messages.len(), 1);
+        assert_eq!(legacy_messages[0].code, "legacy-config-cleanup");
 
-        assert!(!tmp.path().join(LEGACY_CODEX_MCP_JSON).exists());
+        let invalid_tmp = TempDir::new().unwrap();
+        std::fs::write(
+            invalid_tmp.path().join(CODEX_CONFIG_TOML),
+            "[ui
+",
+        )
+        .unwrap();
+        let mut invalid_diag = DiagnosticCollector::new();
+        adapter.emit_pre_write_diagnostics(
+            &[make_stdio_mcp_entry("context7")],
+            invalid_tmp.path(),
+            &mut invalid_diag,
+        );
+        let invalid_messages = invalid_diag.drain();
+        assert_eq!(invalid_messages.len(), 1);
+        assert_eq!(invalid_messages[0].code, "codex-config-parse-error");
     }
 
     #[test]
-    fn emit_pre_write_diagnostics_warns_about_legacy_codex_mcp_json() {
-        let tmp = TempDir::new().unwrap();
-        std::fs::write(tmp.path().join(LEGACY_CODEX_MCP_JSON), "{}").unwrap();
+    fn invalid_toml_is_not_clobbered_during_write_or_remove() {
+        let original = r#"[ui]
+theme = "dark"
+invalid =
+"#;
+
+        let write_tmp = TempDir::new().unwrap();
+        std::fs::write(write_tmp.path().join(CODEX_CONFIG_TOML), original).unwrap();
         let adapter = CodexAdapter;
-        let mut diag = DiagnosticCollector::new();
-
-        adapter.emit_pre_write_diagnostics(&[make_mcp_entry("context7")], tmp.path(), &mut diag);
-
-        let diagnostics = diag.drain();
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].code, "legacy-config-cleanup");
-        assert!(diagnostics[0].message.contains(LEGACY_CODEX_MCP_JSON));
-    }
-
-    #[test]
-    fn emit_pre_write_diagnostics_warns_about_invalid_codex_config_toml() {
-        let tmp = TempDir::new().unwrap();
-        std::fs::write(tmp.path().join(CODEX_CONFIG_TOML), "[ui\n").unwrap();
-        let adapter = CodexAdapter;
-        let mut diag = DiagnosticCollector::new();
-
-        adapter.emit_pre_write_diagnostics(&[make_mcp_entry("context7")], tmp.path(), &mut diag);
-
-        let diagnostics = diag.drain();
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].code, "codex-config-parse-error");
-        assert!(diagnostics[0].message.contains(CODEX_CONFIG_TOML));
-    }
-
-    #[test]
-    fn write_mcp_invalid_toml_returns_error_without_clobbering_existing_file() {
-        let tmp = TempDir::new().unwrap();
-        let original = "[ui]\ntheme = \"dark\"\ninvalid =\n";
-        std::fs::write(tmp.path().join(CODEX_CONFIG_TOML), original).unwrap();
-
-        let adapter = CodexAdapter;
-        let err = adapter
-            .write_config_entries(&[make_mcp_entry("context7")], tmp.path())
+        let write_err = adapter
+            .write_config_entries(&[make_stdio_mcp_entry("context7")], write_tmp.path())
             .expect_err("invalid TOML should fail and not be overwritten");
-        assert!(err.to_string().contains("failed to parse TOML"));
+        assert!(write_err.to_string().contains("failed to parse TOML"));
+        assert_eq!(
+            std::fs::read_to_string(write_tmp.path().join(CODEX_CONFIG_TOML)).unwrap(),
+            original
+        );
 
-        let after = std::fs::read_to_string(tmp.path().join(CODEX_CONFIG_TOML)).unwrap();
-        assert_eq!(after, original);
+        let remove_tmp = TempDir::new().unwrap();
+        std::fs::write(remove_tmp.path().join(CODEX_CONFIG_TOML), original).unwrap();
+        let remove_err = adapter
+            .remove_config_entries(&["mcp:context7".to_string()], remove_tmp.path())
+            .expect_err("invalid TOML should fail and not be overwritten");
+        assert!(remove_err.to_string().contains("failed to parse TOML"));
+        assert_eq!(
+            std::fs::read_to_string(remove_tmp.path().join(CODEX_CONFIG_TOML)).unwrap(),
+            original
+        );
     }
 
     #[test]
-    fn write_hooks_creates_codex_hooks_json() {
-        let tmp = TempDir::new().unwrap();
-        let adapter = CodexAdapter;
-        let entries = vec![make_hook_entry("audit", "pre-exec")];
-        adapter.write_config_entries(&entries, tmp.path()).unwrap();
-
-        let raw = std::fs::read_to_string(tmp.path().join("codex_hooks.json")).unwrap();
-        let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
-        assert!(json["hooks"]["pre-exec"].is_array());
-    }
-
-    #[test]
-    fn write_hooks_replaces_existing_managed_hook_with_same_event_and_name() {
+    fn write_hooks_replaces_existing_managed_hook_for_same_name_and_event() {
         let tmp = TempDir::new().unwrap();
         let adapter = CodexAdapter;
         adapter
@@ -681,46 +623,51 @@ theme = "dark"
     }
 
     #[test]
-    fn remove_mcp_entries_removes_by_name() {
+    fn remove_entries_clean_up_mcp_and_only_matching_hook_event() {
         let tmp = TempDir::new().unwrap();
         let adapter = CodexAdapter;
-        let entries = vec![make_mcp_entry("to-remove"), make_mcp_entry("to-keep")];
-        adapter.write_config_entries(&entries, tmp.path()).unwrap();
 
         adapter
-            .remove_config_entries(&["mcp:to-remove".to_string()], tmp.path())
+            .write_config_entries(
+                &[
+                    make_stdio_mcp_entry("to-remove"),
+                    make_stdio_mcp_entry("to-keep"),
+                    make_hook_entry_with_path("audit", "pre-exec", "/pkg/hooks/audit/run.sh"),
+                    make_hook_entry_with_path("audit", "post-exec", "/pkg/hooks/audit/run.sh"),
+                ],
+                tmp.path(),
+            )
             .unwrap();
 
-        let raw = std::fs::read_to_string(tmp.path().join(CODEX_CONFIG_TOML)).unwrap();
-        let toml: TomlValue = toml::from_str(&raw).unwrap();
+        adapter
+            .remove_config_entries(
+                &[
+                    "mcp:to-remove".to_string(),
+                    "hook:tool.pre:audit".to_string(),
+                ],
+                tmp.path(),
+            )
+            .unwrap();
+
+        let raw_toml = std::fs::read_to_string(tmp.path().join(CODEX_CONFIG_TOML)).unwrap();
+        let toml: TomlValue = toml::from_str(&raw_toml).unwrap();
         assert!(toml["mcp"]["servers"].get("to-remove").is_none());
         assert!(toml["mcp"]["servers"]["to-keep"].is_table());
+
+        let raw_hooks = std::fs::read_to_string(tmp.path().join("codex_hooks.json")).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&raw_hooks).unwrap();
+        assert!(json["hooks"]["pre-exec"].as_array().unwrap().is_empty());
+        assert_eq!(json["hooks"]["post-exec"].as_array().unwrap().len(), 1);
     }
 
     #[test]
-    fn remove_mcp_entries_invalid_toml_returns_error_without_clobbering_existing_file() {
-        let tmp = TempDir::new().unwrap();
-        let original = "[ui]\ntheme = \"dark\"\ninvalid =\n";
-        std::fs::write(tmp.path().join(CODEX_CONFIG_TOML), original).unwrap();
-
-        let adapter = CodexAdapter;
-        let err = adapter
-            .remove_config_entries(&["mcp:context7".to_string()], tmp.path())
-            .expect_err("invalid TOML should fail and not be overwritten");
-        assert!(err.to_string().contains("failed to parse TOML"));
-
-        let after = std::fs::read_to_string(tmp.path().join(CODEX_CONFIG_TOML)).unwrap();
-        assert_eq!(after, original);
-    }
-
-    #[test]
-    fn remove_hook_entries_matches_backslash_commands() {
+    fn remove_hook_entries_match_windows_backslash_paths_without_partial_name_collision() {
         let tmp = TempDir::new().unwrap();
         let existing = serde_json::json!({
             "hooks": {
                 "pre-exec": [
-                    "bash \"C:\\\\pkg\\\\hooks\\\\audit\\\\run.sh\"",
-                    "bash \"C:\\\\pkg\\\\hooks\\\\audit-extended\\\\run.sh\""
+                    r#"bash "C:\\pkg\\hooks\\audit\\run.sh""#,
+                    r#"bash "C:\\pkg\\hooks\\audit-extended\\run.sh""#
                 ]
             }
         });
@@ -737,28 +684,5 @@ theme = "dark"
         let hooks = json["hooks"]["pre-exec"].as_array().unwrap();
         assert_eq!(hooks.len(), 1);
         assert!(hooks[0].as_str().unwrap().contains("audit-extended"));
-    }
-
-    #[test]
-    fn remove_hook_entries_scopes_by_universal_event() {
-        let tmp = TempDir::new().unwrap();
-        let existing = serde_json::json!({
-            "hooks": {
-                "pre-exec": ["bash \"/pkg/hooks/audit/run.sh\""],
-                "post-exec": ["bash \"/pkg/hooks/audit/run.sh\""]
-            }
-        });
-        std::fs::write(
-            tmp.path().join("codex_hooks.json"),
-            serde_json::to_string_pretty(&existing).unwrap(),
-        )
-        .unwrap();
-
-        remove_codex_hook_entries(&["hook:tool.pre:audit".to_string()], tmp.path()).unwrap();
-
-        let raw = std::fs::read_to_string(tmp.path().join("codex_hooks.json")).unwrap();
-        let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
-        assert!(json["hooks"]["pre-exec"].as_array().unwrap().is_empty());
-        assert_eq!(json["hooks"]["post-exec"].as_array().unwrap().len(), 1);
     }
 }

--- a/src/target/opencode.rs
+++ b/src/target/opencode.rs
@@ -364,7 +364,7 @@ mod tests {
     use indexmap::IndexMap;
     use tempfile::TempDir;
 
-    fn make_mcp_entry(name: &str) -> ConfigEntry {
+    fn make_stdio_mcp_entry(name: &str) -> ConfigEntry {
         let mut env = IndexMap::new();
         env.insert("TOKEN".to_string(), "MY_TOKEN".to_string());
         ConfigEntry::McpServer(McpServerEntry {
@@ -401,16 +401,6 @@ mod tests {
         })
     }
 
-    fn make_hook_entry(name: &str, native: &str) -> ConfigEntry {
-        ConfigEntry::Hook(HookEntry {
-            name: name.to_string(),
-            event: "tool.pre".to_string(),
-            native_event: native.to_string(),
-            script_path: format!("/hooks/{name}/run.sh"),
-            order: 0,
-        })
-    }
-
     fn make_hook_entry_with_path(name: &str, native: &str, script_path: &str) -> ConfigEntry {
         ConfigEntry::Hook(HookEntry {
             name: name.to_string(),
@@ -422,81 +412,37 @@ mod tests {
     }
 
     #[test]
-    fn write_config_entries_creates_opencode_json() {
+    fn write_config_entries_merges_mcp_and_hooks_into_single_file() {
         let tmp = TempDir::new().unwrap();
         let adapter = OpencodeAdapter;
-        let entries = vec![make_mcp_entry("context7")];
-        let written = adapter.write_config_entries(&entries, tmp.path()).unwrap();
-        assert_eq!(written.len(), 1);
-        assert!(tmp.path().join("opencode.json").exists());
-
-        let raw = std::fs::read_to_string(tmp.path().join("opencode.json")).unwrap();
-        let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
-        assert!(json["mcp"]["context7"].is_object());
-        assert_eq!(json["mcp"]["context7"]["type"], "local");
-    }
-
-    #[test]
-    fn write_mcp_env_as_plain_name_map() {
-        let tmp = TempDir::new().unwrap();
-        let adapter = OpencodeAdapter;
-        let entries = vec![make_mcp_entry("server")];
-        adapter.write_config_entries(&entries, tmp.path()).unwrap();
-
-        let raw = std::fs::read_to_string(tmp.path().join("opencode.json")).unwrap();
-        let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
-        // OpenCode: env is a plain name map (not interpolated)
-        assert_eq!(json["mcp"]["server"]["environment"]["TOKEN"], "MY_TOKEN");
-    }
-
-    #[test]
-    fn write_mcp_command_merges_command_and_args() {
-        let tmp = TempDir::new().unwrap();
-        let adapter = OpencodeAdapter;
-        adapter
-            .write_config_entries(&[make_mcp_entry("server")], tmp.path())
+        let written = adapter
+            .write_config_entries(
+                &[
+                    make_stdio_mcp_entry("local-server"),
+                    make_http_mcp_entry("remote-server"),
+                    make_hook_entry_with_path("audit", "tool:before", "/hooks/audit/run.sh"),
+                ],
+                tmp.path(),
+            )
             .unwrap();
 
-        let raw = std::fs::read_to_string(tmp.path().join("opencode.json")).unwrap();
-        let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
-        let command = json["mcp"]["server"]["command"].as_array().unwrap();
-        assert_eq!(command[0], "node");
-        assert_eq!(command[1], "server.js");
-    }
-
-    #[test]
-    fn write_http_mcp_uses_remote_type_url_and_plain_headers() {
-        let tmp = TempDir::new().unwrap();
-        let adapter = OpencodeAdapter;
-        adapter
-            .write_config_entries(&[make_http_mcp_entry("remote-server")], tmp.path())
-            .unwrap();
-
-        let raw = std::fs::read_to_string(tmp.path().join("opencode.json")).unwrap();
-        let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
-        let server = &json["mcp"]["remote-server"];
-        assert_eq!(server["type"], "remote");
-        assert_eq!(server["url"], "https://api.example.com/mcp");
-        assert_eq!(server["headers"]["Authorization"], "API_TOKEN");
-        assert_eq!(server["headers"]["X-Custom"], "static-value");
-        assert!(server["command"].is_null());
-    }
-
-    #[test]
-    fn write_hooks_into_same_file() {
-        let tmp = TempDir::new().unwrap();
-        let adapter = OpencodeAdapter;
-        let entries = vec![
-            make_mcp_entry("ctx"),
-            make_hook_entry("audit", "tool:before"),
-        ];
-        let written = adapter.write_config_entries(&entries, tmp.path()).unwrap();
-        // Both written to a single file.
         assert_eq!(written.len(), 1);
-
         let raw = std::fs::read_to_string(tmp.path().join("opencode.json")).unwrap();
         let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
-        assert!(json["mcp"]["ctx"].is_object());
+
+        let local = &json["mcp"]["local-server"];
+        assert_eq!(local["type"], "local");
+        assert_eq!(local["command"][0], "node");
+        assert_eq!(local["command"][1], "server.js");
+        assert_eq!(local["environment"]["TOKEN"], "MY_TOKEN");
+
+        let remote = &json["mcp"]["remote-server"];
+        assert_eq!(remote["type"], "remote");
+        assert_eq!(remote["url"], "https://api.example.com/mcp");
+        assert_eq!(remote["headers"]["Authorization"], "API_TOKEN");
+        assert_eq!(remote["headers"]["X-Custom"], "static-value");
+        assert!(remote["command"].is_null());
+
         assert!(json["hooks"]["tool:before"].is_array());
     }
 
@@ -533,20 +479,37 @@ mod tests {
     }
 
     #[test]
-    fn remove_entries_removes_mcp_and_hooks() {
+    fn remove_entries_removes_selected_mcp_and_hook_entries() {
         let tmp = TempDir::new().unwrap();
         let adapter = OpencodeAdapter;
-        let entries = vec![make_mcp_entry("to-remove"), make_mcp_entry("to-keep")];
-        adapter.write_config_entries(&entries, tmp.path()).unwrap();
+        adapter
+            .write_config_entries(
+                &[
+                    make_stdio_mcp_entry("to-remove"),
+                    make_stdio_mcp_entry("to-keep"),
+                    make_hook_entry_with_path("audit", "tool:before", "/hooks/audit/run.sh"),
+                    make_hook_entry_with_path("audit", "tool:after", "/hooks/audit/run.sh"),
+                ],
+                tmp.path(),
+            )
+            .unwrap();
 
         adapter
-            .remove_config_entries(&["mcp:to-remove".to_string()], tmp.path())
+            .remove_config_entries(
+                &[
+                    "mcp:to-remove".to_string(),
+                    "hook:tool.pre:audit".to_string(),
+                ],
+                tmp.path(),
+            )
             .unwrap();
 
         let raw = std::fs::read_to_string(tmp.path().join("opencode.json")).unwrap();
         let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
         assert!(json["mcp"]["to-remove"].is_null());
         assert!(json["mcp"]["to-keep"].is_object());
+        assert!(json["hooks"]["tool:before"].as_array().unwrap().is_empty());
+        assert_eq!(json["hooks"]["tool:after"].as_array().unwrap().len(), 1);
     }
 
     #[test]
@@ -594,7 +557,7 @@ mod tests {
                 }
             },
             "hooks": {
-                "tool:before": ["bash \"/hooks/audit/run.sh\""]
+                "tool:before": [r#"bash "/hooks/audit/run.sh""#]
             }
         });
         std::fs::write(
@@ -605,7 +568,14 @@ mod tests {
 
         let adapter = OpencodeAdapter;
         adapter
-            .write_config_entries(&[make_hook_entry("audit", "tool:before")], tmp.path())
+            .write_config_entries(
+                &[make_hook_entry_with_path(
+                    "audit",
+                    "tool:before",
+                    "/hooks/audit/run.sh",
+                )],
+                tmp.path(),
+            )
             .unwrap();
 
         let raw = std::fs::read_to_string(tmp.path().join("opencode.json")).unwrap();

--- a/tests/tools_sync.rs
+++ b/tests/tools_sync.rs
@@ -153,7 +153,7 @@ fn sync_deprecated_tools_list_preserved_as_abstract_in_canonical() {
 }
 
 #[test]
-fn sync_tools_lossiness_surfaced_in_sync_output() {
+fn sync_tools_lossiness_warns_on_sync_and_fails_strict_validation() {
     let dir = TempDir::new().unwrap();
     let project = setup_project_with_source(&dir, &[".claude"], &[scoped_tools_agent()]);
 
@@ -171,17 +171,6 @@ fn sync_tools_lossiness_surfaced_in_sync_output() {
         stderr.contains("agent-field-dropped") || stderr.contains("dropped"),
         "sync should warn about dropped scoped tools field: {stderr}"
     );
-}
-
-#[test]
-fn sync_tools_lossiness_strict_fails() {
-    let dir = TempDir::new().unwrap();
-    let project = setup_project_with_source(&dir, &[".claude"], &[scoped_tools_agent()]);
-
-    mars()
-        .args(["sync", "--root", project.to_str().unwrap()])
-        .assert()
-        .success();
 
     mars()
         .args(["validate", "--strict", "--root", project.to_str().unwrap()])


### PR DESCRIPTION
## Summary

- Consolidate and delete redundant tests from the tools abstraction implementation
- 105 → 46 tests in touched files (table-driven consolidation, removed implementation-coupled tests)
- `tests/mcp_sync.rs` unchanged (already behavior-level)

| File | Before | After |
|------|--------|-------|
| `compiler/agents/mod.rs` | 39 | 14 |
| `compiler/agents/lower.rs` | 22 | 10 |
| `compiler/mcp/mod.rs` | 16 | 7 |
| `target/codex.rs` | 14 | 6 |
| `target/opencode.rs` | 9 | 5 |
| `tests/tools_sync.rs` | 5 | 4 |

## Test plan

- [x] Full preflight passes (fmt, clippy, test, build)
- [x] 1006 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)