### PR TITLE
Export agent_body in launch bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Bundle now exports agent_body alongside system_instruction for consumers needing decomposed prompt surfaces.
+
 ## [0.4.8-rc.3] - 2026-05-20
 
 ### Changed

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -556,6 +556,7 @@ mars build launch-bundle [--agent NAME] [--model TOKEN] [flags]
 ```jsonc
 {
   "agent": "agent-name-or-null",
+  "agent_body": "raw-agent-markdown-body",
   "routing": {
     "model": "...",
     "harness": "...",
@@ -576,6 +577,9 @@ mars build launch-bundle [--agent NAME] [--model TOKEN] [flags]
   "warnings": ["..."]
 }
 ```
+
+- `agent_body` is the raw post-frontmatter markdown body from `.mars/agents/<name>.md` in agent/profile mode.
+- `agent_body` is omitted in ad-hoc mode (no `--agent`).
 
 **Warning semantics:** `warnings[]` contains only unexpected, user-actionable conditions. Routing path facts are NOT warnings — `harness_model_source: "passthrough"` and `harness_model_confidence: "unknown"` (e.g., Pi or explicit harness) appear in routing/provenance fields and do not produce warnings. Real warnings include: linked harness constraints exhausting auto-routing candidates, or Cursor experimental target.
 

