### PR TITLE
Pivot profile harness when not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Launch-bundle profile harness now pivots through candidate routing when profile harness missing on host; explicit CLI/alias harness still fails unavailable instead of silently pivoting.
+
 ## [0.4.8-rc.5] - 2026-05-20
 
 ### Added

--- a/src/build/policy/harness.rs
+++ b/src/build/policy/harness.rs
@@ -10,6 +10,7 @@ use crate::models::probes::OpenCodeProbeResult;
 use crate::models::probes::PiProbeResult;
 use crate::routing::{self, RouteConfidence, RoutingInput};
 
+#[derive(Debug)]
 pub(super) struct HarnessResolution {
     pub(super) harness: String,
     pub(super) source: &'static str,
@@ -45,50 +46,20 @@ pub(super) fn resolve_harness(
         routing::normalize_config_default_harness(evidence.config_default_harness, &mut warnings);
     let model_from_cli = input.model_override.is_some();
     let mut selected_harness_order_position = None;
-    let (harness, harness_source, route_confidence, candidates_tried) =
-        if let Some(harness) = input.harness_override {
-            (
-                harness.to_string(),
-                "cli",
-                RouteConfidence::Explicit,
-                vec![harness.to_string()],
-            )
-        } else if model_from_cli {
-            if let Some(harness) = alias_harness {
-                (
-                    harness.to_string(),
-                    "alias",
-                    RouteConfidence::Passthrough,
-                    Vec::new(),
-                )
-            } else {
-                let trace = routing::evaluate_candidates(&RoutingInput {
-                    model_id: evidence.model_id,
-                    provider: evidence.provider,
-                    settings_harness_order: evidence.harness_order,
-                    config_default_harness: normalized_config_default_harness.as_deref(),
-                    installed_harnesses: evidence.installed_harnesses,
-                    linked_harnesses: evidence.linked_harnesses,
-                    opencode_probe_result: evidence.opencode_probe_result,
-                    pi_probe_result: evidence.pi_probe_result,
-                });
-                selected_harness_order_position = trace.harness_order_position;
-                warnings.extend(trace.diagnostics);
-                (
-                    trace.harness,
-                    trace.source.label(),
-                    trace.confidence,
-                    trace.candidates_tried,
-                )
-            }
-        } else if let Some(harness) = profile_harness {
-            (
-                harness.to_string(),
-                "profile",
-                RouteConfidence::Passthrough,
-                Vec::new(),
-            )
-        } else if let Some(harness) = alias_harness {
+    let mut fixed_harness_selection = None;
+    let (harness, harness_source, route_confidence, candidates_tried) = if let Some(harness) =
+        input.harness_override
+    {
+        fixed_harness_selection = Some(("cli", harness));
+        (
+            harness.to_string(),
+            "cli",
+            RouteConfidence::Explicit,
+            vec![harness.to_string()],
+        )
+    } else if model_from_cli {
+        if let Some(harness) = alias_harness {
+            fixed_harness_selection = Some(("alias", harness));
             (
                 harness.to_string(),
                 "alias",
@@ -96,16 +67,8 @@ pub(super) fn resolve_harness(
                 Vec::new(),
             )
         } else {
-            let trace = routing::evaluate_candidates(&RoutingInput {
-                model_id: evidence.model_id,
-                provider: evidence.provider,
-                settings_harness_order: evidence.harness_order,
-                config_default_harness: normalized_config_default_harness.as_deref(),
-                installed_harnesses: evidence.installed_harnesses,
-                linked_harnesses: evidence.linked_harnesses,
-                opencode_probe_result: evidence.opencode_probe_result,
-                pi_probe_result: evidence.pi_probe_result,
-            });
+            let trace =
+                evaluate_candidates(&evidence, normalized_config_default_harness.as_deref());
             selected_harness_order_position = trace.harness_order_position;
             warnings.extend(trace.diagnostics);
             (
@@ -114,7 +77,58 @@ pub(super) fn resolve_harness(
                 trace.confidence,
                 trace.candidates_tried,
             )
-        };
+        }
+    } else if let Some(harness) = profile_harness {
+        if evidence.installed_harnesses.contains(harness) {
+            (
+                harness.to_string(),
+                "profile",
+                RouteConfidence::Passthrough,
+                Vec::new(),
+            )
+        } else {
+            warnings.push(format!(
+                "profile harness '{harness}' not installed; pivoting via model-policies"
+            ));
+            let trace =
+                evaluate_candidates(&evidence, normalized_config_default_harness.as_deref());
+            selected_harness_order_position = trace.harness_order_position;
+            warnings.extend(trace.diagnostics);
+
+            if !evidence.installed_harnesses.contains(&trace.harness) {
+                return Err(unavailable_profile_pivot_error(
+                    harness,
+                    &trace.harness,
+                    evidence.installed_harnesses,
+                ));
+            }
+
+            (
+                trace.harness,
+                trace.source.label(),
+                trace.confidence,
+                trace.candidates_tried,
+            )
+        }
+    } else if let Some(harness) = alias_harness {
+        fixed_harness_selection = Some(("alias", harness));
+        (
+            harness.to_string(),
+            "alias",
+            RouteConfidence::Passthrough,
+            Vec::new(),
+        )
+    } else {
+        let trace = evaluate_candidates(&evidence, normalized_config_default_harness.as_deref());
+        selected_harness_order_position = trace.harness_order_position;
+        warnings.extend(trace.diagnostics);
+        (
+            trace.harness,
+            trace.source.label(),
+            trace.confidence,
+            trace.candidates_tried,
+        )
+    };
 
     let resolved_harness = HarnessKind::from_str(&harness).ok_or_else(|| {
         MarsError::Config(ConfigError::Invalid {
@@ -123,6 +137,16 @@ pub(super) fn resolve_harness(
             ),
         })
     })?;
+
+    if let Some((source, requested_harness)) = fixed_harness_selection
+        && !evidence.installed_harnesses.contains(requested_harness)
+    {
+        return Err(unavailable_fixed_harness_error(
+            source,
+            requested_harness,
+            evidence.installed_harnesses,
+        ));
+    }
 
     Ok(HarnessResolution {
         is_experimental: harness == "cursor",
@@ -134,6 +158,62 @@ pub(super) fn resolve_harness(
         candidates_tried,
         warnings,
     })
+}
+
+fn evaluate_candidates(
+    evidence: &HarnessEvidence<'_>,
+    normalized_config_default_harness: Option<&str>,
+) -> routing::RoutingTrace {
+    routing::evaluate_candidates(&RoutingInput {
+        model_id: evidence.model_id,
+        provider: evidence.provider,
+        settings_harness_order: evidence.harness_order,
+        config_default_harness: normalized_config_default_harness,
+        installed_harnesses: evidence.installed_harnesses,
+        linked_harnesses: evidence.linked_harnesses,
+        opencode_probe_result: evidence.opencode_probe_result,
+        pi_probe_result: evidence.pi_probe_result,
+    })
+}
+
+fn unavailable_profile_pivot_error(
+    requested_harness: &str,
+    selected_harness: &str,
+    installed_harnesses: &HashSet<String>,
+) -> MarsError {
+    MarsError::Config(ConfigError::Invalid {
+        message: format!(
+            "profile harness `{requested_harness}` is not installed and no installed fallback harness is available (selected `{selected_harness}`); installed harnesses: {}",
+            format_installed_harnesses(installed_harnesses)
+        ),
+    })
+}
+
+fn unavailable_fixed_harness_error(
+    source: &str,
+    requested_harness: &str,
+    installed_harnesses: &HashSet<String>,
+) -> MarsError {
+    MarsError::Config(ConfigError::Invalid {
+        message: format!(
+            "{source} harness `{requested_harness}` is not installed; installed harnesses: {}",
+            format_installed_harnesses(installed_harnesses)
+        ),
+    })
+}
+
+fn format_installed_harnesses(installed_harnesses: &HashSet<String>) -> String {
+    let mut names = installed_harnesses
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    names.sort_unstable();
+
+    if names.is_empty() {
+        "(none)".to_string()
+    } else {
+        names.join(", ")
+    }
 }
 
 pub(super) fn harness_kind_to_str(harness: &HarnessKind) -> &'static str {
@@ -150,6 +230,7 @@ pub(super) fn harness_kind_to_str(harness: &HarnessKind) -> &'static str {
 mod tests {
     use super::*;
 
+    use std::collections::HashMap;
     use std::path::Path;
 
     use crate::compiler::agents::AgentProfile;
@@ -232,6 +313,16 @@ mod tests {
         }
     }
 
+    fn positive_opencode_probe() -> OpenCodeProbeResult {
+        OpenCodeProbeResult {
+            providers: HashMap::from([("openai".to_string(), true)]),
+            model_slugs: vec!["openai/gpt-5".to_string()],
+            provider_probe_success: true,
+            model_probe_success: true,
+            error: None,
+        }
+    }
+
     #[test]
     fn cli_override_is_explicit_and_skips_candidate_eval() {
         let installed = installed(&["codex", "pi"]);
@@ -288,6 +379,68 @@ mod tests {
         assert_eq!(resolution.source, "profile");
         assert_eq!(resolution.route_confidence, RouteConfidence::Passthrough);
         assert!(resolution.candidates_tried.is_empty());
+    }
+
+    #[test]
+    fn unavailable_profile_harness_pivots_to_candidate_evaluation() {
+        let installed = installed(&["opencode"]);
+        let profile = profile(Some(HarnessKind::Claude));
+        let input = policy_input(&profile, None, None);
+        let opencode_probe = positive_opencode_probe();
+        let evidence = HarnessEvidence {
+            model_id: "gpt-5",
+            provider: Some("openai"),
+            config_default_harness: None,
+            harness_order: None,
+            installed_harnesses: &installed,
+            linked_harnesses: None,
+            opencode_probe_result: Some(&opencode_probe),
+            pi_probe_result: None,
+        };
+
+        let resolution =
+            resolve_harness(&input, None, evidence).expect("harness should pivot to opencode");
+
+        assert_eq!(resolution.harness, "opencode");
+        assert_eq!(resolution.source, "provider");
+        assert_eq!(resolution.route_confidence, RouteConfidence::Likely);
+        assert_eq!(resolution.candidates_tried, vec!["codex", "pi", "opencode"]);
+        assert!(resolution.warnings.iter().any(|warning| {
+            warning == "profile harness 'claude' not installed; pivoting via model-policies"
+        }));
+    }
+
+    #[test]
+    fn unavailable_profile_harness_errors_when_no_installed_fallback_is_available() {
+        let installed = installed(&["opencode"]);
+        let profile = profile(Some(HarnessKind::Claude));
+        let input = policy_input(&profile, None, None);
+
+        let error = resolve_harness(&input, None, evidence(None, None, &installed))
+            .expect_err("unavailable profile harness should fail without an installed fallback");
+        let message = error.to_string();
+
+        assert!(message.contains("profile harness `claude` is not installed"));
+        assert!(message.contains("selected `claude`"));
+        assert!(message.contains("installed harnesses: opencode"));
+    }
+
+    #[test]
+    fn unavailable_cli_harness_errors_without_pivoting() {
+        let installed = installed(&["codex", "opencode"]);
+        let profile = profile(Some(HarnessKind::Claude));
+        let input = policy_input(&profile, None, Some("claude"));
+
+        let error = resolve_harness(
+            &input,
+            Some(&model_alias(Some("codex"))),
+            evidence(None, None, &installed),
+        )
+        .expect_err("unavailable explicit harness should fail");
+        let message = error.to_string();
+
+        assert!(message.contains("cli harness `claude` is not installed"));
+        assert!(message.contains("installed harnesses: codex, opencode"));
     }
 
     #[test]

--- a/tests/launch_bundle.rs
+++ b/tests/launch_bundle.rs
@@ -279,6 +279,21 @@ fn build_launch_bundle_profile_harness_beats_settings_harness_order() {
 }
 
 #[test]
+fn build_launch_bundle_unavailable_profile_harness_pivots_to_installed_candidate() {
+    routing::build_launch_bundle_unavailable_profile_harness_pivots_to_installed_candidate();
+}
+
+#[test]
+fn build_launch_bundle_unavailable_profile_harness_errors_without_installed_fallback() {
+    routing::build_launch_bundle_unavailable_profile_harness_errors_without_installed_fallback();
+}
+
+#[test]
+fn build_launch_bundle_unavailable_cli_harness_errors_without_pivoting() {
+    routing::build_launch_bundle_unavailable_cli_harness_errors_without_pivoting();
+}
+
+#[test]
 fn build_launch_bundle_alias_harness_beats_settings_harness_order() {
     routing::build_launch_bundle_alias_harness_beats_settings_harness_order();
 }

--- a/tests/launch_bundle/routing.rs
+++ b/tests/launch_bundle/routing.rs
@@ -557,7 +557,7 @@ default_harness = "claude""#;
 
 pub(crate) fn build_launch_bundle_cli_harness_override_beats_settings_harness_order() {
     let temp = TempDir::new().unwrap();
-    let bin_dir = install_fake_harnesses(&temp, &["pi", "opencode"]);
+    let bin_dir = install_fake_harnesses(&temp, &["pi", "opencode", "codex"]);
     let agent_content = r#"---
 name: reviewer
 model: gpt-5
@@ -648,6 +648,143 @@ harness_order = ["codex", "opencode"]"#;
         Some("passthrough")
     );
     assert!(bundle["provenance"]["harness_order_position"].is_null());
+}
+
+pub(crate) fn build_launch_bundle_unavailable_profile_harness_pivots_to_installed_candidate() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = install_fake_harnesses(&temp, &["codex", "opencode"]);
+    let agent_content = r#"---
+name: reviewer
+model: gpt55
+harness: claude
+model-policies:
+  - match:
+      alias: gpt55
+    override:
+      harness: opencode
+---
+Review code changes."#;
+
+    let extra_toml = r#"[settings]
+harness_order = ["opencode", "codex"]
+
+[models.gpt55]
+model = "gpt-5.5"
+provider = "openai""#;
+
+    let cache_root = temp.path().join("mars-cache");
+    write_opencode_probe_cache(
+        &cache_root,
+        now_unix_secs(),
+        json!({
+            "providers": { "openai": true },
+            "model_slugs": ["openai/gpt-5.5"],
+            "provider_probe_success": true,
+            "model_probe_success": true,
+            "error": null
+        }),
+    );
+
+    let (server, project_root) =
+        setup_bundle_project(&temp, "bundle-source", agent_content, &[], extra_toml);
+
+    let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
+    cmd.args(["build", "launch-bundle", "--agent", "reviewer"]);
+    cmd.env("PATH", replace_path_with(&bin_dir));
+    cmd.env("MARS_CACHE_DIR", &cache_root);
+    cmd.env("MARS_PROBE_CACHE_TTL_SECS", "60");
+
+    let output = cmd.assert().success().get_output().clone();
+    let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert_eq!(bundle["routing"]["harness"].as_str(), Some("opencode"));
+    assert_eq!(
+        bundle["provenance"]["harness_source"].as_str(),
+        Some("config-order")
+    );
+    assert_eq!(
+        bundle["provenance"]["harness_order_position"].as_str(),
+        Some("0")
+    );
+    assert_eq!(
+        bundle["routing"]["route_confidence"].as_str(),
+        Some("likely")
+    );
+    assert_eq!(
+        bundle["provenance"]["route_confidence"].as_str(),
+        Some("likely")
+    );
+    assert_eq!(
+        bundle["provenance"]["candidates_tried"].as_str(),
+        Some("opencode")
+    );
+
+    let warnings = bundle["warnings"]
+        .as_array()
+        .expect("warnings should be an array");
+    assert!(warnings.iter().any(|warning| {
+        warning.as_str().unwrap_or_default()
+            == "profile harness 'claude' not installed; pivoting via model-policies"
+    }));
+}
+
+pub(crate) fn build_launch_bundle_unavailable_profile_harness_errors_without_installed_fallback() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = install_fake_harnesses(&temp, &["codex", "opencode"]);
+    let agent_content = r#"---
+name: reviewer
+model: claude-opus-4-6
+harness: claude
+---
+Review code changes."#;
+
+    let (server, project_root) =
+        setup_bundle_project(&temp, "bundle-source", agent_content, &[], "");
+
+    let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
+    cmd.args(["build", "launch-bundle", "--agent", "reviewer"]);
+    cmd.env("PATH", replace_path_with(&bin_dir));
+    cmd.env("MARS_OFFLINE", "1");
+
+    let output = cmd.assert().failure().code(2).get_output().clone();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+
+    assert!(stderr.contains("profile harness `claude` is not installed"));
+    assert!(stderr.contains("installed harnesses: codex, opencode"));
+}
+
+pub(crate) fn build_launch_bundle_unavailable_cli_harness_errors_without_pivoting() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = install_fake_harnesses(&temp, &["codex", "opencode"]);
+    let agent_content = r#"---
+name: reviewer
+model: claude-opus-4-6
+---
+Review code changes."#;
+
+    let (server, project_root) =
+        setup_bundle_project(&temp, "bundle-source", agent_content, &[], "");
+
+    let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
+    cmd.args([
+        "build",
+        "launch-bundle",
+        "--agent",
+        "reviewer",
+        "--harness",
+        "claude",
+    ]);
+    cmd.env("PATH", replace_path_with(&bin_dir));
+
+    let output = cmd.assert().failure().code(2).get_output().clone();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+
+    assert!(stderr.contains("cli harness `claude` is not installed"));
+    assert!(stderr.contains("installed harnesses: codex, opencode"));
+    assert!(
+        !stderr.contains("pivoting via model-policies"),
+        "explicit CLI harness must not auto-pivot: {stderr}"
+    );
 }
 
 pub(crate) fn build_launch_bundle_alias_harness_beats_settings_harness_order() {
@@ -1619,6 +1756,7 @@ default_harness = "Pi""#;
 
 pub(crate) fn build_launch_bundle_synthesizes_opencode_model_when_cache_missing() {
     let temp = TempDir::new().unwrap();
+    let bin_dir = install_fake_harnesses(&temp, &["opencode"]);
     let agent_content = r#"---
 name: reviewer
 model: gpt5
@@ -1639,6 +1777,7 @@ model = "gpt-5""#;
         "--harness",
         "opencode",
     ]);
+    cmd.env("PATH", replace_path_with(&bin_dir));
 
     let output = cmd.assert().success().get_output().clone();
     let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
@@ -1667,6 +1806,7 @@ model = "gpt-5""#;
 
 pub(crate) fn build_launch_bundle_explicit_unknown_harness_model_path_passes_through_quietly() {
     let temp = TempDir::new().unwrap();
+    let bin_dir = install_fake_harnesses(&temp, &["opencode"]);
     let agent_content = r#"---
 name: reviewer
 model: unknown-model-token
@@ -1685,6 +1825,7 @@ Review code changes."#;
         "--harness",
         "opencode",
     ]);
+    cmd.env("PATH", replace_path_with(&bin_dir));
 
     let output = cmd.assert().success().get_output().clone();
     let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();


### PR DESCRIPTION
## Summary
- Pivot launch-bundle profile harness resolution through candidate routing when the profile harness is not installed.
- Keep fixed CLI/alias harness selections non-pivoting and fail clearly when the requested harness is not installed.
- Add unit and launch-bundle integration coverage for pivot, no-fallback error, and explicit-harness error behavior.

## Why
Meridian bundle consumers were receiving profile-declared harnesses that were not available on the host, causing downstream launch failures on partial installs.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo build --release`
- Push preflight: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test -- --skip cli::version::tests::run`, `cargo build --release`
