### PR TITLE
Harden Mars RC release recovery

### DIFF
--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -270,9 +270,34 @@ jobs:
 
           push_tag_with_retry() {
             local tag_ref="$1"
+            local expected_commit="$2"
+
+            validate_local_tag_commit() {
+              local validate_tag_ref="$1"
+              local validate_expected_commit="$2"
+              local validate_context="$3"
+
+              if git rev-parse -q --verify "refs/tags/${validate_tag_ref}" >/dev/null; then
+                local observed_commit
+                observed_commit="$(git rev-parse "${validate_tag_ref}^{commit}")"
+                if [[ "${observed_commit}" != "${validate_expected_commit}" ]]; then
+                  echo "::error::Tag ${validate_tag_ref} resolved to ${observed_commit} ${validate_context}; expected ${validate_expected_commit}."
+                  return 1
+                fi
+              fi
+            }
+
+            if ! validate_local_tag_commit "${tag_ref}" "${expected_commit}" "before push"; then
+              return 1
+            fi
+
             for attempt in 1 2 3; do
               if git push "https://x-access-token:${TAG_PUSH_TOKEN}@github.com/${REPOSITORY}.git" "refs/tags/${tag_ref}"; then
                 return 0
+              fi
+
+              if ! validate_local_tag_commit "${tag_ref}" "${expected_commit}" "after failed push attempt ${attempt}"; then
+                return 1
               fi
 
               if [[ "${attempt}" -eq 3 ]]; then
@@ -282,6 +307,13 @@ jobs:
 
               echo "::warning::Push for tag ${tag_ref} failed on attempt ${attempt}; refetching tags and retrying."
               git fetch --tags --force
+              if ! validate_local_tag_commit "${tag_ref}" "${expected_commit}" "after refetch on failed attempt ${attempt}"; then
+                return 1
+              fi
+              if git rev-parse -q --verify "refs/tags/${tag_ref}" >/dev/null; then
+                echo "::notice::Tag ${tag_ref} already exists on expected commit ${expected_commit}; treating push as success."
+                return 0
+              fi
               sleep $((attempt * 2))
             done
           }
@@ -297,7 +329,7 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git tag -a "${MISSING_TAG}" "${MISSING_TAG_COMMIT}" -m "Release ${MISSING_TAG#v}"
-            push_tag_with_retry "${MISSING_TAG}"
+            push_tag_with_retry "${MISSING_TAG}" "${MISSING_TAG_COMMIT}"
             echo "::notice::Created missing tag ${MISSING_TAG} for existing release commit ${MISSING_TAG_COMMIT}."
           fi
 
@@ -452,9 +484,34 @@ jobs:
 
           push_tag_with_retry() {
             local tag_ref="$1"
+            local expected_commit="$2"
+
+            validate_local_tag_commit() {
+              local validate_tag_ref="$1"
+              local validate_expected_commit="$2"
+              local validate_context="$3"
+
+              if git rev-parse -q --verify "refs/tags/${validate_tag_ref}" >/dev/null; then
+                local observed_commit
+                observed_commit="$(git rev-parse "${validate_tag_ref}^{commit}")"
+                if [[ "${observed_commit}" != "${validate_expected_commit}" ]]; then
+                  echo "::error::Tag ${validate_tag_ref} resolved to ${observed_commit} ${validate_context}; expected ${validate_expected_commit}."
+                  return 1
+                fi
+              fi
+            }
+
+            if ! validate_local_tag_commit "${tag_ref}" "${expected_commit}" "before push"; then
+              return 1
+            fi
+
             for attempt in 1 2 3; do
               if git push "https://x-access-token:${TAG_PUSH_TOKEN}@github.com/${REPOSITORY}.git" "refs/tags/${tag_ref}"; then
                 return 0
+              fi
+
+              if ! validate_local_tag_commit "${tag_ref}" "${expected_commit}" "after failed push attempt ${attempt}"; then
+                return 1
               fi
 
               if [[ "${attempt}" -eq 3 ]]; then
@@ -464,6 +521,13 @@ jobs:
 
               echo "::warning::Push for tag ${tag_ref} failed on attempt ${attempt}; refetching tags and retrying."
               git fetch --tags --force
+              if ! validate_local_tag_commit "${tag_ref}" "${expected_commit}" "after refetch on failed attempt ${attempt}"; then
+                return 1
+              fi
+              if git rev-parse -q --verify "refs/tags/${tag_ref}" >/dev/null; then
+                echo "::notice::Tag ${tag_ref} already exists on expected commit ${expected_commit}; treating push as success."
+                return 0
+              fi
               sleep $((attempt * 2))
             done
           }