--- a/src/build/bundle.rs
+++ b/src/build/bundle.rs
@@ -8,6 +8,8 @@ pub const SLOT_PLACEHOLDER: &str = "###SLOT###";
 pub struct LaunchBundle {
     pub version: u32,
     pub agent: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_body: Option<String>,
     pub routing: Routing,
     pub execution_policy: ExecutionPolicy,
     pub prompt_surface: PromptSurface,

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -30,7 +30,7 @@ pub fn build_launch_bundle(
 ) -> Result<LaunchBundle, MarsError> {
     let mut warnings: Vec<String> = Vec::new();
     let profile: AgentProfile;
-    let body: String;
+    let agent_body: Option<String>;
 
     if let Some(agent) = request.agent.as_deref() {
         let agent_path = agent_file_path(&ctx.project_root, agent);
@@ -67,11 +67,11 @@ pub fn build_launch_bundle(
                 .iter()
                 .map(|diag| format!("agent `{agent}`: {}", diag.message())),
         );
-        body = frontmatter.body().to_string();
+        agent_body = Some(frontmatter.body().to_string());
         profile = parsed_profile;
     } else {
         profile = empty_agent_profile();
-        body = String::new();
+        agent_body = None;
     }
 
     let policy = resolve_policy(PolicyInput {
@@ -91,7 +91,7 @@ pub fn build_launch_bundle(
 
     let prompt = compile_prompt_surface(
         &mars_dir,
-        &body,
+        agent_body.as_deref().unwrap_or(""),
         &effective_skills,
         &request.extra_skills,
         &policy.routing.harness,
@@ -106,6 +106,7 @@ pub fn build_launch_bundle(
     Ok(LaunchBundle {
         version: 1,
         agent: request.agent,
+        agent_body,
         routing: policy.routing,
         execution_policy: policy.execution_policy,
         prompt_surface: bundle::PromptSurface {

--- a/tests/launch_bundle/schema.rs
+++ b/tests/launch_bundle/schema.rs
@@ -5,6 +5,13 @@ use assert_fs::prelude::*;
 use httpmock::MockServer;
 use serde_json::Value;
 
+fn assert_field_absent_or_null(bundle: &Value, field: &str) {
+    assert!(
+        bundle.get(field).is_none() || bundle[field].is_null(),
+        "{field} should be absent or null"
+    );
+}
+
 pub(crate) fn build_launch_bundle_outputs_schema_and_slot_placeholders() {
     let temp = TempDir::new().unwrap();
     let bin_dir = install_fake_harnesses(temp.path(), &["codex"]);
@@ -16,7 +23,9 @@ tools: [Bash, Write]
 disallowed-tools: [Agent]
 mcp-tools: [plugin:context7:context7]
 ---
-Review code changes."#;
+
+Review code changes.
+"#;
     let skill_content =
         "---\nname: planning\ndescription: Plan tasks\n---\nUse this skill to plan.";
 
@@ -46,6 +55,15 @@ Review code changes."#;
 
     assert_eq!(bundle["version"].as_u64(), Some(1));
     assert_eq!(bundle["agent"].as_str(), Some("reviewer"));
+    assert_eq!(
+        bundle["agent_body"].as_str(),
+        Some("\nReview code changes.\n")
+    );
+    let system_instruction = bundle["prompt_surface"]["system_instruction"]
+        .as_str()
+        .expect("system instruction should be string");
+    assert!(system_instruction.contains("# Agent Profile\n\nReview code changes.\n\n"));
+    assert!(!system_instruction.contains("# Agent Profile\n\n\nReview code changes.\n\n"));
     assert_eq!(bundle["routing"]["harness"].as_str(), Some("codex"));
     assert!(bundle["routing"]["route_confidence"].is_string());
     assert!(bundle["routing"]["harness_model"].is_string());
@@ -105,6 +123,7 @@ Review code changes."#;
 
     assert_eq!(bundle["version"].as_u64(), Some(1));
     assert!(bundle["agent"].is_null());
+    assert_field_absent_or_null(&bundle, "agent_body");
     assert_eq!(
         bundle["routing"]["model_token"].as_str(),
         Some("gpt-5.4-mini")
@@ -147,6 +166,7 @@ pub(crate) fn build_launch_bundle_ad_hoc_without_mars_toml() {
     let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
 
     assert!(bundle["agent"].is_null());
+    assert_field_absent_or_null(&bundle, "agent_body");
     assert_eq!(bundle["routing"]["harness"].as_str(), Some("pi"));
     assert_eq!(
         bundle["routing"]["harness_model_source"].as_str(),


### PR DESCRIPTION
## Why

Fixes #52. `mars build launch-bundle` exposed the composed `system_instruction` plus skills/docs/scaffolding, but not the raw agent body before composition. Consumers building decomposed prompt pipelines need that source body separately.

## Goal

Agent-backed launch bundles expose top-level `agent_body` without changing the existing composed `prompt_surface.system_instruction`. Ad-hoc/no-agent bundles omit `agent_body`.

## Summary

- Added `agent_body: Option<String>` to the serialized launch bundle.
- Threaded the raw post-frontmatter agent markdown body through bundle assembly before prompt composition.
- Left `system_instruction` composition unchanged.
- Added launch-bundle schema coverage for agent-backed and ad-hoc bundles.
- Documented the new JSON field and updated the changelog.

## Work Item

mars-agent-body-export

## Changes

- `src/build/bundle.rs`: new top-level optional `agent_body` field, omitted when `None`.
- `src/build/mod.rs`: captures `Frontmatter::body()` as the single owned raw body source, passes it to prompt compilation, and serializes it for agent bundles.
- `tests/launch_bundle/schema.rs`: verifies raw whitespace preservation for `agent_body`, ad-hoc absence/null behavior, and trimmed composed system prompt behavior.
- `docs/cli/commands.md`: documents `agent_body` semantics.
- `CHANGELOG.md`: adds the user-visible bundle export note.

## Verification

- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo build --release`
- `meridian kg check docs/cli/commands.md`
- Pre-push hook / `scripts/preflight.sh` via `git push`:
  - `cargo fmt --check`
  - `cargo clippy --all-targets -- -D warnings`
  - `cargo test -- --skip cli::version::tests::run`
  - `cargo build --release`
- Live smoke probe with `target/release/mars`:
  - agent bundle returned valid JSON with populated raw `agent_body`
  - ad-hoc bundle returned valid JSON with `agent: null` and omitted `agent_body`
  - evidence: `/home/jimyao/.meridian/git/haowjy-meridian-cli-docs/work/mars-agent-body-export/live-probe-evidence.md`

## Knowledge Updates

- Updated `docs/cli/commands.md` launch-bundle JSON documentation.
- Updated `CHANGELOG.md` under `[Unreleased]`.

## Spawn Trace

- p1772 explorer — mapped launch-bundle assembly and tests.
- p1774 coder — implemented `agent_body`, tests, changelog.
- p1775 reviewer — pre-commit correctness/test review.
- p1776 coder — addressed reviewer test-quality findings.
- p1778 reviewer — final correctness review.
- p1779 simplify-reviewer — simplification audit.
- p1780 reviewer — final structural review.
- p1781 coder — removed duplicate body state and updated docs.
- p1783 smoke-tester — final live CLI probes.
- p1784 qa-lead — test-suite audit.
- p1787 coder — rustfmt follow-up from pre-push.

## Release Label Guide

Set `release:patch`.
