### PR TITLE
Add settings default model routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- `[settings].default_model` support for launch-bundle model resolution (`cli > profile > project > error`), with `provenance.model_source = "project"` when selected.
+
 ## [0.4.8-rc.4] - 2026-05-20
 
 ### Added

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -540,6 +540,7 @@ mars build launch-bundle [--agent NAME] [--model TOKEN] [flags]
 - Reads `.mars/agents/<name>.md` from the nearest `mars.toml` project
 - Requires a project with `mars sync` already run
 - Inherits all profile fields (model, harness, effort, approval, skills, tools)
+- Model precedence is `--model` > profile model > `settings.default_model`.
 
 | Flag | Description |
 |---|---|
@@ -570,7 +571,7 @@ mars build launch-bundle [--agent NAME] [--model TOKEN] [flags]
   "tools": { "..." },
   "skills_metadata": { "loaded": ["..."], "missing": ["..."] },
   "provenance": {
-    "model_source": "...",
+    "model_source": "cli|profile|project",
     "harness_source": "...",
     "candidates_tried": "..."
   },

--- a/docs/config/mars-toml.md
+++ b/docs/config/mars-toml.md
@@ -167,6 +167,8 @@ exclude = ["*-preview*", "*-latest"]         # Then hide these
 | `agent_emission` | string | `"auto"` | Native harness agent emission: `auto`, `always`, or `never` |
 | `min_mars_version` | string | unset | Minimum Mars binary version required for this project |
 | `models_cache_ttl_hours` | integer | `24` | Model catalog cache TTL; `0` forces refresh |