@@ -499,7 +563,7 @@ jobs:
             git tag -a "v${NEXT_VERSION}" "${release_commit_sha}" -m "Release ${NEXT_VERSION}"
           fi
 
-          push_tag_with_retry "v${NEXT_VERSION}"
+          push_tag_with_retry "v${NEXT_VERSION}" "${release_commit_sha}"
           echo "tag=v${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
 
   publish:

--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -340,7 +340,8 @@ jobs:
               fi
               local remote_tag_commit=""
               local remote_status=0
-              if remote_tag_commit="$(resolve_remote_tag_commit "${tag_ref}" "${release_remote_url}")"; then
+              remote_tag_commit="$(resolve_remote_tag_commit "${tag_ref}" "${release_remote_url}")" && remote_status=0 || remote_status=$?
+              if [[ "${remote_status}" -eq 0 ]]; then
                 if [[ "${remote_tag_commit}" == "${expected_commit}" ]]; then
                   echo "::notice::Remote tag ${tag_ref} already exists on expected commit ${expected_commit}; treating push as success."
                   return 0
@@ -348,7 +349,6 @@ jobs:
                 echo "::error::Remote tag ${tag_ref} resolves to ${remote_tag_commit}; expected ${expected_commit}."
                 return 1
               fi
-              remote_status=$?
               if [[ "${remote_status}" -eq 1 ]]; then
                 echo "::notice::Remote tag ${tag_ref} not found yet after failed push attempt ${attempt}; retrying."
               fi
@@ -592,7 +592,8 @@ jobs:
               fi
               local remote_tag_commit=""
               local remote_status=0
-              if remote_tag_commit="$(resolve_remote_tag_commit "${tag_ref}" "${release_remote_url}")"; then
+              remote_tag_commit="$(resolve_remote_tag_commit "${tag_ref}" "${release_remote_url}")" && remote_status=0 || remote_status=$?
+              if [[ "${remote_status}" -eq 0 ]]; then
                 if [[ "${remote_tag_commit}" == "${expected_commit}" ]]; then
                   echo "::notice::Remote tag ${tag_ref} already exists on expected commit ${expected_commit}; treating push as success."
                   return 0
@@ -600,7 +601,6 @@ jobs:
                 echo "::error::Remote tag ${tag_ref} resolves to ${remote_tag_commit}; expected ${expected_commit}."
                 return 1
               fi
-              remote_status=$?
               if [[ "${remote_status}" -eq 1 ]]; then
                 echo "::notice::Remote tag ${tag_ref} not found yet after failed push attempt ${attempt}; retrying."
               fi

--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -267,6 +267,7 @@ jobs:
           TAG_PUSH_TOKEN: ${{ github.token }}
         run: |
           git fetch --tags --force
+          release_remote_url="https://x-access-token:${TAG_PUSH_TOKEN}@github.com/${REPOSITORY}.git"
 
           push_tag_with_retry() {
             local tag_ref="$1"
@@ -285,6 +286,33 @@ jobs:
                   return 1
                 fi
               fi
+            }
+
+            resolve_remote_tag_commit() {
+              local resolve_tag_ref="$1"
+              local resolve_remote_url="$2"
+              local remote_refs
+              local peeled_commit
+              local ref_commit
+
+              if ! remote_refs="$(git ls-remote --tags "${resolve_remote_url}" "refs/tags/${resolve_tag_ref}" "refs/tags/${resolve_tag_ref}^{}")"; then
+                echo "::warning::Failed to query remote tag ${resolve_tag_ref}; will retry push."
+                return 2
+              fi
+
+              peeled_commit="$(awk '$2 ~ /\^\{\}$/ { print $1; exit }' <<<"${remote_refs}")"
+              if [[ -n "${peeled_commit}" ]]; then
+                echo "${peeled_commit}"
+                return 0
+              fi
+
+              ref_commit="$(awk '$2 !~ /\^\{\}$/ { print $1; exit }' <<<"${remote_refs}")"
+              if [[ -n "${ref_commit}" ]]; then
+                echo "${ref_commit}"
+                return 0
+              fi
+
+              return 1
             }
 
             if ! validate_local_tag_commit "${tag_ref}" "${expected_commit}" "before push"; then
@@ -310,9 +338,19 @@ jobs:
               if ! validate_local_tag_commit "${tag_ref}" "${expected_commit}" "after refetch on failed attempt ${attempt}"; then
                 return 1
               fi
-              if git rev-parse -q --verify "refs/tags/${tag_ref}" >/dev/null; then
-                echo "::notice::Tag ${tag_ref} already exists on expected commit ${expected_commit}; treating push as success."
-                return 0
+              local remote_tag_commit=""
+              local remote_status=0
+              if remote_tag_commit="$(resolve_remote_tag_commit "${tag_ref}" "${release_remote_url}")"; then
+                if [[ "${remote_tag_commit}" == "${expected_commit}" ]]; then
+                  echo "::notice::Remote tag ${tag_ref} already exists on expected commit ${expected_commit}; treating push as success."
+                  return 0
+                fi
+                echo "::error::Remote tag ${tag_ref} resolves to ${remote_tag_commit}; expected ${expected_commit}."
+                return 1
+              fi
+              remote_status=$?
+              if [[ "${remote_status}" -eq 1 ]]; then
+                echo "::notice::Remote tag ${tag_ref} not found yet after failed push attempt ${attempt}; retrying."
               fi
               sleep $((attempt * 2))
             done
@@ -481,6 +519,7 @@ jobs:
           TAG_PUSH_TOKEN: ${{ github.token }}
         run: |
           release_commit_sha="${RELEASE_COMMIT_SHA}"
+          release_remote_url="https://x-access-token:${TAG_PUSH_TOKEN}@github.com/${REPOSITORY}.git"
 
           push_tag_with_retry() {
             local tag_ref="$1"
@@ -499,6 +538,33 @@ jobs:
                   return 1
                 fi
               fi
+            }
+
+            resolve_remote_tag_commit() {
+              local resolve_tag_ref="$1"
+              local resolve_remote_url="$2"
+              local remote_refs
+              local peeled_commit
+              local ref_commit
+
+              if ! remote_refs="$(git ls-remote --tags "${resolve_remote_url}" "refs/tags/${resolve_tag_ref}" "refs/tags/${resolve_tag_ref}^{}")"; then
+                echo "::warning::Failed to query remote tag ${resolve_tag_ref}; will retry push."
+                return 2
+              fi
+
+              peeled_commit="$(awk '$2 ~ /\^\{\}$/ { print $1; exit }' <<<"${remote_refs}")"
+              if [[ -n "${peeled_commit}" ]]; then
+                echo "${peeled_commit}"
+                return 0
+              fi
+
+              ref_commit="$(awk '$2 !~ /\^\{\}$/ { print $1; exit }' <<<"${remote_refs}")"
+              if [[ -n "${ref_commit}" ]]; then
+                echo "${ref_commit}"
+                return 0
+              fi
+
+              return 1
             }
 
             if ! validate_local_tag_commit "${tag_ref}" "${expected_commit}" "before push"; then
@@ -524,9 +590,19 @@ jobs:
               if ! validate_local_tag_commit "${tag_ref}" "${expected_commit}" "after refetch on failed attempt ${attempt}"; then
                 return 1
               fi