+| `default_harness` | string | unset | Default harness for launch routing when profile/alias/provider cannot resolve one |
+| `default_model` | string | unset | Project-wide default model token when neither `--model` nor the agent profile sets one. |
 | `model_visibility` | table | `{}` | Consumer-only display filter for `mars models list` output |
 
 `.mars/` is always the canonical compiled store. Target sync is opt-in: if neither `targets` nor legacy `managed_root` is set, Mars creates no target-sync targets by default.

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -78,6 +78,7 @@ pub fn build_launch_bundle(
         project_root: &ctx.project_root,
         profile: &profile,
         model_override: request.model.as_deref(),
+        config_default_model: None,
         harness_override: request.harness.as_deref(),
         effort_override: request.effort.as_deref(),
         approval_override: request.approval.as_deref(),

--- a/src/build/policy/config.rs
+++ b/src/build/policy/config.rs
@@ -8,6 +8,7 @@ use crate::models::{self, ModelAlias};
 pub(super) struct PolicyResolutionConfig {
     pub(super) aliases: IndexMap<String, ModelAlias>,
     pub(super) default_harness: Option<String>,
+    pub(super) default_model: Option<String>,
     pub(super) harness_order: Option<Vec<String>>,
     pub(super) linked_harnesses: Vec<String>,
 }
@@ -17,6 +18,7 @@ pub(super) fn load_policy_resolution_config(
 ) -> Result<PolicyResolutionConfig, MarsError> {
     let mut merged = models::builtin_aliases();
     let mut default_harness = None;
+    let mut default_model = None;
     let mut harness_order = None;
     let mut linked_harnesses = Vec::new();
 
@@ -32,6 +34,7 @@ pub(super) fn load_policy_resolution_config(
     match crate::config::load(project_root) {
         Ok(config) => {
             default_harness = config.settings.default_harness.clone();
+            default_model = config.settings.default_model.clone();
             harness_order = config.settings.harness_order.clone();
             linked_harnesses = config.settings.linked_harnesses();
             for (name, alias) in &config.models {
@@ -45,6 +48,7 @@ pub(super) fn load_policy_resolution_config(
     Ok(PolicyResolutionConfig {
         aliases: merged,
         default_harness,
+        default_model,
         harness_order,
         linked_harnesses,
     })

--- a/src/build/policy/harness.rs
+++ b/src/build/policy/harness.rs
@@ -207,6 +207,7 @@ mod tests {
             project_root: Path::new("."),
             profile,
             model_override,
+            config_default_model: None,
             harness_override,
             effort_override: None,
             approval_override: None,

--- a/src/build/policy/mod.rs
+++ b/src/build/policy/mod.rs
@@ -16,6 +16,7 @@ pub struct PolicyInput<'a> {
     pub project_root: &'a Path,
     pub profile: &'a AgentProfile,
     pub model_override: Option<&'a str>,
+    pub config_default_model: Option<&'a str>,
     pub harness_override: Option<&'a str>,
     pub effort_override: Option<&'a str>,
     pub approval_override: Option<&'a str>,
@@ -35,7 +36,17 @@ pub fn resolve_policy(input: PolicyInput<'_>) -> Result<ResolvedPolicy, MarsErro
 
     let resolution_config = config::load_policy_resolution_config(input.project_root)?;
     let cache = model::load_models_cache(input.project_root)?;
-    let resolved_model = model::resolve_model(&input, &resolution_config.aliases, &cache)?;
+    let model_input = PolicyInput {
+        project_root: input.project_root,
+        profile: input.profile,
+        model_override: input.model_override,
+        config_default_model: resolution_config.default_model.as_deref(),
+        harness_override: input.harness_override,
+        effort_override: input.effort_override,
+        approval_override: input.approval_override,
+        sandbox_override: input.sandbox_override,
+    };
+    let resolved_model = model::resolve_model(&model_input, &resolution_config.aliases, &cache)?;
 
     warnings.extend(resolved_model.warnings);
     provenance.insert(
@@ -52,7 +63,7 @@ pub fn resolve_policy(input: PolicyInput<'_>) -> Result<ResolvedPolicy, MarsErro
     let pi_probe_result = capability_snapshot.pi.result();
 
     let harness_resolution = harness::resolve_harness(
-        &input,
+        &model_input,
         resolved_model.alias,
         harness::HarnessEvidence {
             model_id: &resolved_model.model,

--- a/src/build/policy/model.rs
+++ b/src/build/policy/model.rs
@@ -16,6 +16,10 @@ pub(super) struct ResolvedModel<'a> {
     pub(super) warnings: Vec<String>,
 }
 
+/// Resolve model selection precedence for launch-bundle.
+///
+/// Resolution order is `cli > profile > project > error` where project maps to
+/// `settings.default_model` from `mars.toml`.
 pub(super) fn resolve_model<'a>(
     input: &PolicyInput<'_>,
     aliases: &'a IndexMap<String, ModelAlias>,
@@ -27,12 +31,15 @@ pub(super) fn resolve_model<'a>(
         Some(model) => (model.to_string(), "cli".to_string()),
         None => match input.profile.model.as_deref() {
             Some(model) => (model.to_string(), "profile".to_string()),
-            None => {
-                return Err(MarsError::Config(ConfigError::Invalid {
-                    message: "launch-bundle requires a model (set `model:` in the agent profile or pass `--model`)"
-                        .to_string(),
-                }));
-            }
+            None => match input.config_default_model {
+                Some(model) => (model.to_string(), "project".to_string()),
+                None => {
+                    return Err(MarsError::Config(ConfigError::Invalid {
+                        message: "launch-bundle requires a model (set `model:` in the agent profile, set `settings.default_model` in mars.toml, or pass `--model`)"
+                            .to_string(),
+                    }));
+                }
+            },
         },
     };
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -228,6 +228,9 @@ pub struct Settings {
     /// Default harness for launch routing when profile/alias/provider cannot resolve one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_harness: Option<String>,
+    /// Project-wide default model token when no CLI override or profile model is set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_model: Option<String>,
     /// Ordered harness preference for launch-bundle candidate selection.
     ///
     /// When set, replaces built-in provider preference ordering for candidate
@@ -260,6 +263,7 @@ impl Default for Settings {
             models_cache_ttl_hours: default_models_cache_ttl_hours(),
             min_mars_version: None,
             default_harness: None,
+            default_model: None,
             harness_order: None,
             agent_emission: None,
         }
@@ -776,6 +780,15 @@ fn validate_save_roundtrip(original: &Config, reparsed: &Config) -> Result<(), M
             message: format!(
                 "refusing to save config: settings.default_harness changed during roundtrip ({:?} -> {:?})",
                 original.settings.default_harness, reparsed.settings.default_harness
+            ),
+        }
+        .into());
+    }
+    if reparsed.settings.default_model != original.settings.default_model {
+        return Err(ConfigError::Invalid {
+            message: format!(
+                "refusing to save config: settings.default_model changed during roundtrip ({:?} -> {:?})",
+                original.settings.default_model, reparsed.settings.default_model
             ),
         }
         .into());
@@ -2110,6 +2123,28 @@ default_harness = "codex"
         assert_eq!(
             roundtripped.settings.default_harness,
             config.settings.default_harness
+        );
+    }
+
+    #[test]
+    fn settings_default_model_parses_and_roundtrips() {
+        let config: Config = toml::from_str(
+            r#"
+[settings]
+default_model = "gpt-5.4-mini"
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            config.settings.default_model.as_deref(),
+            Some("gpt-5.4-mini")
+        );
+
+        let serialized = toml::to_string_pretty(&config).unwrap();
+        let roundtripped: Config = toml::from_str(&serialized).unwrap();
+        assert_eq!(
+            roundtripped.settings.default_model,
+            config.settings.default_model
         );
     }
 

--- a/tests/launch_bundle.rs
+++ b/tests/launch_bundle.rs
@@ -224,6 +224,21 @@ fn build_launch_bundle_cli_direct_model_id_prefers_provider_harness_over_profile
 }
 
 #[test]
+fn build_launch_bundle_uses_settings_default_model_when_profile_and_cli_missing() {
+    routing::build_launch_bundle_uses_settings_default_model_when_profile_and_cli_missing();
+}
+
+#[test]
+fn build_launch_bundle_cli_model_override_beats_settings_default_model() {
+    routing::build_launch_bundle_cli_model_override_beats_settings_default_model();
+}
+
+#[test]
+fn build_launch_bundle_profile_model_beats_settings_default_model() {
+    routing::build_launch_bundle_profile_model_beats_settings_default_model();
+}
+
+#[test]
 fn build_launch_bundle_invalid_settings_default_harness_warns_and_falls_back_to_default() {
     routing::build_launch_bundle_invalid_settings_default_harness_warns_and_falls_back_to_default();
 }

--- a/tests/launch_bundle/routing.rs
+++ b/tests/launch_bundle/routing.rs
@@ -305,6 +305,106 @@ Review code changes."#;
     );
 }
 
+pub(crate) fn build_launch_bundle_uses_settings_default_model_when_profile_and_cli_missing() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = install_fake_harnesses(&temp, &["codex"]);
+    let agent_content = r#"---
+name: reviewer
+---
+Review code changes."#;
+
+    let extra_toml = r#"[settings]
+default_model = "gpt-5.4-mini""#;
+
+    let (server, project_root) =
+        setup_bundle_project(&temp, "bundle-source", agent_content, &[], extra_toml);
+
+    let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
+    cmd.args(["build", "launch-bundle", "--agent", "reviewer"]);
+    cmd.env("PATH", replace_path_with(&bin_dir));
+
+    let output = cmd.assert().success().get_output().clone();
+    let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert_eq!(
+        bundle["routing"]["model_token"].as_str(),
+        Some("gpt-5.4-mini")
+    );
+    assert_eq!(
+        bundle["provenance"]["model_source"].as_str(),
+        Some("project")
+    );
+    assert_eq!(bundle["routing"]["harness"].as_str(), Some("codex"));
+    assert_eq!(
+        bundle["provenance"]["harness_source"].as_str(),
+        Some("provider")
+    );
+}
+
+pub(crate) fn build_launch_bundle_cli_model_override_beats_settings_default_model() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = install_fake_harnesses(&temp, &["codex"]);
+    let agent_content = r#"---
+name: reviewer
+---
+Review code changes."#;
+
+    let extra_toml = r#"[settings]
+default_model = "gpt-5.4-mini""#;
+
+    let (server, project_root) =
+        setup_bundle_project(&temp, "bundle-source", agent_content, &[], extra_toml);
+
+    let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
+    cmd.args([
+        "build",
+        "launch-bundle",
+        "--agent",
+        "reviewer",
+        "--model",
+        "gpt-5",
+    ]);
+    cmd.env("PATH", replace_path_with(&bin_dir));
+
+    let output = cmd.assert().success().get_output().clone();
+    let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert_eq!(bundle["routing"]["model_token"].as_str(), Some("gpt-5"));
+    assert_eq!(bundle["provenance"]["model_source"].as_str(), Some("cli"));
+}
+
+pub(crate) fn build_launch_bundle_profile_model_beats_settings_default_model() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = install_fake_harnesses(&temp, &["claude"]);
+    let agent_content = r#"---
+name: reviewer
+model: claude-opus-4-6
+---
+Review code changes."#;
+
+    let extra_toml = r#"[settings]
+default_model = "gpt-5.4-mini""#;
+
+    let (server, project_root) =
+        setup_bundle_project(&temp, "bundle-source", agent_content, &[], extra_toml);
+
+    let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
+    cmd.args(["build", "launch-bundle", "--agent", "reviewer"]);
+    cmd.env("PATH", replace_path_with(&bin_dir));
+
+    let output = cmd.assert().success().get_output().clone();
+    let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert_eq!(
+        bundle["routing"]["model_token"].as_str(),
+        Some("claude-opus-4-6")
+    );
+    assert_eq!(
+        bundle["provenance"]["model_source"].as_str(),
+        Some("profile")
+    );
+}
+
 pub(crate) fn build_launch_bundle_invalid_settings_default_harness_warns_and_falls_back_to_default()
 {
     let temp = TempDir::new().unwrap();

--- a/tests/launch_bundle/schema.rs
+++ b/tests/launch_bundle/schema.rs
@@ -295,7 +295,8 @@ Review code changes."#;
     cmd.assert()
         .failure()
         .code(2)
-        .stderr(predicates::str::contains("requires a model"));
+        .stderr(predicates::str::contains("requires a model"))
+        .stderr(predicates::str::contains("settings.default_model"));
 }
 
 pub(crate) fn build_launch_bundle_ad_hoc_requires_model() {


### PR DESCRIPTION
## Why

Meridian is deleting its duplicated `[defaults].model` project config. Mars needs the project-wide default model source so launch-bundle routing can stay centralized in mars.

## Goal

Projects can set `[settings].default_model` in `mars.toml`, and `mars build launch-bundle --agent ...` resolves models with precedence `--model > profile model > settings.default_model > error`.

## Summary

Added `[settings].default_model` to the config schema and launch-bundle model resolver. Project defaults now flow through policy resolution, produce `provenance.model_source = "project"`, and preserve existing CLI/profile precedence.

## Work Item

settings-default-model

## Changes

- Added `Settings.default_model` with serde defaults, default construction, save-roundtrip guard, and config parse/roundtrip coverage.
- Plumbed the project default model through launch-bundle policy config into model resolution.
- Updated missing-model error text to mention `settings.default_model`.
- Added launch-bundle tests for project default selection, CLI/profile precedence over project default, and missing-model diagnostics.
- Updated CLI/config docs and CHANGELOG `[Unreleased]`.

## Verification

- `cargo fmt`
- `cargo test`
- Smoke tester verified focused launch-bundle CLI behavior for project/CLI/profile/error cases.
- QA audit strengthened the project-default test to assert downstream harness routing.
- Pre-push hook passed:
  - `cargo fmt --check`
  - `cargo clippy --all-targets -- -D warnings`
  - `cargo test -- --skip cli::version::tests::run`
  - `cargo build --release`

## Knowledge Updates

- Updated `docs/config/mars-toml.md` for `[settings].default_model`.
- Updated `docs/cli/commands.md` for launch-bundle model precedence and `model_source = "project"`.

## Spawn Trace

- p1811 coder — implemented default_model schema, resolver, tests, docs, changelog.
- p1813 reviewer — correctness/regression review.
- p1814 reviewer — structural review.
- p1815 simplify-reviewer — simplification audit.
- p1816 smoke-tester — runtime verification of model precedence/error behavior.
- p1823 coder — docs follow-up for CLI precedence wording.
- p1824 qa-lead — test-suite audit and strengthened routing assertion.