-              if git rev-parse -q --verify "refs/tags/${tag_ref}" >/dev/null; then
-                echo "::notice::Tag ${tag_ref} already exists on expected commit ${expected_commit}; treating push as success."
-                return 0
+              local remote_tag_commit=""
+              local remote_status=0
+              if remote_tag_commit="$(resolve_remote_tag_commit "${tag_ref}" "${release_remote_url}")"; then
+                if [[ "${remote_tag_commit}" == "${expected_commit}" ]]; then
+                  echo "::notice::Remote tag ${tag_ref} already exists on expected commit ${expected_commit}; treating push as success."
+                  return 0
+                fi
+                echo "::error::Remote tag ${tag_ref} resolves to ${remote_tag_commit}; expected ${expected_commit}."
+                return 1
+              fi
+              remote_status=$?
+              if [[ "${remote_status}" -eq 1 ]]; then
+                echo "::notice::Remote tag ${tag_ref} not found yet after failed push attempt ${attempt}; retrying."
               fi
               sleep $((attempt * 2))
             done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `release-on-main` tag push retries now verify expected tag commit before/after retries, fail fast on wrong-commit collisions, and treat refetch-discovered expected tags as success.
+
 ## [0.4.7-rc.1] - 2026-05-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
-- `release-on-main` tag push retries now verify expected tag commit before/after retries, fail fast on wrong-commit collisions, and treat refetch-discovered expected tags as success.
+- `release-on-main` tag push retries now verify expected tag commit before/after retries, confirm remote tag commit via `git ls-remote` (including annotated tag peel refs), fail fast on wrong-commit collisions, and only treat confirmed remote tags as success.
 
 ## [0.4.7-rc.1] - 2026-05-17
 

--- a/tests/release_metadata.rs
+++ b/tests/release_metadata.rs
@@ -176,9 +176,26 @@ fn release_on_main_uses_trigger_marker_and_rerun_tag_recovery() {
     assert!(workflow.contains(
         "Tag ${validate_tag_ref} resolved to ${observed_commit} ${validate_context}; expected ${validate_expected_commit}."
     ));
+    assert_eq!(
+        workflow
+            .matches("git ls-remote --tags \"${resolve_remote_url}\" \"refs/tags/${resolve_tag_ref}\" \"refs/tags/${resolve_tag_ref}^{}\"")
+            .count(),
+        2,
+        "both tag push helpers must verify remote tag refs including peeled annotated tag"
+    );
     assert!(workflow.contains(
+        "Remote tag ${tag_ref} already exists on expected commit ${expected_commit}; treating push as success."
+    ));
+    assert!(workflow.contains(
+        "Remote tag ${tag_ref} resolves to ${remote_tag_commit}; expected ${expected_commit}."
+    ));
+    assert!(workflow.contains(
+        "Remote tag ${tag_ref} not found yet after failed push attempt ${attempt}; retrying."
+    ));
+    assert!(!workflow.contains(
         "Tag ${tag_ref} already exists on expected commit ${expected_commit}; treating push as success."
     ));
+    assert!(workflow.contains("if [[ \"${remote_status}\" -eq 1 ]]; then"));
     assert!(workflow.contains("after refetch on failed attempt ${attempt}"));
     assert!(workflow.contains("echo \"tag=${MISSING_TAG}\" >> \"$GITHUB_OUTPUT\""));
     assert!(workflow.contains("steps.push_release.outputs.tag || steps.push_missing_tag.outputs.tag || steps.release_guard.outputs.existing_release_tag"));

--- a/tests/release_metadata.rs
+++ b/tests/release_metadata.rs
@@ -192,9 +192,10 @@ fn release_on_main_uses_trigger_marker_and_rerun_tag_recovery() {
     assert!(workflow.contains(
         "Remote tag ${tag_ref} not found yet after failed push attempt ${attempt}; retrying."
     ));
-    assert!(!workflow.contains(
-        "remote_status=$?\n              if [[ \"${remote_status}\" -eq 1 ]]; then"
-    ));
+    assert!(
+        !workflow
+            .contains("remote_status=$?\n              if [[ \"${remote_status}\" -eq 1 ]]; then")
+    );
     assert_eq!(
         workflow
             .matches("remote_tag_commit=\"$(resolve_remote_tag_commit \"${tag_ref}\" \"${release_remote_url}\")\" && remote_status=0 || remote_status=$?")

--- a/tests/release_metadata.rs
+++ b/tests/release_metadata.rs
@@ -193,6 +193,16 @@ fn release_on_main_uses_trigger_marker_and_rerun_tag_recovery() {
         "Remote tag ${tag_ref} not found yet after failed push attempt ${attempt}; retrying."
     ));
     assert!(!workflow.contains(
+        "remote_status=$?\n              if [[ \"${remote_status}\" -eq 1 ]]; then"
+    ));
+    assert_eq!(
+        workflow
+            .matches("remote_tag_commit=\"$(resolve_remote_tag_commit \"${tag_ref}\" \"${release_remote_url}\")\" && remote_status=0 || remote_status=$?")
+            .count(),
+        2,
+        "both tag push helpers should capture resolver exit status explicitly"
+    );
+    assert!(!workflow.contains(
         "Tag ${tag_ref} already exists on expected commit ${expected_commit}; treating push as success."
     ));
     assert!(workflow.contains("if [[ \"${remote_status}\" -eq 1 ]]; then"));

--- a/tests/release_metadata.rs
+++ b/tests/release_metadata.rs
@@ -158,12 +158,28 @@ fn release_on_main_uses_trigger_marker_and_rerun_tag_recovery() {
     assert!(workflow.contains("echo \"missing_tag=${selected_tag}\" >> \"$GITHUB_OUTPUT\""));
     assert!(workflow.contains("if: steps.release_intent.outputs.should_release == 'true' && steps.release_guard.outputs.tag_missing == 'true'"));
     assert!(workflow.contains("id: push_missing_tag"));
+    assert_eq!(
+        workflow.matches("local expected_commit=\"$2\"").count(),
+        2,
+        "both tag push helpers should accept expected commit"
+    );
     assert!(workflow.contains(
         "git tag -a \"${MISSING_TAG}\" \"${MISSING_TAG_COMMIT}\" -m \"Release ${MISSING_TAG#v}\""
     ));
+    assert!(workflow.contains("push_tag_with_retry \"${MISSING_TAG}\" \"${MISSING_TAG_COMMIT}\""));
+    assert!(
+        workflow.contains("push_tag_with_retry \"v${NEXT_VERSION}\" \"${release_commit_sha}\"")
+    );
     assert!(workflow.contains(
         "Tag ${MISSING_TAG} already exists on ${tag_commit}, expected ${MISSING_TAG_COMMIT}."
     ));
+    assert!(workflow.contains(
+        "Tag ${validate_tag_ref} resolved to ${observed_commit} ${validate_context}; expected ${validate_expected_commit}."
+    ));
+    assert!(workflow.contains(
+        "Tag ${tag_ref} already exists on expected commit ${expected_commit}; treating push as success."
+    ));
+    assert!(workflow.contains("after refetch on failed attempt ${attempt}"));
     assert!(workflow.contains("echo \"tag=${MISSING_TAG}\" >> \"$GITHUB_OUTPUT\""));
     assert!(workflow.contains("steps.push_release.outputs.tag || steps.push_missing_tag.outputs.tag || steps.release_guard.outputs.existing_release_tag"));
 }


### PR DESCRIPTION
## Summary
- Hardens `release-on-main` reruns with exact `Release-Trigger` matching, missing-tag recovery, and expected-commit-safe tag push retries.
- Selects one merged `main` PR deterministically for release labels and fails closed on GitHub API errors or ambiguous PR candidates.
- Keeps RC publishing semantics: RC tags remain `vX.Y.Z-rc.N`, PyPI uses `X.Y.ZrcN`, GitHub releases are prerelease, npm publishes under `rc`.
- Tightens `cargo publish` idempotency so only already-published/uploaded cases are ignored.

## Work item
mars-launch-bundle-design

## Verification
- `cargo fmt --check`
- `cargo test -q --test release_metadata`
- `actionlint .github/workflows/release-on-main.yml .github/workflows/release.yml`
- `git diff --check`
- `scripts/preflight.sh full`
- pre-push hook full preflight during `git push`
- final reviewer spawn: ship / no blocking findings
