### PR TITLE
Add agent overlay schema and settings model-policies to bundle resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Added `[agents.<name>]` launch-bundle overlay schema in `mars.toml` / `mars.local.toml` with routing + execution-policy fields and per-overlay `model-policies`.
+- Added `[[settings.model-policies]]` project-level policy schema, shared with profile + overlay via one `ModelPolicyRule` type.
+- Added launch-bundle provenance key `matched_policy_rule` (`overlay:<idx>`, `profile:<idx>`, `settings:<idx>`).
+
+### Changed
+- Launch-bundle policy resolution now composes model-policies across overlay → profile → settings (first match wins) and emits new provenance sources: `overlay`, `overlay-model-policy`, `settings-model-policy`.
+- Launch-bundle model resolution now honors `[agents.<name>].model` before profile/default model.
+- `mars.local.toml` overlay merge now does name-keyed replacement for `[agents.<name>]`; local `settings.model-policies` replaces base list.
+
 ## [0.4.8-rc.6] - 2026-05-21
 
 ### Changed

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -76,6 +76,7 @@ pub fn build_launch_bundle(
 
     let policy = resolve_policy(PolicyInput {
         project_root: &ctx.project_root,
+        agent: request.agent.as_deref(),
         profile: &profile,
         model_override: request.model.as_deref(),
         config_default_model: None,

--- a/src/build/policy/config.rs
+++ b/src/build/policy/config.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use indexmap::IndexMap;
 
+use crate::config::{AgentOverlay, ModelPolicyRule};
 use crate::error::{ConfigError, MarsError};
 use crate::models::{self, ModelAlias};
 
@@ -11,6 +12,8 @@ pub(super) struct PolicyResolutionConfig {
     pub(super) default_model: Option<String>,
     pub(super) harness_order: Option<Vec<String>>,
     pub(super) linked_harnesses: Vec<String>,
+    pub(super) agents: IndexMap<String, AgentOverlay>,
+    pub(super) settings_model_policies: Vec<ModelPolicyRule>,
 }
 
 pub(super) fn load_policy_resolution_config(
@@ -21,6 +24,8 @@ pub(super) fn load_policy_resolution_config(
     let mut default_model = None;
     let mut harness_order = None;
     let mut linked_harnesses = Vec::new();
+    let mut agents = IndexMap::new();
+    let mut settings_model_policies = Vec::new();
 
     let merged_path = project_root.join(".mars").join("models-merged.json");
     if let Ok(content) = std::fs::read_to_string(&merged_path)
@@ -37,9 +42,14 @@ pub(super) fn load_policy_resolution_config(
             default_model = config.settings.default_model.clone();
             harness_order = config.settings.harness_order.clone();
             linked_harnesses = config.settings.linked_harnesses();
+            agents = config.agents.clone();
             for (name, alias) in &config.models {
                 merged.insert(name.clone(), alias.clone());
             }
+            let local = crate::config::load_local(project_root)?;
+            agents = crate::config::merged_agent_overlays(&agents, &local);
+            settings_model_policies =
+                crate::config::merged_settings_model_policies(&config.settings, &local);
         }
         Err(MarsError::Config(ConfigError::NotFound { .. })) => {}
         Err(err) => return Err(err),
@@ -51,5 +61,7 @@ pub(super) fn load_policy_resolution_config(
         default_model,
         harness_order,
         linked_harnesses,
+        agents,
+        settings_model_policies,
     })
 }

--- a/src/build/policy/execution.rs
+++ b/src/build/policy/execution.rs
@@ -1,23 +1,18 @@
 use crate::build::policy::{
-    MatchedModelPolicy, PolicyInput, PolicyLayer, policy_override_string, policy_override_u8,
-    policy_override_u32,
+    MatchedModelPolicy, PolicyInput, PolicySource, ResolvedField, matched_policy_string_override,
+    matched_policy_u8_override, matched_policy_u32_override,
 };
 use crate::compiler::agents::{ApprovalMode, EffortLevel, OverrideFields, SandboxMode};
 use crate::config::AgentOverlay;
 use crate::models::ModelAlias;
 
 pub(super) struct ExecutionResolution {
-    pub(super) effort: Option<String>,
-    pub(super) approval: Option<String>,
-    pub(super) sandbox: Option<String>,
-    pub(super) autocompact: Option<u32>,
-    pub(super) autocompact_pct: Option<u8>,
+    pub(super) effort: ResolvedField<Option<String>>,
+    pub(super) approval: ResolvedField<Option<String>>,
+    pub(super) sandbox: ResolvedField<Option<String>>,
+    pub(super) autocompact: ResolvedField<Option<u32>>,
+    pub(super) autocompact_pct: ResolvedField<Option<u8>>,
     pub(super) native_config: Option<serde_json::Map<String, serde_json::Value>>,
-    pub(super) effort_source: String,
-    pub(super) approval_source: String,
-    pub(super) sandbox_source: String,
-    pub(super) autocompact_source: String,
-    pub(super) autocompact_pct_source: String,
 }
 
 pub(super) fn resolve_execution_policy(
@@ -31,25 +26,23 @@ pub(super) fn resolve_execution_policy(
         .and_then(|fields| fields.native_config.clone())
         .filter(|map| !map.is_empty());
 
-    let (effort, effort_source) = resolve_effort(
+    let effort = resolve_effort(
         input,
         alias,
         overlay,
         matched_policy,
         matched_harness_override,
     );
-    let (approval, approval_source) =
-        resolve_approval(input, overlay, matched_policy, matched_harness_override);
-    let (sandbox, sandbox_source) =
-        resolve_sandbox(input, overlay, matched_policy, matched_harness_override);
-    let (autocompact, autocompact_source) = resolve_autocompact(
+    let approval = resolve_approval(input, overlay, matched_policy, matched_harness_override);
+    let sandbox = resolve_sandbox(input, overlay, matched_policy, matched_harness_override);
+    let autocompact = resolve_autocompact(
         input,
         alias,
         overlay,
         matched_policy,
         matched_harness_override,
     );
-    let (autocompact_pct, autocompact_pct_source) = resolve_autocompact_pct(
+    let autocompact_pct = resolve_autocompact_pct(
         input,
         alias,
         overlay,
@@ -64,12 +57,53 @@ pub(super) fn resolve_execution_policy(
         autocompact,
         autocompact_pct,
         native_config,
-        effort_source,
-        approval_source,
-        sandbox_source,
-        autocompact_source,
-        autocompact_pct_source,
     }
+}
+
+fn resolved_field<T>(value: Option<T>, source: PolicySource) -> ResolvedField<Option<T>> {
+    ResolvedField {
+        value,
+        source,
+        matched_rule: None,
+    }
+}
+
+fn resolved_policy_field<T>(decision: ResolvedField<T>) -> ResolvedField<Option<T>> {
+    ResolvedField {
+        value: Some(decision.value),
+        source: decision.source,
+        matched_rule: decision.matched_rule,
+    }
+}
+
+fn policy_string_override_by_source(
+    matched_policy: Option<&MatchedModelPolicy>,
+    key: &str,
+    source: PolicySource,
+) -> Option<ResolvedField<Option<String>>> {
+    matched_policy_string_override(matched_policy, key)
+        .filter(|decision| decision.source == source)
+        .map(resolved_policy_field)
+}
+
+fn policy_u32_override_by_source(
+    matched_policy: Option<&MatchedModelPolicy>,
+    key: &str,
+    source: PolicySource,
+) -> Option<ResolvedField<Option<u32>>> {
+    matched_policy_u32_override(matched_policy, key)
+        .filter(|decision| decision.source == source)
+        .map(resolved_policy_field)
+}
+
+fn policy_u8_override_by_source(
+    matched_policy: Option<&MatchedModelPolicy>,
+    key: &str,
+    source: PolicySource,
+) -> Option<ResolvedField<Option<u8>>> {
+    matched_policy_u8_override(matched_policy, key)
+        .filter(|decision| decision.source == source)
+        .map(resolved_policy_field)
 }
 
 fn resolve_effort(
@@ -78,44 +112,46 @@ fn resolve_effort(
     overlay: Option<&AgentOverlay>,
     matched_policy: Option<&MatchedModelPolicy>,
     matched_harness_override: Option<&OverrideFields>,
-) -> (Option<String>, String) {
+) -> ResolvedField<Option<String>> {
     if let Some(effort) = input.effort_override {
-        return (Some(effort.to_string()), "cli".to_string());
+        return resolved_field(Some(effort.to_string()), PolicySource::Cli);
     }
     if let Some(effort) = matched_harness_override.and_then(|entry| entry.effort.as_ref()) {
-        return (
+        return resolved_field(
             Some(effort_level_to_str(effort).to_string()),
-            "profile-harness-override".to_string(),
+            PolicySource::ProfileHarnessOverride,
         );
     }
     if let Some(overlay_effort) = overlay.and_then(|entry| entry.effort.as_deref()) {
-        return (Some(overlay_effort.to_string()), "overlay".to_string());
+        return resolved_field(Some(overlay_effort.to_string()), PolicySource::Overlay);
     }
-    if let Some((value, source)) =
-        policy_string_override_by_layer(matched_policy, "effort", PolicyLayer::Overlay)
+    if let Some(decision) =
+        policy_string_override_by_source(matched_policy, "effort", PolicySource::OverlayModelPolicy)
     {
-        return (Some(value), source.to_string());
+        return decision;
     }
     if let Some(effort) = input.profile.effort.as_ref() {
-        return (
+        return resolved_field(
             Some(effort_level_to_str(effort).to_string()),
-            "profile".to_string(),
+            PolicySource::Profile,
         );
     }
-    if let Some((value, source)) =
-        policy_string_override_by_layer(matched_policy, "effort", PolicyLayer::Profile)
+    if let Some(decision) =
+        policy_string_override_by_source(matched_policy, "effort", PolicySource::ProfileModelPolicy)
     {
-        return (Some(value), source.to_string());
+        return decision;
     }
-    if let Some((value, source)) =
-        policy_string_override_by_layer(matched_policy, "effort", PolicyLayer::Settings)
-    {
-        return (Some(value), source.to_string());
+    if let Some(decision) = policy_string_override_by_source(
+        matched_policy,
+        "effort",
+        PolicySource::SettingsModelPolicy,
+    ) {
+        return decision;
     }
     if let Some(effort) = alias.and_then(|entry| entry.default_effort.clone()) {
-        return (Some(effort), "alias".to_string());
+        return resolved_field(Some(effort), PolicySource::Alias);
     }
-    (None, "unset".to_string())
+    resolved_field(None, PolicySource::Unset)
 }
 
 fn resolve_approval(
@@ -123,41 +159,47 @@ fn resolve_approval(
     overlay: Option<&AgentOverlay>,
     matched_policy: Option<&MatchedModelPolicy>,
     matched_harness_override: Option<&OverrideFields>,
-) -> (Option<String>, String) {
+) -> ResolvedField<Option<String>> {
     if let Some(approval) = input.approval_override {
-        return (Some(approval.to_string()), "cli".to_string());
+        return resolved_field(Some(approval.to_string()), PolicySource::Cli);
     }
     if let Some(approval) = matched_harness_override.and_then(|entry| entry.approval.as_ref()) {
-        return (
+        return resolved_field(
             Some(approval_mode_to_str(approval).to_string()),
-            "profile-harness-override".to_string(),
+            PolicySource::ProfileHarnessOverride,
         );
     }
     if let Some(overlay_approval) = overlay.and_then(|entry| entry.approval.as_deref()) {
-        return (Some(overlay_approval.to_string()), "overlay".to_string());
+        return resolved_field(Some(overlay_approval.to_string()), PolicySource::Overlay);
     }
-    if let Some((value, source)) =
-        policy_string_override_by_layer(matched_policy, "approval", PolicyLayer::Overlay)
-    {
-        return (Some(value), source.to_string());
+    if let Some(decision) = policy_string_override_by_source(
+        matched_policy,
+        "approval",
+        PolicySource::OverlayModelPolicy,
+    ) {
+        return decision;
     }
     if let Some(approval) = input.profile.approval.as_ref() {
-        return (
+        return resolved_field(
             Some(approval_mode_to_str(approval).to_string()),
-            "profile".to_string(),
+            PolicySource::Profile,
         );
     }
-    if let Some((value, source)) =
-        policy_string_override_by_layer(matched_policy, "approval", PolicyLayer::Profile)
-    {
-        return (Some(value), source.to_string());
+    if let Some(decision) = policy_string_override_by_source(
+        matched_policy,
+        "approval",
+        PolicySource::ProfileModelPolicy,
+    ) {
+        return decision;
     }
-    if let Some((value, source)) =
-        policy_string_override_by_layer(matched_policy, "approval", PolicyLayer::Settings)
-    {
-        return (Some(value), source.to_string());
+    if let Some(decision) = policy_string_override_by_source(
+        matched_policy,
+        "approval",
+        PolicySource::SettingsModelPolicy,
+    ) {
+        return decision;
     }
-    (None, "unset".to_string())
+    resolved_field(None, PolicySource::Unset)
 }
 
 fn resolve_sandbox(
@@ -165,41 +207,47 @@ fn resolve_sandbox(
     overlay: Option<&AgentOverlay>,
     matched_policy: Option<&MatchedModelPolicy>,
     matched_harness_override: Option<&OverrideFields>,
-) -> (Option<String>, String) {
+) -> ResolvedField<Option<String>> {
     if let Some(sandbox) = input.sandbox_override {
-        return (Some(sandbox.to_string()), "cli".to_string());
+        return resolved_field(Some(sandbox.to_string()), PolicySource::Cli);
     }
     if let Some(sandbox) = matched_harness_override.and_then(|entry| entry.sandbox.as_ref()) {
-        return (
+        return resolved_field(
             Some(sandbox_mode_to_str(sandbox).to_string()),
-            "profile-harness-override".to_string(),
+            PolicySource::ProfileHarnessOverride,
         );
     }
     if let Some(overlay_sandbox) = overlay.and_then(|entry| entry.sandbox.as_deref()) {
-        return (Some(overlay_sandbox.to_string()), "overlay".to_string());
+        return resolved_field(Some(overlay_sandbox.to_string()), PolicySource::Overlay);
     }
-    if let Some((value, source)) =
-        policy_string_override_by_layer(matched_policy, "sandbox", PolicyLayer::Overlay)
-    {
-        return (Some(value), source.to_string());
+    if let Some(decision) = policy_string_override_by_source(
+        matched_policy,
+        "sandbox",
+        PolicySource::OverlayModelPolicy,
+    ) {
+        return decision;
     }
     if let Some(sandbox) = input.profile.sandbox.as_ref() {
-        return (
+        return resolved_field(
             Some(sandbox_mode_to_str(sandbox).to_string()),
-            "profile".to_string(),
+            PolicySource::Profile,
         );
     }
-    if let Some((value, source)) =
-        policy_string_override_by_layer(matched_policy, "sandbox", PolicyLayer::Profile)
-    {
-        return (Some(value), source.to_string());
+    if let Some(decision) = policy_string_override_by_source(
+        matched_policy,
+        "sandbox",
+        PolicySource::ProfileModelPolicy,
+    ) {
+        return decision;
     }
-    if let Some((value, source)) =
-        policy_string_override_by_layer(matched_policy, "sandbox", PolicyLayer::Settings)
-    {
-        return (Some(value), source.to_string());
+    if let Some(decision) = policy_string_override_by_source(
+        matched_policy,
+        "sandbox",
+        PolicySource::SettingsModelPolicy,
+    ) {
+        return decision;
     }
-    (None, "unset".to_string())
+    resolved_field(None, PolicySource::Unset)
 }
 
 fn resolve_autocompact(
@@ -208,38 +256,44 @@ fn resolve_autocompact(
     overlay: Option<&AgentOverlay>,
     matched_policy: Option<&MatchedModelPolicy>,
     matched_harness_override: Option<&OverrideFields>,
-) -> (Option<u32>, String) {
+) -> ResolvedField<Option<u32>> {
     if let Some(autocompact) = matched_harness_override.and_then(|entry| entry.autocompact) {
-        return (Some(autocompact), "profile-harness-override".to_string());
+        return resolved_field(Some(autocompact), PolicySource::ProfileHarnessOverride);
     }
     if let Some(autocompact) = overlay
         .and_then(|entry| entry.autocompact)
         .and_then(|value| u32::try_from(value).ok())
     {
-        return (Some(autocompact), "overlay".to_string());
+        return resolved_field(Some(autocompact), PolicySource::Overlay);
     }
-    if let Some((value, source)) =
-        policy_u32_override_by_layer(matched_policy, "autocompact", PolicyLayer::Overlay)
-    {
-        return (Some(value), source.to_string());
+    if let Some(decision) = policy_u32_override_by_source(
+        matched_policy,
+        "autocompact",
+        PolicySource::OverlayModelPolicy,
+    ) {
+        return decision;
     }
     if let Some(autocompact) = input.profile.autocompact {
-        return (Some(autocompact), "profile".to_string());
+        return resolved_field(Some(autocompact), PolicySource::Profile);
     }
-    if let Some((value, source)) =
-        policy_u32_override_by_layer(matched_policy, "autocompact", PolicyLayer::Profile)
-    {
-        return (Some(value), source.to_string());
+    if let Some(decision) = policy_u32_override_by_source(
+        matched_policy,
+        "autocompact",
+        PolicySource::ProfileModelPolicy,
+    ) {
+        return decision;
     }
-    if let Some((value, source)) =
-        policy_u32_override_by_layer(matched_policy, "autocompact", PolicyLayer::Settings)
-    {
-        return (Some(value), source.to_string());
+    if let Some(decision) = policy_u32_override_by_source(
+        matched_policy,
+        "autocompact",
+        PolicySource::SettingsModelPolicy,
+    ) {
+        return decision;
     }
     if let Some(autocompact) = alias.and_then(|entry| entry.autocompact) {
-        return (Some(autocompact), "alias".to_string());
+        return resolved_field(Some(autocompact), PolicySource::Alias);
     }
-    (None, "unset".to_string())
+    resolved_field(None, PolicySource::Unset)
 }
 
 fn resolve_autocompact_pct(
@@ -248,43 +302,46 @@ fn resolve_autocompact_pct(
     overlay: Option<&AgentOverlay>,
     matched_policy: Option<&MatchedModelPolicy>,
     matched_harness_override: Option<&OverrideFields>,
-) -> (Option<u8>, String) {
+) -> ResolvedField<Option<u8>> {
     if let Some(autocompact_pct) = matched_harness_override.and_then(|entry| entry.autocompact_pct)
     {
-        return (
-            Some(autocompact_pct),
-            "profile-harness-override".to_string(),
-        );
+        return resolved_field(Some(autocompact_pct), PolicySource::ProfileHarnessOverride);
     }
     if let Some(autocompact_pct) = overlay
         .and_then(|entry| entry.autocompact_pct)
         .and_then(|value| u8::try_from(value).ok())
         .filter(|value| (1..=100).contains(value))
     {
-        return (Some(autocompact_pct), "overlay".to_string());
+        return resolved_field(Some(autocompact_pct), PolicySource::Overlay);
     }
-    if let Some((value, source)) =
-        policy_u8_override_by_layer(matched_policy, "autocompact_pct", PolicyLayer::Overlay)
-    {
-        return (Some(value), source.to_string());
+    if let Some(decision) = policy_u8_override_by_source(
+        matched_policy,
+        "autocompact_pct",
+        PolicySource::OverlayModelPolicy,
+    ) {
+        return decision;
     }
     if let Some(autocompact_pct) = input.profile.autocompact_pct {
-        return (Some(autocompact_pct), "profile".to_string());
+        return resolved_field(Some(autocompact_pct), PolicySource::Profile);
     }
-    if let Some((value, source)) =
-        policy_u8_override_by_layer(matched_policy, "autocompact_pct", PolicyLayer::Profile)
-    {
-        return (Some(value), source.to_string());
+    if let Some(decision) = policy_u8_override_by_source(
+        matched_policy,
+        "autocompact_pct",
+        PolicySource::ProfileModelPolicy,
+    ) {
+        return decision;
     }
-    if let Some((value, source)) =
-        policy_u8_override_by_layer(matched_policy, "autocompact_pct", PolicyLayer::Settings)
-    {
-        return (Some(value), source.to_string());
+    if let Some(decision) = policy_u8_override_by_source(
+        matched_policy,
+        "autocompact_pct",
+        PolicySource::SettingsModelPolicy,
+    ) {
+        return decision;
     }
     if let Some(autocompact_pct) = alias.and_then(|entry| entry.autocompact_pct) {
-        return (Some(autocompact_pct), "alias".to_string());
+        return resolved_field(Some(autocompact_pct), PolicySource::Alias);
     }
-    (None, "unset".to_string())
+    resolved_field(None, PolicySource::Unset)
 }
 
 fn effort_level_to_str(effort: &EffortLevel) -> &'static str {
@@ -312,34 +369,4 @@ fn sandbox_mode_to_str(mode: &SandboxMode) -> &'static str {
         SandboxMode::WorkspaceWrite => "workspace-write",
         SandboxMode::DangerFullAccess => "danger-full-access",
     }
-}
-
-fn policy_string_override_by_layer(
-    matched_policy: Option<&MatchedModelPolicy>,
-    key: &str,
-    layer: PolicyLayer,
-) -> Option<(String, &'static str)> {
-    let policy = matched_policy.filter(|entry| entry.layer == layer)?;
-    let value = policy_override_string(&policy.rule, key)?;
-    Some((value, layer.field_source_label()))
-}
-
-fn policy_u32_override_by_layer(
-    matched_policy: Option<&MatchedModelPolicy>,
-    key: &str,
-    layer: PolicyLayer,
-) -> Option<(u32, &'static str)> {
-    let policy = matched_policy.filter(|entry| entry.layer == layer)?;
-    let value = policy_override_u32(&policy.rule, key)?;
-    Some((value, layer.field_source_label()))
-}
-
-fn policy_u8_override_by_layer(
-    matched_policy: Option<&MatchedModelPolicy>,
-    key: &str,
-    layer: PolicyLayer,
-) -> Option<(u8, &'static str)> {
-    let policy = matched_policy.filter(|entry| entry.layer == layer)?;
-    let value = policy_override_u8(&policy.rule, key)?;
-    Some((value, layer.field_source_label()))
 }

--- a/src/build/policy/execution.rs
+++ b/src/build/policy/execution.rs
@@ -1,5 +1,9 @@
-use crate::build::policy::PolicyInput;
+use crate::build::policy::{
+    MatchedModelPolicy, PolicyInput, PolicyLayer, policy_override_string, policy_override_u8,
+    policy_override_u32,
+};
 use crate::compiler::agents::{ApprovalMode, EffortLevel, OverrideFields, SandboxMode};
+use crate::config::AgentOverlay;
 use crate::models::ModelAlias;
 
 pub(super) struct ExecutionResolution {
@@ -19,19 +23,39 @@ pub(super) struct ExecutionResolution {
 pub(super) fn resolve_execution_policy(
     input: &PolicyInput<'_>,
     alias: Option<&ModelAlias>,
+    overlay: Option<&AgentOverlay>,
+    matched_policy: Option<&MatchedModelPolicy>,
     matched_harness_override: Option<&OverrideFields>,
 ) -> ExecutionResolution {
     let native_config = matched_harness_override
         .and_then(|fields| fields.native_config.clone())
         .filter(|map| !map.is_empty());
 
-    let (effort, effort_source) = resolve_effort(input, alias, matched_harness_override);
-    let (approval, approval_source) = resolve_approval(input, matched_harness_override);
-    let (sandbox, sandbox_source) = resolve_sandbox(input, matched_harness_override);
-    let (autocompact, autocompact_source) =
-        resolve_autocompact(input, alias, matched_harness_override);
-    let (autocompact_pct, autocompact_pct_source) =
-        resolve_autocompact_pct(input, alias, matched_harness_override);
+    let (effort, effort_source) = resolve_effort(
+        input,
+        alias,
+        overlay,
+        matched_policy,
+        matched_harness_override,
+    );
+    let (approval, approval_source) =
+        resolve_approval(input, overlay, matched_policy, matched_harness_override);
+    let (sandbox, sandbox_source) =
+        resolve_sandbox(input, overlay, matched_policy, matched_harness_override);
+    let (autocompact, autocompact_source) = resolve_autocompact(
+        input,
+        alias,
+        overlay,
+        matched_policy,
+        matched_harness_override,
+    );
+    let (autocompact_pct, autocompact_pct_source) = resolve_autocompact_pct(
+        input,
+        alias,
+        overlay,
+        matched_policy,
+        matched_harness_override,
+    );
 
     ExecutionResolution {
         effort,
@@ -51,6 +75,8 @@ pub(super) fn resolve_execution_policy(
 fn resolve_effort(
     input: &PolicyInput<'_>,
     alias: Option<&ModelAlias>,
+    overlay: Option<&AgentOverlay>,
+    matched_policy: Option<&MatchedModelPolicy>,
     matched_harness_override: Option<&OverrideFields>,
 ) -> (Option<String>, String) {
     if let Some(effort) = input.effort_override {
@@ -62,11 +88,29 @@ fn resolve_effort(
             "profile-harness-override".to_string(),
         );
     }
+    if let Some(overlay_effort) = overlay.and_then(|entry| entry.effort.as_deref()) {
+        return (Some(overlay_effort.to_string()), "overlay".to_string());
+    }
+    if let Some((value, source)) =
+        policy_string_override_by_layer(matched_policy, "effort", PolicyLayer::Overlay)
+    {
+        return (Some(value), source.to_string());
+    }
     if let Some(effort) = input.profile.effort.as_ref() {
         return (
             Some(effort_level_to_str(effort).to_string()),
             "profile".to_string(),
         );
+    }
+    if let Some((value, source)) =
+        policy_string_override_by_layer(matched_policy, "effort", PolicyLayer::Profile)
+    {
+        return (Some(value), source.to_string());
+    }
+    if let Some((value, source)) =
+        policy_string_override_by_layer(matched_policy, "effort", PolicyLayer::Settings)
+    {
+        return (Some(value), source.to_string());
     }
     if let Some(effort) = alias.and_then(|entry| entry.default_effort.clone()) {
         return (Some(effort), "alias".to_string());
@@ -76,6 +120,8 @@ fn resolve_effort(
 
 fn resolve_approval(
     input: &PolicyInput<'_>,
+    overlay: Option<&AgentOverlay>,
+    matched_policy: Option<&MatchedModelPolicy>,
     matched_harness_override: Option<&OverrideFields>,
 ) -> (Option<String>, String) {
     if let Some(approval) = input.approval_override {
@@ -87,17 +133,37 @@ fn resolve_approval(
             "profile-harness-override".to_string(),
         );
     }
+    if let Some(overlay_approval) = overlay.and_then(|entry| entry.approval.as_deref()) {
+        return (Some(overlay_approval.to_string()), "overlay".to_string());
+    }
+    if let Some((value, source)) =
+        policy_string_override_by_layer(matched_policy, "approval", PolicyLayer::Overlay)
+    {
+        return (Some(value), source.to_string());
+    }
     if let Some(approval) = input.profile.approval.as_ref() {
         return (
             Some(approval_mode_to_str(approval).to_string()),
             "profile".to_string(),
         );
     }
+    if let Some((value, source)) =
+        policy_string_override_by_layer(matched_policy, "approval", PolicyLayer::Profile)
+    {
+        return (Some(value), source.to_string());
+    }
+    if let Some((value, source)) =
+        policy_string_override_by_layer(matched_policy, "approval", PolicyLayer::Settings)
+    {
+        return (Some(value), source.to_string());
+    }
     (None, "unset".to_string())
 }
 
 fn resolve_sandbox(
     input: &PolicyInput<'_>,
+    overlay: Option<&AgentOverlay>,
+    matched_policy: Option<&MatchedModelPolicy>,
     matched_harness_override: Option<&OverrideFields>,
 ) -> (Option<String>, String) {
     if let Some(sandbox) = input.sandbox_override {
@@ -109,11 +175,29 @@ fn resolve_sandbox(
             "profile-harness-override".to_string(),
         );
     }
+    if let Some(overlay_sandbox) = overlay.and_then(|entry| entry.sandbox.as_deref()) {
+        return (Some(overlay_sandbox.to_string()), "overlay".to_string());
+    }
+    if let Some((value, source)) =
+        policy_string_override_by_layer(matched_policy, "sandbox", PolicyLayer::Overlay)
+    {
+        return (Some(value), source.to_string());
+    }
     if let Some(sandbox) = input.profile.sandbox.as_ref() {
         return (
             Some(sandbox_mode_to_str(sandbox).to_string()),
             "profile".to_string(),
         );
+    }
+    if let Some((value, source)) =
+        policy_string_override_by_layer(matched_policy, "sandbox", PolicyLayer::Profile)
+    {
+        return (Some(value), source.to_string());
+    }
+    if let Some((value, source)) =
+        policy_string_override_by_layer(matched_policy, "sandbox", PolicyLayer::Settings)
+    {
+        return (Some(value), source.to_string());
     }
     (None, "unset".to_string())
 }
@@ -121,13 +205,36 @@ fn resolve_sandbox(
 fn resolve_autocompact(
     input: &PolicyInput<'_>,
     alias: Option<&ModelAlias>,
+    overlay: Option<&AgentOverlay>,
+    matched_policy: Option<&MatchedModelPolicy>,
     matched_harness_override: Option<&OverrideFields>,
 ) -> (Option<u32>, String) {
     if let Some(autocompact) = matched_harness_override.and_then(|entry| entry.autocompact) {
         return (Some(autocompact), "profile-harness-override".to_string());
     }
+    if let Some(autocompact) = overlay
+        .and_then(|entry| entry.autocompact)
+        .and_then(|value| u32::try_from(value).ok())
+    {
+        return (Some(autocompact), "overlay".to_string());
+    }
+    if let Some((value, source)) =
+        policy_u32_override_by_layer(matched_policy, "autocompact", PolicyLayer::Overlay)
+    {
+        return (Some(value), source.to_string());
+    }
     if let Some(autocompact) = input.profile.autocompact {
         return (Some(autocompact), "profile".to_string());
+    }
+    if let Some((value, source)) =
+        policy_u32_override_by_layer(matched_policy, "autocompact", PolicyLayer::Profile)
+    {
+        return (Some(value), source.to_string());
+    }
+    if let Some((value, source)) =
+        policy_u32_override_by_layer(matched_policy, "autocompact", PolicyLayer::Settings)
+    {
+        return (Some(value), source.to_string());
     }
     if let Some(autocompact) = alias.and_then(|entry| entry.autocompact) {
         return (Some(autocompact), "alias".to_string());
@@ -138,6 +245,8 @@ fn resolve_autocompact(
 fn resolve_autocompact_pct(
     input: &PolicyInput<'_>,
     alias: Option<&ModelAlias>,
+    overlay: Option<&AgentOverlay>,
+    matched_policy: Option<&MatchedModelPolicy>,
     matched_harness_override: Option<&OverrideFields>,
 ) -> (Option<u8>, String) {
     if let Some(autocompact_pct) = matched_harness_override.and_then(|entry| entry.autocompact_pct)
@@ -147,8 +256,30 @@ fn resolve_autocompact_pct(
             "profile-harness-override".to_string(),
         );
     }
+    if let Some(autocompact_pct) = overlay
+        .and_then(|entry| entry.autocompact_pct)
+        .and_then(|value| u8::try_from(value).ok())
+        .filter(|value| (1..=100).contains(value))
+    {
+        return (Some(autocompact_pct), "overlay".to_string());
+    }
+    if let Some((value, source)) =
+        policy_u8_override_by_layer(matched_policy, "autocompact_pct", PolicyLayer::Overlay)
+    {
+        return (Some(value), source.to_string());
+    }
     if let Some(autocompact_pct) = input.profile.autocompact_pct {
         return (Some(autocompact_pct), "profile".to_string());
+    }
+    if let Some((value, source)) =
+        policy_u8_override_by_layer(matched_policy, "autocompact_pct", PolicyLayer::Profile)
+    {
+        return (Some(value), source.to_string());
+    }
+    if let Some((value, source)) =
+        policy_u8_override_by_layer(matched_policy, "autocompact_pct", PolicyLayer::Settings)
+    {
+        return (Some(value), source.to_string());
     }
     if let Some(autocompact_pct) = alias.and_then(|entry| entry.autocompact_pct) {
         return (Some(autocompact_pct), "alias".to_string());
@@ -181,4 +312,34 @@ fn sandbox_mode_to_str(mode: &SandboxMode) -> &'static str {
         SandboxMode::WorkspaceWrite => "workspace-write",
         SandboxMode::DangerFullAccess => "danger-full-access",
     }
+}
+
+fn policy_string_override_by_layer(
+    matched_policy: Option<&MatchedModelPolicy>,
+    key: &str,
+    layer: PolicyLayer,
+) -> Option<(String, &'static str)> {
+    let policy = matched_policy.filter(|entry| entry.layer == layer)?;
+    let value = policy_override_string(&policy.rule, key)?;
+    Some((value, layer.field_source_label()))
+}
+
+fn policy_u32_override_by_layer(
+    matched_policy: Option<&MatchedModelPolicy>,
+    key: &str,
+    layer: PolicyLayer,
+) -> Option<(u32, &'static str)> {
+    let policy = matched_policy.filter(|entry| entry.layer == layer)?;
+    let value = policy_override_u32(&policy.rule, key)?;
+    Some((value, layer.field_source_label()))
+}
+
+fn policy_u8_override_by_layer(
+    matched_policy: Option<&MatchedModelPolicy>,
+    key: &str,
+    layer: PolicyLayer,
+) -> Option<(u8, &'static str)> {
+    let policy = matched_policy.filter(|entry| entry.layer == layer)?;
+    let value = policy_override_u8(&policy.rule, key)?;
+    Some((value, layer.field_source_label()))
 }

--- a/src/build/policy/execution.rs
+++ b/src/build/policy/execution.rs
@@ -1,3 +1,7 @@
+use crate::build::policy::PolicySource::{
+    Alias, Cli, Overlay, OverlayModelPolicy, Profile, ProfileHarnessOverride, ProfileModelPolicy,
+    SettingsModelPolicy, Unset,
+};
 use crate::build::policy::{
     MatchedModelPolicy, PolicyInput, PolicySource, ResolvedField, matched_policy_string_override,
     matched_policy_u8_override, matched_policy_u32_override,
@@ -68,6 +72,44 @@ fn resolved_field<T>(value: Option<T>, source: PolicySource) -> ResolvedField<Op
     }
 }
 
+fn field_layer<T>(source: PolicySource, value: Option<T>) -> Option<ResolvedField<Option<T>>> {
+    value.map(|value| resolved_field(Some(value), source))
+}
+
+struct PolicyFieldLayers<T> {
+    cli: Option<T>,
+    harness_override: Option<T>,
+    overlay: Option<T>,
+    profile: Option<T>,
+    alias: Option<T>,
+}
+
+fn resolve_policy_field<T>(
+    key: &str,
+    matched_policy: Option<&MatchedModelPolicy>,
+    policy_override_by_source: impl Fn(
+        Option<&MatchedModelPolicy>,
+        &str,
+        PolicySource,
+    ) -> Option<ResolvedField<Option<T>>>,
+    layers: PolicyFieldLayers<T>,
+) -> ResolvedField<Option<T>> {
+    [
+        field_layer(Cli, layers.cli),
+        field_layer(ProfileHarnessOverride, layers.harness_override),
+        field_layer(Overlay, layers.overlay),
+        policy_override_by_source(matched_policy, key, OverlayModelPolicy),
+        field_layer(Profile, layers.profile),
+        policy_override_by_source(matched_policy, key, ProfileModelPolicy),
+        policy_override_by_source(matched_policy, key, SettingsModelPolicy),
+        field_layer(Alias, layers.alias),
+    ]
+    .into_iter()
+    .flatten()
+    .next()
+    .unwrap_or_else(|| resolved_field(None, Unset))
+}
+
 fn resolved_policy_field<T>(decision: ResolvedField<T>) -> ResolvedField<Option<T>> {
     ResolvedField {
         value: Some(decision.value),
@@ -113,45 +155,28 @@ fn resolve_effort(
     matched_policy: Option<&MatchedModelPolicy>,
     matched_harness_override: Option<&OverrideFields>,
 ) -> ResolvedField<Option<String>> {
-    if let Some(effort) = input.effort_override {
-        return resolved_field(Some(effort.to_string()), PolicySource::Cli);
-    }
-    if let Some(effort) = matched_harness_override.and_then(|entry| entry.effort.as_ref()) {
-        return resolved_field(
-            Some(effort_level_to_str(effort).to_string()),
-            PolicySource::ProfileHarnessOverride,
-        );
-    }
-    if let Some(overlay_effort) = overlay.and_then(|entry| entry.effort.as_deref()) {
-        return resolved_field(Some(overlay_effort.to_string()), PolicySource::Overlay);
-    }
-    if let Some(decision) =
-        policy_string_override_by_source(matched_policy, "effort", PolicySource::OverlayModelPolicy)
-    {
-        return decision;
-    }
-    if let Some(effort) = input.profile.effort.as_ref() {
-        return resolved_field(
-            Some(effort_level_to_str(effort).to_string()),
-            PolicySource::Profile,
-        );
-    }
-    if let Some(decision) =
-        policy_string_override_by_source(matched_policy, "effort", PolicySource::ProfileModelPolicy)
-    {
-        return decision;
-    }
-    if let Some(decision) = policy_string_override_by_source(
-        matched_policy,
+    resolve_policy_field(
         "effort",
-        PolicySource::SettingsModelPolicy,
-    ) {
-        return decision;
-    }
-    if let Some(effort) = alias.and_then(|entry| entry.default_effort.clone()) {
-        return resolved_field(Some(effort), PolicySource::Alias);
-    }
-    resolved_field(None, PolicySource::Unset)
+        matched_policy,
+        policy_string_override_by_source,
+        PolicyFieldLayers {
+            cli: input.effort_override.map(str::to_string),
+            harness_override: matched_harness_override
+                .and_then(|entry| entry.effort.as_ref())
+                .map(effort_level_to_str)
+                .map(str::to_string),
+            overlay: overlay
+                .and_then(|entry| entry.effort.as_deref())
+                .map(str::to_string),
+            profile: input
+                .profile
+                .effort
+                .as_ref()
+                .map(effort_level_to_str)
+                .map(str::to_string),
+            alias: alias.and_then(|entry| entry.default_effort.clone()),
+        },
+    )
 }
 
 fn resolve_approval(
@@ -160,46 +185,28 @@ fn resolve_approval(
     matched_policy: Option<&MatchedModelPolicy>,
     matched_harness_override: Option<&OverrideFields>,
 ) -> ResolvedField<Option<String>> {
-    if let Some(approval) = input.approval_override {
-        return resolved_field(Some(approval.to_string()), PolicySource::Cli);
-    }
-    if let Some(approval) = matched_harness_override.and_then(|entry| entry.approval.as_ref()) {
-        return resolved_field(
-            Some(approval_mode_to_str(approval).to_string()),
-            PolicySource::ProfileHarnessOverride,
-        );
-    }
-    if let Some(overlay_approval) = overlay.and_then(|entry| entry.approval.as_deref()) {
-        return resolved_field(Some(overlay_approval.to_string()), PolicySource::Overlay);
-    }
-    if let Some(decision) = policy_string_override_by_source(
-        matched_policy,
+    resolve_policy_field(
         "approval",
-        PolicySource::OverlayModelPolicy,
-    ) {
-        return decision;
-    }
-    if let Some(approval) = input.profile.approval.as_ref() {
-        return resolved_field(
-            Some(approval_mode_to_str(approval).to_string()),
-            PolicySource::Profile,
-        );
-    }
-    if let Some(decision) = policy_string_override_by_source(
         matched_policy,
-        "approval",
-        PolicySource::ProfileModelPolicy,
-    ) {
-        return decision;
-    }
-    if let Some(decision) = policy_string_override_by_source(
-        matched_policy,
-        "approval",
-        PolicySource::SettingsModelPolicy,
-    ) {
-        return decision;
-    }
-    resolved_field(None, PolicySource::Unset)
+        policy_string_override_by_source,
+        PolicyFieldLayers {
+            cli: input.approval_override.map(str::to_string),
+            harness_override: matched_harness_override
+                .and_then(|entry| entry.approval.as_ref())
+                .map(approval_mode_to_str)
+                .map(str::to_string),
+            overlay: overlay
+                .and_then(|entry| entry.approval.as_deref())
+                .map(str::to_string),
+            profile: input
+                .profile
+                .approval
+                .as_ref()
+                .map(approval_mode_to_str)
+                .map(str::to_string),
+            alias: None,
+        },
+    )
 }
 
 fn resolve_sandbox(
@@ -208,46 +215,28 @@ fn resolve_sandbox(
     matched_policy: Option<&MatchedModelPolicy>,
     matched_harness_override: Option<&OverrideFields>,
 ) -> ResolvedField<Option<String>> {
-    if let Some(sandbox) = input.sandbox_override {
-        return resolved_field(Some(sandbox.to_string()), PolicySource::Cli);
-    }
-    if let Some(sandbox) = matched_harness_override.and_then(|entry| entry.sandbox.as_ref()) {
-        return resolved_field(
-            Some(sandbox_mode_to_str(sandbox).to_string()),
-            PolicySource::ProfileHarnessOverride,
-        );
-    }
-    if let Some(overlay_sandbox) = overlay.and_then(|entry| entry.sandbox.as_deref()) {
-        return resolved_field(Some(overlay_sandbox.to_string()), PolicySource::Overlay);
-    }
-    if let Some(decision) = policy_string_override_by_source(
-        matched_policy,
+    resolve_policy_field(
         "sandbox",
-        PolicySource::OverlayModelPolicy,
-    ) {
-        return decision;
-    }
-    if let Some(sandbox) = input.profile.sandbox.as_ref() {
-        return resolved_field(
-            Some(sandbox_mode_to_str(sandbox).to_string()),
-            PolicySource::Profile,
-        );
-    }
-    if let Some(decision) = policy_string_override_by_source(
         matched_policy,
-        "sandbox",
-        PolicySource::ProfileModelPolicy,
-    ) {
-        return decision;
-    }
-    if let Some(decision) = policy_string_override_by_source(
-        matched_policy,
-        "sandbox",
-        PolicySource::SettingsModelPolicy,
-    ) {
-        return decision;
-    }
-    resolved_field(None, PolicySource::Unset)
+        policy_string_override_by_source,
+        PolicyFieldLayers {
+            cli: input.sandbox_override.map(str::to_string),
+            harness_override: matched_harness_override
+                .and_then(|entry| entry.sandbox.as_ref())
+                .map(sandbox_mode_to_str)
+                .map(str::to_string),
+            overlay: overlay
+                .and_then(|entry| entry.sandbox.as_deref())
+                .map(str::to_string),
+            profile: input
+                .profile
+                .sandbox
+                .as_ref()
+                .map(sandbox_mode_to_str)
+                .map(str::to_string),
+            alias: None,
+        },
+    )
 }
 
 fn resolve_autocompact(
@@ -257,43 +246,20 @@ fn resolve_autocompact(
     matched_policy: Option<&MatchedModelPolicy>,
     matched_harness_override: Option<&OverrideFields>,
 ) -> ResolvedField<Option<u32>> {
-    if let Some(autocompact) = matched_harness_override.and_then(|entry| entry.autocompact) {
-        return resolved_field(Some(autocompact), PolicySource::ProfileHarnessOverride);
-    }
-    if let Some(autocompact) = overlay
-        .and_then(|entry| entry.autocompact)
-        .and_then(|value| u32::try_from(value).ok())
-    {
-        return resolved_field(Some(autocompact), PolicySource::Overlay);
-    }
-    if let Some(decision) = policy_u32_override_by_source(
-        matched_policy,
+    resolve_policy_field(
         "autocompact",
-        PolicySource::OverlayModelPolicy,
-    ) {
-        return decision;
-    }
-    if let Some(autocompact) = input.profile.autocompact {
-        return resolved_field(Some(autocompact), PolicySource::Profile);
-    }
-    if let Some(decision) = policy_u32_override_by_source(
         matched_policy,
-        "autocompact",
-        PolicySource::ProfileModelPolicy,
-    ) {
-        return decision;
-    }
-    if let Some(decision) = policy_u32_override_by_source(
-        matched_policy,
-        "autocompact",
-        PolicySource::SettingsModelPolicy,
-    ) {
-        return decision;
-    }
-    if let Some(autocompact) = alias.and_then(|entry| entry.autocompact) {
-        return resolved_field(Some(autocompact), PolicySource::Alias);
-    }
-    resolved_field(None, PolicySource::Unset)
+        policy_u32_override_by_source,
+        PolicyFieldLayers {
+            cli: None,
+            harness_override: matched_harness_override.and_then(|entry| entry.autocompact),
+            overlay: overlay
+                .and_then(|entry| entry.autocompact)
+                .and_then(|value| u32::try_from(value).ok()),
+            profile: input.profile.autocompact,
+            alias: alias.and_then(|entry| entry.autocompact),
+        },
+    )
 }
 
 fn resolve_autocompact_pct(
@@ -303,45 +269,21 @@ fn resolve_autocompact_pct(
     matched_policy: Option<&MatchedModelPolicy>,
     matched_harness_override: Option<&OverrideFields>,
 ) -> ResolvedField<Option<u8>> {
-    if let Some(autocompact_pct) = matched_harness_override.and_then(|entry| entry.autocompact_pct)
-    {
-        return resolved_field(Some(autocompact_pct), PolicySource::ProfileHarnessOverride);
-    }
-    if let Some(autocompact_pct) = overlay
-        .and_then(|entry| entry.autocompact_pct)
-        .and_then(|value| u8::try_from(value).ok())
-        .filter(|value| (1..=100).contains(value))
-    {
-        return resolved_field(Some(autocompact_pct), PolicySource::Overlay);
-    }
-    if let Some(decision) = policy_u8_override_by_source(
-        matched_policy,
+    resolve_policy_field(
         "autocompact_pct",
-        PolicySource::OverlayModelPolicy,
-    ) {
-        return decision;
-    }
-    if let Some(autocompact_pct) = input.profile.autocompact_pct {
-        return resolved_field(Some(autocompact_pct), PolicySource::Profile);
-    }
-    if let Some(decision) = policy_u8_override_by_source(
         matched_policy,
-        "autocompact_pct",
-        PolicySource::ProfileModelPolicy,
-    ) {
-        return decision;
-    }
-    if let Some(decision) = policy_u8_override_by_source(
-        matched_policy,
-        "autocompact_pct",
-        PolicySource::SettingsModelPolicy,
-    ) {
-        return decision;
-    }
-    if let Some(autocompact_pct) = alias.and_then(|entry| entry.autocompact_pct) {
-        return resolved_field(Some(autocompact_pct), PolicySource::Alias);
-    }
-    resolved_field(None, PolicySource::Unset)
+        policy_u8_override_by_source,
+        PolicyFieldLayers {
+            cli: None,
+            harness_override: matched_harness_override.and_then(|entry| entry.autocompact_pct),
+            overlay: overlay
+                .and_then(|entry| entry.autocompact_pct)
+                .and_then(|value| u8::try_from(value).ok())
+                .filter(|value| (1..=100).contains(value)),
+            profile: input.profile.autocompact_pct,
+            alias: alias.and_then(|entry| entry.autocompact_pct),
+        },
+    )
 }
 
 fn effort_level_to_str(effort: &EffortLevel) -> &'static str {

--- a/src/build/policy/harness.rs
+++ b/src/build/policy/harness.rs
@@ -2,7 +2,9 @@
 
 use std::collections::HashSet;
 
-use crate::build::policy::{MatchedModelPolicy, PolicyInput, policy_override_string};
+use crate::build::policy::{
+    MatchedModelPolicy, PolicyInput, PolicySource, ResolvedField, matched_policy_string_override,
+};
 use crate::compiler::agents::HarnessKind;
 use crate::config::AgentOverlay;
 use crate::error::{ConfigError, MarsError};
@@ -13,8 +15,7 @@ use crate::routing::{self, RouteConfidence, RoutingInput};
 
 #[derive(Debug)]
 pub(super) struct HarnessResolution {
-    pub(super) harness: String,
-    pub(super) source: &'static str,
+    pub(super) harness: ResolvedField<String>,
     pub(super) harness_order_position: Option<usize>,
     pub(super) route_confidence: RouteConfidence,
     pub(super) candidates_tried: Vec<String>,
@@ -48,171 +49,191 @@ pub(super) fn resolve_harness(
         .and_then(|entry| entry.harness.as_deref())
         .map(str::trim)
         .filter(|value| !value.is_empty());
-    let overlay_policy_harness = matched_policy
-        .filter(|policy| policy.layer == crate::build::policy::PolicyLayer::Overlay)
-        .and_then(|policy| policy_override_string(&policy.rule, "harness"));
-    let profile_policy_harness = matched_policy
-        .filter(|policy| policy.layer == crate::build::policy::PolicyLayer::Profile)
-        .and_then(|policy| policy_override_string(&policy.rule, "harness"));
-    let settings_policy_harness = matched_policy
-        .filter(|policy| policy.layer == crate::build::policy::PolicyLayer::Settings)
-        .and_then(|policy| policy_override_string(&policy.rule, "harness"));
+    let policy_harness = matched_policy_string_override(matched_policy, "harness");
+    let overlay_policy_harness = policy_harness
+        .as_ref()
+        .filter(|decision| decision.source == PolicySource::OverlayModelPolicy)
+        .cloned();
+    let profile_policy_harness = policy_harness
+        .as_ref()
+        .filter(|decision| decision.source == PolicySource::ProfileModelPolicy)
+        .cloned();
+    let settings_policy_harness = policy_harness
+        .as_ref()
+        .filter(|decision| decision.source == PolicySource::SettingsModelPolicy)
+        .cloned();
     let alias_harness = alias.and_then(|entry| entry.harness.as_deref());
     let normalized_config_default_harness =
         routing::normalize_config_default_harness(evidence.config_default_harness, &mut warnings);
     let model_from_cli = input.model_override.is_some();
     let mut selected_harness_order_position = None;
-    let mut fixed_harness_selection = None;
-    let (harness, harness_source, route_confidence, candidates_tried) = if let Some(harness) =
-        input.harness_override
-    {
-        fixed_harness_selection = Some(("cli", harness));
-        (
-            harness.to_string(),
-            "cli",
-            RouteConfidence::Explicit,
-            vec![harness.to_string()],
-        )
-    } else if let Some(harness) = overlay_harness {
-        fixed_harness_selection = Some(("overlay", harness));
-        (
-            harness.to_string(),
-            "overlay",
-            RouteConfidence::Passthrough,
-            Vec::new(),
-        )
-    } else if let Some(harness) = overlay_policy_harness.as_deref() {
-        fixed_harness_selection = Some(("overlay-model-policy", harness));
-        (
-            harness.to_string(),
-            "overlay-model-policy",
-            RouteConfidence::Passthrough,
-            Vec::new(),
-        )
-    } else if model_from_cli {
-        if let Some(harness) = settings_policy_harness.as_deref() {
-            fixed_harness_selection = Some(("settings-model-policy", harness));
-            (
-                harness.to_string(),
-                "settings-model-policy",
-                RouteConfidence::Passthrough,
-                Vec::new(),
-            )
-        } else if let Some(harness) = alias_harness {
-            fixed_harness_selection = Some(("alias", harness));
-            (
-                harness.to_string(),
-                "alias",
-                RouteConfidence::Passthrough,
-                Vec::new(),
-            )
-        } else {
-            let trace =
-                evaluate_candidates(&evidence, normalized_config_default_harness.as_deref());
-            selected_harness_order_position = trace.harness_order_position;
-            warnings.extend(trace.diagnostics);
-            (
-                trace.harness,
-                trace.source.label(),
-                trace.confidence,
-                trace.candidates_tried,
-            )
-        }
-    } else if let Some(harness) = profile_harness {
-        if evidence.installed_harnesses.contains(harness) {
-            (
-                harness.to_string(),
-                "profile",
-                RouteConfidence::Passthrough,
-                Vec::new(),
-            )
-        } else {
-            warnings.push(format!(
-                "profile harness '{harness}' not installed; pivoting via model-policies"
-            ));
-            let trace =
-                evaluate_candidates(&evidence, normalized_config_default_harness.as_deref());
-            selected_harness_order_position = trace.harness_order_position;
-            warnings.extend(trace.diagnostics);
-
-            if !evidence.installed_harnesses.contains(&trace.harness) {
-                return Err(unavailable_profile_pivot_error(
-                    harness,
-                    &trace.harness,
-                    evidence.installed_harnesses,
+    let fixed_harness_selection = resolve_fixed_harness_selection(
+        input,
+        model_from_cli,
+        overlay_harness,
+        overlay_policy_harness,
+        profile_harness,
+        profile_policy_harness,
+        settings_policy_harness,
+        alias_harness,
+    );
+    let (harness, route_confidence, candidates_tried, unavailable_profile_harness) =
+        if let Some(selection) = fixed_harness_selection.clone() {
+            if selection.source == PolicySource::Profile
+                && !evidence
+                    .installed_harnesses
+                    .contains(selection.value.as_str())
+            {
+                warnings.push(format!(
+                    "profile harness '{}' not installed; pivoting via model-policies",
+                    selection.value
                 ));
+                let trace =
+                    evaluate_candidates(&evidence, normalized_config_default_harness.as_deref());
+                selected_harness_order_position = trace.harness_order_position;
+                warnings.extend(trace.diagnostics);
+                let unavailable = (!evidence.installed_harnesses.contains(&trace.harness))
+                    .then_some(selection.value.clone());
+                (
+                    ResolvedField {
+                        value: trace.harness,
+                        source: trace.source.into(),
+                        matched_rule: None,
+                    },
+                    trace.confidence,
+                    trace.candidates_tried,
+                    unavailable,
+                )
+            } else {
+                let candidates_tried = if selection.source == PolicySource::Cli {
+                    vec![selection.value.clone()]
+                } else {
+                    Vec::new()
+                };
+                let confidence = if selection.source == PolicySource::Cli {
+                    RouteConfidence::Explicit
+                } else {
+                    RouteConfidence::Passthrough
+                };
+                (selection, confidence, candidates_tried, None)
             }
-
+        } else {
+            let trace =
+                evaluate_candidates(&evidence, normalized_config_default_harness.as_deref());
+            selected_harness_order_position = trace.harness_order_position;
+            warnings.extend(trace.diagnostics);
             (
-                trace.harness,
-                trace.source.label(),
+                ResolvedField {
+                    value: trace.harness,
+                    source: trace.source.into(),
+                    matched_rule: None,
+                },
                 trace.confidence,
                 trace.candidates_tried,
+                None,
             )
-        }
-    } else if let Some(harness) = profile_policy_harness.as_deref() {
-        fixed_harness_selection = Some(("profile-model-policy", harness));
-        (
-            harness.to_string(),
-            "profile-model-policy",
-            RouteConfidence::Passthrough,
-            Vec::new(),
-        )
-    } else if let Some(harness) = settings_policy_harness.as_deref() {
-        fixed_harness_selection = Some(("settings-model-policy", harness));
-        (
-            harness.to_string(),
-            "settings-model-policy",
-            RouteConfidence::Passthrough,
-            Vec::new(),
-        )
-    } else if let Some(harness) = alias_harness {
-        fixed_harness_selection = Some(("alias", harness));
-        (
-            harness.to_string(),
-            "alias",
-            RouteConfidence::Passthrough,
-            Vec::new(),
-        )
-    } else {
-        let trace = evaluate_candidates(&evidence, normalized_config_default_harness.as_deref());
-        selected_harness_order_position = trace.harness_order_position;
-        warnings.extend(trace.diagnostics);
-        (
-            trace.harness,
-            trace.source.label(),
-            trace.confidence,
-            trace.candidates_tried,
-        )
-    };
+        };
 
-    let resolved_harness = HarnessKind::from_str(&harness).ok_or_else(|| {
+    if let Some(profile_harness) = unavailable_profile_harness {
+        return Err(unavailable_profile_pivot_error(
+            &profile_harness,
+            &harness.value,
+            evidence.installed_harnesses,
+        ));
+    }
+
+    let resolved_harness = HarnessKind::from_str(&harness.value).ok_or_else(|| {
         MarsError::Config(ConfigError::Invalid {
             message: format!(
-                "resolved harness `{harness}` is invalid; expected one of: claude, codex, opencode, cursor, pi"
+                "resolved harness `{}` is invalid; expected one of: claude, codex, opencode, cursor, pi",
+                harness.value
             ),
         })
     })?;
 
-    if let Some((source, requested_harness)) = fixed_harness_selection
-        && !evidence.installed_harnesses.contains(requested_harness)
+    if let Some(selection) = fixed_harness_selection
+        && selection.source != PolicySource::Profile
+        && !evidence
+            .installed_harnesses
+            .contains(selection.value.as_str())
     {
         return Err(unavailable_fixed_harness_error(
-            source,
-            requested_harness,
+            selection.source.label(),
+            &selection.value,
             evidence.installed_harnesses,
         ));
     }
 
     Ok(HarnessResolution {
-        is_experimental: harness == "cursor",
+        is_experimental: harness.value == "cursor",
         resolved_harness,
         harness,
-        source: harness_source,
         harness_order_position: selected_harness_order_position,
         route_confidence,
         candidates_tried,
         warnings,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn resolve_fixed_harness_selection(
+    input: &PolicyInput<'_>,
+    model_from_cli: bool,
+    overlay_harness: Option<&str>,
+    overlay_policy_harness: Option<ResolvedField<String>>,
+    profile_harness: Option<&str>,
+    profile_policy_harness: Option<ResolvedField<String>>,
+    settings_policy_harness: Option<ResolvedField<String>>,
+    alias_harness: Option<&str>,
+) -> Option<ResolvedField<String>> {
+    if let Some(harness) = input.harness_override {
+        return Some(ResolvedField {
+            value: harness.to_string(),
+            source: PolicySource::Cli,
+            matched_rule: None,
+        });
+    }
+    if let Some(harness) = overlay_harness {
+        return Some(ResolvedField {
+            value: harness.to_string(),
+            source: PolicySource::Overlay,
+            matched_rule: None,
+        });
+    }
+    if let Some(harness) = overlay_policy_harness {
+        return Some(harness);
+    }
+    if model_from_cli {
+        if let Some(harness) = settings_policy_harness {
+            return Some(harness);
+        }
+        if let Some(harness) = alias_harness {
+            return Some(ResolvedField {
+                value: harness.to_string(),
+                source: PolicySource::Alias,
+                matched_rule: None,
+            });
+        }
+        return None;
+    }
+
+    if let Some(harness) = profile_harness {
+        return Some(ResolvedField {
+            value: harness.to_string(),
+            source: PolicySource::Profile,
+            matched_rule: None,
+        });
+    }
+    if let Some(harness) = profile_policy_harness {
+        return Some(harness);
+    }
+    if let Some(harness) = settings_policy_harness {
+        return Some(harness);
+    }
+    alias_harness.map(|harness| ResolvedField {
+        value: harness.to_string(),
+        source: PolicySource::Alias,
+        matched_rule: None,
     })
 }
 
@@ -395,8 +416,8 @@ mod tests {
         )
         .expect("harness should resolve");
 
-        assert_eq!(resolution.harness, "pi");
-        assert_eq!(resolution.source, "cli");
+        assert_eq!(resolution.harness.value, "pi");
+        assert_eq!(resolution.harness.source, PolicySource::Cli);
         assert_eq!(resolution.route_confidence, RouteConfidence::Explicit);
         assert_eq!(resolution.candidates_tried, vec!["pi".to_string()]);
         assert_eq!(resolution.harness_order_position, None);
@@ -417,8 +438,8 @@ mod tests {
         )
         .expect("harness should resolve");
 
-        assert_eq!(resolution.harness, "codex");
-        assert_eq!(resolution.source, "alias");
+        assert_eq!(resolution.harness.value, "codex");
+        assert_eq!(resolution.harness.source, PolicySource::Alias);
         assert_eq!(resolution.route_confidence, RouteConfidence::Passthrough);
         assert!(resolution.candidates_tried.is_empty());
     }
@@ -438,8 +459,8 @@ mod tests {
         )
         .expect("harness should resolve");
 
-        assert_eq!(resolution.harness, "pi");
-        assert_eq!(resolution.source, "profile");
+        assert_eq!(resolution.harness.value, "pi");
+        assert_eq!(resolution.harness.source, PolicySource::Profile);
         assert_eq!(resolution.route_confidence, RouteConfidence::Passthrough);
         assert!(resolution.candidates_tried.is_empty());
     }
@@ -464,8 +485,8 @@ mod tests {
         let resolution = resolve_harness(&input, None, None, None, evidence)
             .expect("harness should pivot to opencode");
 
-        assert_eq!(resolution.harness, "opencode");
-        assert_eq!(resolution.source, "provider");
+        assert_eq!(resolution.harness.value, "opencode");
+        assert_eq!(resolution.harness.source, PolicySource::Provider);
         assert_eq!(resolution.route_confidence, RouteConfidence::Likely);
         assert_eq!(resolution.candidates_tried, vec!["codex", "pi", "opencode"]);
         assert!(resolution.warnings.iter().any(|warning| {
@@ -524,8 +545,8 @@ mod tests {
         )
         .expect("harness should resolve");
 
-        assert_eq!(resolution.harness, "pi");
-        assert_eq!(resolution.source, "config-order");
+        assert_eq!(resolution.harness.value, "pi");
+        assert_eq!(resolution.harness.source, PolicySource::ConfigOrder);
         assert_eq!(resolution.route_confidence, RouteConfidence::Passthrough);
         assert_eq!(resolution.harness_order_position, Some(0));
         assert_eq!(resolution.candidates_tried, vec!["pi".to_string()]);

--- a/src/build/policy/harness.rs
+++ b/src/build/policy/harness.rs
@@ -2,8 +2,9 @@
 
 use std::collections::HashSet;
 
-use crate::build::policy::PolicyInput;
+use crate::build::policy::{MatchedModelPolicy, PolicyInput, policy_override_string};
 use crate::compiler::agents::HarnessKind;
+use crate::config::AgentOverlay;
 use crate::error::{ConfigError, MarsError};
 use crate::models::ModelAlias;
 use crate::models::probes::OpenCodeProbeResult;
@@ -36,11 +37,26 @@ pub(super) struct HarnessEvidence<'a> {
 pub(super) fn resolve_harness(
     input: &PolicyInput<'_>,
     alias: Option<&ModelAlias>,
+    overlay: Option<&AgentOverlay>,
+    matched_policy: Option<&MatchedModelPolicy>,
     evidence: HarnessEvidence<'_>,
 ) -> Result<HarnessResolution, MarsError> {
     let mut warnings = Vec::new();
 
     let profile_harness = input.profile.harness.as_ref().map(harness_kind_to_str);
+    let overlay_harness = overlay
+        .and_then(|entry| entry.harness.as_deref())
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let overlay_policy_harness = matched_policy
+        .filter(|policy| policy.layer == crate::build::policy::PolicyLayer::Overlay)
+        .and_then(|policy| policy_override_string(&policy.rule, "harness"));
+    let profile_policy_harness = matched_policy
+        .filter(|policy| policy.layer == crate::build::policy::PolicyLayer::Profile)
+        .and_then(|policy| policy_override_string(&policy.rule, "harness"));
+    let settings_policy_harness = matched_policy
+        .filter(|policy| policy.layer == crate::build::policy::PolicyLayer::Settings)
+        .and_then(|policy| policy_override_string(&policy.rule, "harness"));
     let alias_harness = alias.and_then(|entry| entry.harness.as_deref());
     let normalized_config_default_harness =
         routing::normalize_config_default_harness(evidence.config_default_harness, &mut warnings);
@@ -57,8 +73,32 @@ pub(super) fn resolve_harness(
             RouteConfidence::Explicit,
             vec![harness.to_string()],
         )
+    } else if let Some(harness) = overlay_harness {
+        fixed_harness_selection = Some(("overlay", harness));
+        (
+            harness.to_string(),
+            "overlay",
+            RouteConfidence::Passthrough,
+            Vec::new(),
+        )
+    } else if let Some(harness) = overlay_policy_harness.as_deref() {
+        fixed_harness_selection = Some(("overlay-model-policy", harness));
+        (
+            harness.to_string(),
+            "overlay-model-policy",
+            RouteConfidence::Passthrough,
+            Vec::new(),
+        )
     } else if model_from_cli {
-        if let Some(harness) = alias_harness {
+        if let Some(harness) = settings_policy_harness.as_deref() {
+            fixed_harness_selection = Some(("settings-model-policy", harness));
+            (
+                harness.to_string(),
+                "settings-model-policy",
+                RouteConfidence::Passthrough,
+                Vec::new(),
+            )
+        } else if let Some(harness) = alias_harness {
             fixed_harness_selection = Some(("alias", harness));
             (
                 harness.to_string(),
@@ -110,6 +150,22 @@ pub(super) fn resolve_harness(
                 trace.candidates_tried,
             )
         }
+    } else if let Some(harness) = profile_policy_harness.as_deref() {
+        fixed_harness_selection = Some(("profile-model-policy", harness));
+        (
+            harness.to_string(),
+            "profile-model-policy",
+            RouteConfidence::Passthrough,
+            Vec::new(),
+        )
+    } else if let Some(harness) = settings_policy_harness.as_deref() {
+        fixed_harness_selection = Some(("settings-model-policy", harness));
+        (
+            harness.to_string(),
+            "settings-model-policy",
+            RouteConfidence::Passthrough,
+            Vec::new(),
+        )
     } else if let Some(harness) = alias_harness {
         fixed_harness_selection = Some(("alias", harness));
         (
@@ -286,6 +342,7 @@ mod tests {
     ) -> PolicyInput<'a> {
         PolicyInput {
             project_root: Path::new("."),
+            agent: None,
             profile,
             model_override,
             config_default_model: None,
@@ -332,6 +389,8 @@ mod tests {
         let resolution = resolve_harness(
             &input,
             Some(&model_alias(Some("codex"))),
+            None,
+            None,
             evidence(None, None, &installed),
         )
         .expect("harness should resolve");
@@ -352,6 +411,8 @@ mod tests {
         let resolution = resolve_harness(
             &input,
             Some(&model_alias(Some("codex"))),
+            None,
+            None,
             evidence(None, None, &installed),
         )
         .expect("harness should resolve");
@@ -371,6 +432,8 @@ mod tests {
         let resolution = resolve_harness(
             &input,
             Some(&model_alias(Some("codex"))),
+            None,
+            None,
             evidence(None, None, &installed),
         )
         .expect("harness should resolve");
@@ -398,8 +461,8 @@ mod tests {
             pi_probe_result: None,
         };
 
-        let resolution =
-            resolve_harness(&input, None, evidence).expect("harness should pivot to opencode");
+        let resolution = resolve_harness(&input, None, None, None, evidence)
+            .expect("harness should pivot to opencode");
 
         assert_eq!(resolution.harness, "opencode");
         assert_eq!(resolution.source, "provider");
@@ -416,7 +479,7 @@ mod tests {
         let profile = profile(Some(HarnessKind::Claude));
         let input = policy_input(&profile, None, None);
 
-        let error = resolve_harness(&input, None, evidence(None, None, &installed))
+        let error = resolve_harness(&input, None, None, None, evidence(None, None, &installed))
             .expect_err("unavailable profile harness should fail without an installed fallback");
         let message = error.to_string();
 
@@ -434,6 +497,8 @@ mod tests {
         let error = resolve_harness(
             &input,
             Some(&model_alias(Some("codex"))),
+            None,
+            None,
             evidence(None, None, &installed),
         )
         .expect_err("unavailable explicit harness should fail");
@@ -450,8 +515,14 @@ mod tests {
         let profile = profile(None);
         let input = policy_input(&profile, None, None);
 
-        let resolution = resolve_harness(&input, None, evidence(None, Some(&order), &installed))
-            .expect("harness should resolve");
+        let resolution = resolve_harness(
+            &input,
+            None,
+            None,
+            None,
+            evidence(None, Some(&order), &installed),
+        )
+        .expect("harness should resolve");
 
         assert_eq!(resolution.harness, "pi");
         assert_eq!(resolution.source, "config-order");
@@ -466,8 +537,14 @@ mod tests {
         let profile = profile(Some(HarnessKind::Pi));
         let input = policy_input(&profile, None, None);
 
-        let resolution = resolve_harness(&input, None, evidence(Some("bogus"), None, &installed))
-            .expect("harness should resolve");
+        let resolution = resolve_harness(
+            &input,
+            None,
+            None,
+            None,
+            evidence(Some("bogus"), None, &installed),
+        )
+        .expect("harness should resolve");
 
         assert!(
             resolution

--- a/src/build/policy/mod.rs
+++ b/src/build/policy/mod.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use crate::build::bundle::ExecutionPolicy;
 use crate::compiler::agents::AgentProfile;
+use crate::config::{AgentOverlay, ModelPolicyMatchType, ModelPolicyRule};
 use crate::error::MarsError;
 use crate::harness::host::{CapabilityCollectionOptions, collect_capability_snapshot};
 
@@ -14,6 +15,7 @@ mod runnable;
 
 pub struct PolicyInput<'a> {
     pub project_root: &'a Path,
+    pub agent: Option<&'a str>,
     pub profile: &'a AgentProfile,
     pub model_override: Option<&'a str>,
     pub config_default_model: Option<&'a str>,
@@ -30,14 +32,50 @@ pub struct ResolvedPolicy {
     pub warnings: Vec<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PolicyLayer {
+    Overlay,
+    Profile,
+    Settings,
+}
+
+impl PolicyLayer {
+    fn matched_rule_layer_label(self) -> &'static str {
+        match self {
+            Self::Overlay => "overlay",
+            Self::Profile => "profile",
+            Self::Settings => "settings",
+        }
+    }
+
+    pub(super) fn field_source_label(self) -> &'static str {
+        match self {
+            Self::Overlay => "overlay-model-policy",
+            Self::Profile => "profile-model-policy",
+            Self::Settings => "settings-model-policy",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct MatchedModelPolicy {
+    pub(super) layer: PolicyLayer,
+    pub(super) index: usize,
+    pub(super) rule: ModelPolicyRule,
+}
+
 pub fn resolve_policy(input: PolicyInput<'_>) -> Result<ResolvedPolicy, MarsError> {
     let mut warnings = Vec::new();
     let mut provenance = BTreeMap::new();
 
     let resolution_config = config::load_policy_resolution_config(input.project_root)?;
+    let overlay = input
+        .agent
+        .and_then(|name| resolution_config.agents.get(name));
     let cache = model::load_models_cache(input.project_root)?;
     let model_input = PolicyInput {
         project_root: input.project_root,
+        agent: input.agent,
         profile: input.profile,
         model_override: input.model_override,
         config_default_model: resolution_config.default_model.as_deref(),
@@ -46,13 +84,33 @@ pub fn resolve_policy(input: PolicyInput<'_>) -> Result<ResolvedPolicy, MarsErro
         approval_override: input.approval_override,
         sandbox_override: input.sandbox_override,
     };
-    let resolved_model = model::resolve_model(&model_input, &resolution_config.aliases, &cache)?;
+    let resolved_model =
+        model::resolve_model(&model_input, overlay, &resolution_config.aliases, &cache)?;
 
     warnings.extend(resolved_model.warnings);
     provenance.insert(
         "model_source".to_string(),
         resolved_model.model_source.clone(),
     );
+    let matched_policy = match_model_policy(
+        compose_effective_policies(
+            overlay,
+            &input.profile.model_policies,
+            &resolution_config.settings_model_policies,
+        ),
+        &resolved_model.model,
+        &resolved_model.model_token,
+    );
+    if let Some(policy) = matched_policy.as_ref() {
+        provenance.insert(
+            "matched_policy_rule".to_string(),
+            format!(
+                "{}:{}",
+                policy.layer.matched_rule_layer_label(),
+                policy.index
+            ),
+        );
+    }
 
     let capability_snapshot = collect_capability_snapshot(&CapabilityCollectionOptions {
         offline: crate::models::is_mars_offline(),
@@ -65,6 +123,8 @@ pub fn resolve_policy(input: PolicyInput<'_>) -> Result<ResolvedPolicy, MarsErro
     let harness_resolution = harness::resolve_harness(
         &model_input,
         resolved_model.alias,
+        overlay,
+        matched_policy.as_ref(),
         harness::HarnessEvidence {
             model_id: &resolved_model.model,
             provider: resolved_model.provider.as_deref(),
@@ -107,8 +167,13 @@ pub fn resolve_policy(input: PolicyInput<'_>) -> Result<ResolvedPolicy, MarsErro
         .profile
         .harness_overrides
         .get(&harness_resolution.resolved_harness);
-    let execution_resolution =
-        execution::resolve_execution_policy(&input, resolved_model.alias, matched_harness_override);
+    let execution_resolution = execution::resolve_execution_policy(
+        &input,
+        resolved_model.alias,
+        overlay,
+        matched_policy.as_ref(),
+        matched_harness_override,
+    );
 
     provenance.insert(
         "effort_source".to_string(),
@@ -164,4 +229,89 @@ pub fn resolve_policy(input: PolicyInput<'_>) -> Result<ResolvedPolicy, MarsErro
         provenance,
         warnings,
     })
+}
+
+pub(super) fn policy_override_string(rule: &ModelPolicyRule, key: &str) -> Option<String> {
+    let value = rule
+        .overrides
+        .get(serde_yaml::Value::String(key.to_string()))?
+        .as_str()?;
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+pub(super) fn policy_override_u32(rule: &ModelPolicyRule, key: &str) -> Option<u32> {
+    let value = rule
+        .overrides
+        .get(serde_yaml::Value::String(key.to_string()))?;
+    match value {
+        serde_yaml::Value::Number(number) => {
+            let parsed = number.as_u64()?;
+            u32::try_from(parsed).ok()
+        }
+        _ => None,
+    }
+}
+
+pub(super) fn policy_override_u8(rule: &ModelPolicyRule, key: &str) -> Option<u8> {
+    let value = rule
+        .overrides
+        .get(serde_yaml::Value::String(key.to_string()))?;
+    match value {
+        serde_yaml::Value::Number(number) => {
+            let parsed = number.as_u64()?;
+            let percent = u8::try_from(parsed).ok()?;
+            (1..=100).contains(&percent).then_some(percent)
+        }
+        _ => None,
+    }
+}
+
+fn compose_effective_policies<'a>(
+    overlay: Option<&'a AgentOverlay>,
+    profile_policies: &'a [ModelPolicyRule],
+    settings_policies: &'a [ModelPolicyRule],
+) -> Vec<(PolicyLayer, usize, &'a ModelPolicyRule)> {
+    let mut composed = Vec::new();
+    if let Some(agent_overlay) = overlay {
+        for (index, rule) in agent_overlay.model_policies.iter().enumerate() {
+            composed.push((PolicyLayer::Overlay, index, rule));
+        }
+    }
+    for (index, rule) in profile_policies.iter().enumerate() {
+        composed.push((PolicyLayer::Profile, index, rule));
+    }
+    for (index, rule) in settings_policies.iter().enumerate() {
+        composed.push((PolicyLayer::Settings, index, rule));
+    }
+    composed
+}
+
+fn match_model_policy(
+    policies: Vec<(PolicyLayer, usize, &ModelPolicyRule)>,
+    canonical_model_id: &str,
+    selected_model_token: &str,
+) -> Option<MatchedModelPolicy> {
+    if canonical_model_id.is_empty() || selected_model_token.is_empty() {
+        return None;
+    }
+
+    for (layer, index, rule) in policies {
+        let matched = match rule.match_type {
+            ModelPolicyMatchType::Model => rule.match_value == canonical_model_id,
+            ModelPolicyMatchType::Alias => rule.match_value == selected_model_token,
+            ModelPolicyMatchType::ModelGlob => {
+                crate::models::glob_match(&rule.match_value, canonical_model_id)
+            }
+        };
+        if matched {
+            return Some(MatchedModelPolicy {
+                layer,
+                index,
+                rule: rule.clone(),
+            });
+        }
+    }
+
+    None
 }

--- a/src/build/policy/mod.rs
+++ b/src/build/policy/mod.rs
@@ -33,6 +33,59 @@ pub struct ResolvedPolicy {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PolicySource {
+    Cli,
+    Overlay,
+    OverlayModelPolicy,
+    Profile,
+    ProfileModelPolicy,
+    SettingsModelPolicy,
+    Alias,
+    Project,
+    ConfigOrder,
+    Config,
+    Provider,
+    Default,
+    ProfileHarnessOverride,
+    Unset,
+}
+
+impl PolicySource {
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            Self::Cli => "cli",
+            Self::Overlay => "overlay",
+            Self::OverlayModelPolicy => "overlay-model-policy",
+            Self::Profile => "profile",
+            Self::ProfileModelPolicy => "profile-model-policy",
+            Self::SettingsModelPolicy => "settings-model-policy",
+            Self::Alias => "alias",
+            Self::Project => "project",
+            Self::ConfigOrder => "config-order",
+            Self::Config => "config",
+            Self::Provider => "provider",
+            Self::Default => "default",
+            Self::ProfileHarnessOverride => "profile-harness-override",
+            Self::Unset => "unset",
+        }
+    }
+}
+
+impl From<crate::routing::RouteSource> for PolicySource {
+    fn from(source: crate::routing::RouteSource) -> Self {
+        match source {
+            crate::routing::RouteSource::Cli => Self::Cli,
+            crate::routing::RouteSource::Profile => Self::Profile,
+            crate::routing::RouteSource::Alias => Self::Alias,
+            crate::routing::RouteSource::ConfigOrder => Self::ConfigOrder,
+            crate::routing::RouteSource::ConfigDefault => Self::Config,
+            crate::routing::RouteSource::Provider => Self::Provider,
+            crate::routing::RouteSource::HardcodedDefault => Self::Default,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum PolicyLayer {
     Overlay,
     Profile,
@@ -48,13 +101,32 @@ impl PolicyLayer {
         }
     }
 
-    pub(super) fn field_source_label(self) -> &'static str {
+    pub(super) fn field_source(self) -> PolicySource {
         match self {
-            Self::Overlay => "overlay-model-policy",
-            Self::Profile => "profile-model-policy",
-            Self::Settings => "settings-model-policy",
+            Self::Overlay => PolicySource::OverlayModelPolicy,
+            Self::Profile => PolicySource::ProfileModelPolicy,
+            Self::Settings => PolicySource::SettingsModelPolicy,
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct MatchedPolicyRuleRef {
+    pub(super) layer: PolicyLayer,
+    pub(super) index: usize,
+}
+
+impl MatchedPolicyRuleRef {
+    pub(super) fn label(self) -> String {
+        format!("{}:{}", self.layer.matched_rule_layer_label(), self.index)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct ResolvedField<T> {
+    pub(super) value: T,
+    pub(super) source: PolicySource,
+    pub(super) matched_rule: Option<MatchedPolicyRuleRef>,
 }
 
 #[derive(Debug, Clone)]
@@ -62,6 +134,15 @@ pub(super) struct MatchedModelPolicy {
     pub(super) layer: PolicyLayer,
     pub(super) index: usize,
     pub(super) rule: ModelPolicyRule,
+}
+
+impl MatchedModelPolicy {
+    pub(super) fn matched_rule_ref(&self) -> MatchedPolicyRuleRef {
+        MatchedPolicyRuleRef {
+            layer: self.layer,
+            index: self.index,
+        }
+    }
 }
 
 pub fn resolve_policy(input: PolicyInput<'_>) -> Result<ResolvedPolicy, MarsError> {
@@ -90,10 +171,10 @@ pub fn resolve_policy(input: PolicyInput<'_>) -> Result<ResolvedPolicy, MarsErro
     warnings.extend(resolved_model.warnings);
     provenance.insert(
         "model_source".to_string(),
-        resolved_model.model_source.clone(),
+        resolved_model.model_source.label().to_string(),
     );
     let matched_policy = match_model_policy(
-        compose_effective_policies(
+        effective_policies(
             overlay,
             &input.profile.model_policies,
             &resolution_config.settings_model_policies,
@@ -101,16 +182,6 @@ pub fn resolve_policy(input: PolicyInput<'_>) -> Result<ResolvedPolicy, MarsErro
         &resolved_model.model,
         &resolved_model.model_token,
     );
-    if let Some(policy) = matched_policy.as_ref() {
-        provenance.insert(
-            "matched_policy_rule".to_string(),
-            format!(
-                "{}:{}",
-                policy.layer.matched_rule_layer_label(),
-                policy.index
-            ),
-        );
-    }
 
     let capability_snapshot = collect_capability_snapshot(&CapabilityCollectionOptions {
         offline: crate::models::is_mars_offline(),
@@ -141,7 +212,7 @@ pub fn resolve_policy(input: PolicyInput<'_>) -> Result<ResolvedPolicy, MarsErro
     warnings.extend(harness_resolution.warnings);
     provenance.insert(
         "harness_source".to_string(),
-        harness_resolution.source.to_string(),
+        harness_resolution.harness.source.label().to_string(),
     );
     provenance.insert(
         "route_confidence".to_string(),
@@ -151,7 +222,7 @@ pub fn resolve_policy(input: PolicyInput<'_>) -> Result<ResolvedPolicy, MarsErro
         "candidates_tried".to_string(),
         harness_resolution.candidates_tried.join(","),
     );
-    if harness_resolution.source == "config-order"
+    if harness_resolution.harness.source == PolicySource::ConfigOrder
         && let Some(position) = harness_resolution.harness_order_position
     {
         provenance.insert("harness_order_position".to_string(), position.to_string());
@@ -177,35 +248,55 @@ pub fn resolve_policy(input: PolicyInput<'_>) -> Result<ResolvedPolicy, MarsErro
 
     provenance.insert(
         "effort_source".to_string(),
-        execution_resolution.effort_source,
+        execution_resolution.effort.source.label().to_string(),
     );
     provenance.insert(
         "approval_source".to_string(),
-        execution_resolution.approval_source,
+        execution_resolution.approval.source.label().to_string(),
     );
     provenance.insert(
         "sandbox_source".to_string(),
-        execution_resolution.sandbox_source,
+        execution_resolution.sandbox.source.label().to_string(),
     );
     provenance.insert(
         "autocompact_source".to_string(),
-        execution_resolution.autocompact_source,
+        execution_resolution.autocompact.source.label().to_string(),
     );
     provenance.insert(
         "autocompact_pct_source".to_string(),
-        execution_resolution.autocompact_pct_source,
+        execution_resolution
+            .autocompact_pct
+            .source
+            .label()
+            .to_string(),
     );
     if execution_resolution.native_config.is_some() {
         provenance.insert(
             "native_config_source".to_string(),
-            "profile-harness-override".to_string(),
+            PolicySource::ProfileHarnessOverride.label().to_string(),
         );
+    }
+    let matched_rule = harness_resolution
+        .harness
+        .matched_rule
+        .or(execution_resolution.effort.matched_rule)
+        .or(execution_resolution.approval.matched_rule)
+        .or(execution_resolution.sandbox.matched_rule)
+        .or(execution_resolution.autocompact.matched_rule)
+        .or(execution_resolution.autocompact_pct.matched_rule)
+        .or_else(|| {
+            matched_policy
+                .as_ref()
+                .map(MatchedModelPolicy::matched_rule_ref)
+        });
+    if let Some(matched_rule) = matched_rule {
+        provenance.insert("matched_policy_rule".to_string(), matched_rule.label());
     }
 
     let routing_resolution = runnable::resolve_routing(runnable::RoutingInput {
         model: resolved_model.model,
         model_token: resolved_model.model_token,
-        harness: harness_resolution.harness,
+        harness: harness_resolution.harness.value,
         route_confidence: harness_resolution.route_confidence.label().to_string(),
         provider: resolved_model.provider.as_deref(),
         opencode_probe_result,
@@ -217,11 +308,11 @@ pub fn resolve_policy(input: PolicyInput<'_>) -> Result<ResolvedPolicy, MarsErro
     Ok(ResolvedPolicy {
         routing: routing_resolution.routing,
         execution_policy: ExecutionPolicy {
-            effort: execution_resolution.effort,
-            approval: execution_resolution.approval,
-            sandbox: execution_resolution.sandbox,
-            autocompact: execution_resolution.autocompact,
-            autocompact_pct: execution_resolution.autocompact_pct,
+            effort: execution_resolution.effort.value,
+            approval: execution_resolution.approval.value,
+            sandbox: execution_resolution.sandbox.value,
+            autocompact: execution_resolution.autocompact.value,
+            autocompact_pct: execution_resolution.autocompact_pct.value,
             timeout: None,
             native_config: execution_resolution.native_config,
             codex_rules: None,
@@ -267,28 +358,75 @@ pub(super) fn policy_override_u8(rule: &ModelPolicyRule, key: &str) -> Option<u8
     }
 }
 
-fn compose_effective_policies<'a>(
+pub(super) fn matched_policy_string_override(
+    matched_policy: Option<&MatchedModelPolicy>,
+    key: &str,
+) -> Option<ResolvedField<String>> {
+    let policy = matched_policy?;
+    let value = policy_override_string(&policy.rule, key)?;
+    Some(ResolvedField {
+        value,
+        source: policy.layer.field_source(),
+        matched_rule: Some(policy.matched_rule_ref()),
+    })
+}
+
+pub(super) fn matched_policy_u32_override(
+    matched_policy: Option<&MatchedModelPolicy>,
+    key: &str,
+) -> Option<ResolvedField<u32>> {
+    let policy = matched_policy?;
+    let value = policy_override_u32(&policy.rule, key)?;
+    Some(ResolvedField {
+        value,
+        source: policy.layer.field_source(),
+        matched_rule: Some(policy.matched_rule_ref()),
+    })
+}
+
+pub(super) fn matched_policy_u8_override(
+    matched_policy: Option<&MatchedModelPolicy>,
+    key: &str,
+) -> Option<ResolvedField<u8>> {
+    let policy = matched_policy?;
+    let value = policy_override_u8(&policy.rule, key)?;
+    Some(ResolvedField {
+        value,
+        source: policy.layer.field_source(),
+        matched_rule: Some(policy.matched_rule_ref()),
+    })
+}
+
+fn effective_policies<'a>(
     overlay: Option<&'a AgentOverlay>,
     profile_policies: &'a [ModelPolicyRule],
     settings_policies: &'a [ModelPolicyRule],
-) -> Vec<(PolicyLayer, usize, &'a ModelPolicyRule)> {
-    let mut composed = Vec::new();
-    if let Some(agent_overlay) = overlay {
-        for (index, rule) in agent_overlay.model_policies.iter().enumerate() {
-            composed.push((PolicyLayer::Overlay, index, rule));
-        }
-    }
-    for (index, rule) in profile_policies.iter().enumerate() {
-        composed.push((PolicyLayer::Profile, index, rule));
-    }
-    for (index, rule) in settings_policies.iter().enumerate() {
-        composed.push((PolicyLayer::Settings, index, rule));
-    }
-    composed
+) -> impl Iterator<Item = (PolicyLayer, usize, &'a ModelPolicyRule)> + 'a {
+    overlay
+        .into_iter()
+        .flat_map(|agent_overlay| {
+            agent_overlay
+                .model_policies
+                .iter()
+                .enumerate()
+                .map(|(index, rule)| (PolicyLayer::Overlay, index, rule))
+        })
+        .chain(
+            profile_policies
+                .iter()
+                .enumerate()
+                .map(|(index, rule)| (PolicyLayer::Profile, index, rule)),
+        )
+        .chain(
+            settings_policies
+                .iter()
+                .enumerate()
+                .map(|(index, rule)| (PolicyLayer::Settings, index, rule)),
+        )
 }
 
-fn match_model_policy(
-    policies: Vec<(PolicyLayer, usize, &ModelPolicyRule)>,
+fn match_model_policy<'a>(
+    policies: impl Iterator<Item = (PolicyLayer, usize, &'a ModelPolicyRule)>,
     canonical_model_id: &str,
     selected_model_token: &str,
 ) -> Option<MatchedModelPolicy> {

--- a/src/build/policy/model.rs
+++ b/src/build/policy/model.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use indexmap::IndexMap;
 
 use crate::build::policy::PolicyInput;
+use crate::config::AgentOverlay;
 use crate::error::{ConfigError, MarsError};
 use crate::models::{self, ModelAlias, ModelsCache};
 
@@ -22,6 +23,7 @@ pub(super) struct ResolvedModel<'a> {
 /// `settings.default_model` from `mars.toml`.
 pub(super) fn resolve_model<'a>(
     input: &PolicyInput<'_>,
+    overlay: Option<&AgentOverlay>,
     aliases: &'a IndexMap<String, ModelAlias>,
     cache: &ModelsCache,
 ) -> Result<ResolvedModel<'a>, MarsError> {
@@ -29,16 +31,19 @@ pub(super) fn resolve_model<'a>(
 
     let (model_token, model_source) = match input.model_override {
         Some(model) => (model.to_string(), "cli".to_string()),
-        None => match input.profile.model.as_deref() {
-            Some(model) => (model.to_string(), "profile".to_string()),
-            None => match input.config_default_model {
-                Some(model) => (model.to_string(), "project".to_string()),
-                None => {
-                    return Err(MarsError::Config(ConfigError::Invalid {
-                        message: "launch-bundle requires a model (set `model:` in the agent profile, set `settings.default_model` in mars.toml, or pass `--model`)"
-                            .to_string(),
-                    }));
-                }
+        None => match overlay.and_then(|entry| entry.model.as_deref()) {
+            Some(model) => (model.to_string(), "overlay".to_string()),
+            None => match input.profile.model.as_deref() {
+                Some(model) => (model.to_string(), "profile".to_string()),
+                None => match input.config_default_model {
+                    Some(model) => (model.to_string(), "project".to_string()),
+                    None => {
+                        return Err(MarsError::Config(ConfigError::Invalid {
+                            message: "launch-bundle requires a model (set `model:` in the agent profile, set `settings.default_model` in mars.toml, or pass `--model`)"
+                                .to_string(),
+                        }));
+                    }
+                },
             },
         },
     };

--- a/src/build/policy/model.rs
+++ b/src/build/policy/model.rs
@@ -2,14 +2,14 @@ use std::path::Path;
 
 use indexmap::IndexMap;
 
-use crate::build::policy::PolicyInput;
+use crate::build::policy::{PolicyInput, PolicySource};
 use crate::config::AgentOverlay;
 use crate::error::{ConfigError, MarsError};
 use crate::models::{self, ModelAlias, ModelsCache};
 
 pub(super) struct ResolvedModel<'a> {
     pub(super) model_token: String,
-    pub(super) model_source: String,
+    pub(super) model_source: PolicySource,
     pub(super) model: String,
     pub(super) alias: Option<&'a ModelAlias>,
     pub(super) alias_resolution_failed: bool,
@@ -30,13 +30,13 @@ pub(super) fn resolve_model<'a>(
     let mut warnings = Vec::new();
 
     let (model_token, model_source) = match input.model_override {
-        Some(model) => (model.to_string(), "cli".to_string()),
+        Some(model) => (model.to_string(), PolicySource::Cli),
         None => match overlay.and_then(|entry| entry.model.as_deref()) {
-            Some(model) => (model.to_string(), "overlay".to_string()),
+            Some(model) => (model.to_string(), PolicySource::Overlay),
             None => match input.profile.model.as_deref() {
-                Some(model) => (model.to_string(), "profile".to_string()),
+                Some(model) => (model.to_string(), PolicySource::Profile),
                 None => match input.config_default_model {
-                    Some(model) => (model.to_string(), "project".to_string()),
+                    Some(model) => (model.to_string(), PolicySource::Project),
                     None => {
                         return Err(MarsError::Config(ConfigError::Invalid {
                             message: "launch-bundle requires a model (set `model:` in the agent profile, set `settings.default_model` in mars.toml, or pass `--model`)"

--- a/src/compiler/agents/mod.rs
+++ b/src/compiler/agents/mod.rs
@@ -827,6 +827,81 @@ fn push_model_policy_invalid(
     });
 }
 
+fn push_model_policy_parse_error(
+    diags: &mut Vec<AgentDiagnostic>,
+    position: usize,
+    error: crate::config::ModelPolicyRuleParseError,
+) {
+    let rule_field = format!("model-policies[{position}]");
+    match error {
+        crate::config::ModelPolicyRuleParseError::RuleMustBeMapping { found } => {
+            push_model_policy_invalid(diags, rule_field, found, "mapping with match and override");
+        }
+        crate::config::ModelPolicyRuleParseError::MatchMissing => {
+            push_model_policy_invalid(
+                diags,
+                format!("{rule_field}.match"),
+                "<missing>",
+                "mapping with exactly one of model, alias, model-glob",
+            );
+        }
+        crate::config::ModelPolicyRuleParseError::MatchMustBeMapping { found } => {
+            push_model_policy_invalid(
+                diags,
+                format!("{rule_field}.match"),
+                found,
+                "mapping with exactly one of model, alias, model-glob",
+            );
+        }
+        crate::config::ModelPolicyRuleParseError::MatchMustContainExactlyOne { found } => {
+            push_model_policy_invalid(
+                diags,
+                format!("{rule_field}.match"),
+                found,
+                "exactly one of model, alias, model-glob",
+            );
+        }
+        crate::config::ModelPolicyRuleParseError::MatchKeyMustBeString { found } => {
+            push_model_policy_invalid(
+                diags,
+                format!("{rule_field}.match"),
+                found,
+                "model, alias, model-glob",
+            );
+        }
+        crate::config::ModelPolicyRuleParseError::UnknownMatchKey { key } => {
+            push_model_policy_invalid(
+                diags,
+                format!("{rule_field}.match"),
+                key,
+                "model, alias, model-glob",
+            );
+        }
+        crate::config::ModelPolicyRuleParseError::MatchValueMustBeString { key, found } => {
+            push_model_policy_invalid(
+                diags,
+                format!("{rule_field}.match.{key}"),
+                found,
+                "non-empty string",
+            );
+        }
+        crate::config::ModelPolicyRuleParseError::MatchValueEmpty { key } => {
+            push_model_policy_invalid(
+                diags,
+                format!("{rule_field}.match.{key}"),
+                "<empty>",
+                "non-empty string",
+            );
+        }
+        crate::config::ModelPolicyRuleParseError::OverrideMustBeMapping { found } => {
+            push_model_policy_invalid(diags, format!("{rule_field}.override"), found, "mapping");
+        }
+        crate::config::ModelPolicyRuleParseError::NoFallbackMustBeBoolean { found } => {
+            push_model_policy_invalid(diags, format!("{rule_field}.no-fallback"), found, "boolean");
+        }
+    }
+}
+
 fn parse_model_policies(val: &Value, diags: &mut Vec<AgentDiagnostic>) -> Vec<ModelPolicyRule> {
     let Some(seq) = val.as_sequence() else {
         push_model_policy_invalid(
@@ -841,117 +916,10 @@ fn parse_model_policies(val: &Value, diags: &mut Vec<AgentDiagnostic>) -> Vec<Mo
     let mut out = Vec::new();
     for (index, entry) in seq.iter().enumerate() {
         let position = index + 1;
-        let Some(rule) = entry.as_mapping() else {
-            push_model_policy_invalid(
-                diags,
-                format!("model-policies[{position}]"),
-                format!("{entry:?}"),
-                "mapping with match and override",
-            );
-            continue;
-        };
-
-        let match_value = rule.get(Value::String("match".to_string()));
-        let Some(match_mapping) = match_value.and_then(Value::as_mapping) else {
-            push_model_policy_invalid(
-                diags,
-                format!("model-policies[{position}].match"),
-                match_value
-                    .map(|value| format!("{value:?}"))
-                    .unwrap_or_else(|| "<missing>".to_string()),
-                "mapping with exactly one of model, alias, model-glob",
-            );
-            continue;
-        };
-
-        let normalized_match_keys: Vec<&str> =
-            match_mapping.keys().filter_map(Value::as_str).collect();
-        if normalized_match_keys.len() != 1 {
-            push_model_policy_invalid(
-                diags,
-                format!("model-policies[{position}].match"),
-                format!("{match_mapping:?}"),
-                "exactly one of model, alias, model-glob",
-            );
-            continue;
+        match crate::config::parse_model_policy_rule_value(entry) {
+            Ok(rule) => out.push(rule),
+            Err(error) => push_model_policy_parse_error(diags, position, error),
         }
-        let match_key = normalized_match_keys[0];
-        if !matches!(match_key, "model" | "alias" | "model-glob") {
-            push_model_policy_invalid(
-                diags,
-                format!("model-policies[{position}].match"),
-                match_key,
-                "model, alias, model-glob",
-            );
-            continue;
-        }
-        let raw_match_value = match_mapping.get(Value::String(match_key.to_string()));
-        let Some(match_text) = raw_match_value.and_then(Value::as_str).map(str::trim) else {
-            push_model_policy_invalid(
-                diags,
-                format!("model-policies[{position}].match.{match_key}"),
-                raw_match_value
-                    .map(|value| format!("{value:?}"))
-                    .unwrap_or_else(|| "<missing>".to_string()),
-                "non-empty string",
-            );
-            continue;
-        };
-        if match_text.is_empty() {
-            push_model_policy_invalid(
-                diags,
-                format!("model-policies[{position}].match.{match_key}"),
-                "<empty>",
-                "non-empty string",
-            );
-            continue;
-        }
-
-        let override_value = rule.get(Value::String("override".to_string()));
-        let empty_override = serde_yaml::Mapping::new();
-        let override_mapping = match override_value {
-            None | Some(Value::Null) => &empty_override,
-            Some(value) => {
-                let Some(mapping) = value.as_mapping() else {
-                    push_model_policy_invalid(
-                        diags,
-                        format!("model-policies[{position}].override"),
-                        format!("{value:?}"),
-                        "mapping",
-                    );
-                    continue;
-                };
-                mapping
-            }
-        };
-
-        let no_fallback = match rule.get(Value::String("no-fallback".to_string())) {
-            None | Some(Value::Null) => false,
-            Some(Value::Bool(value)) => *value,
-            Some(value) => {
-                push_model_policy_invalid(
-                    diags,
-                    format!("model-policies[{position}].no-fallback"),
-                    format!("{value:?}"),
-                    "boolean",
-                );
-                continue;
-            }
-        };
-
-        let match_type = match match_key {
-            "model" => ModelPolicyMatchType::Model,
-            "alias" => ModelPolicyMatchType::Alias,
-            "model-glob" => ModelPolicyMatchType::ModelGlob,
-            _ => unreachable!("match_key was validated above"),
-        };
-
-        out.push(ModelPolicyRule {
-            match_type,
-            match_value: match_text.to_string(),
-            no_fallback,
-            overrides: override_mapping.clone(),
-        });
     }
     out
 }

--- a/src/compiler/agents/mod.rs
+++ b/src/compiler/agents/mod.rs
@@ -9,6 +9,7 @@ pub mod lower;
 
 use serde_yaml::Value;
 
+pub use crate::config::{ModelPolicyMatchType, ModelPolicyRule};
 use crate::frontmatter::{Frontmatter, FrontmatterError};
 
 // ---------------------------------------------------------------------------
@@ -222,25 +223,6 @@ impl HarnessOverrides {
     }
 }
 
-/// Parsed `model-policies:` entry.
-///
-/// Per the spec (D43), model-policies are consumed by Meridian at runtime.
-/// Mars parses them at compile time only for validation and preservation.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ModelPolicyEntry {
-    pub match_type: ModelPolicyMatchType,
-    pub match_value: String,
-    pub no_fallback: bool,
-    pub overrides: serde_yaml::Mapping,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ModelPolicyMatchType {
-    Model,
-    Alias,
-    ModelGlob,
-}
-
 /// Marker for a validated fanout inventory entry (`fanout:`).
 ///
 /// Fanout is metadata-only (D43): it never gains lowering behavior.
@@ -290,7 +272,7 @@ pub struct AgentProfile {
 
     // --- Override tables ---
     pub harness_overrides: HarnessOverrides,
-    pub model_policies: Vec<ModelPolicyEntry>,
+    pub model_policies: Vec<ModelPolicyRule>,
     pub fanout: Vec<FanoutEntry>,
 }
 
@@ -845,7 +827,7 @@ fn push_model_policy_invalid(
     });
 }
 
-fn parse_model_policies(val: &Value, diags: &mut Vec<AgentDiagnostic>) -> Vec<ModelPolicyEntry> {
+fn parse_model_policies(val: &Value, diags: &mut Vec<AgentDiagnostic>) -> Vec<ModelPolicyRule> {
     let Some(seq) = val.as_sequence() else {
         push_model_policy_invalid(
             diags,
@@ -964,7 +946,7 @@ fn parse_model_policies(val: &Value, diags: &mut Vec<AgentDiagnostic>) -> Vec<Mo
             _ => unreachable!("match_key was validated above"),
         };
 
-        out.push(ModelPolicyEntry {
+        out.push(ModelPolicyRule {
             match_type,
             match_value: match_text.to_string(),
             no_fallback,

--- a/src/compiler/agents/tests.rs
+++ b/src/compiler/agents/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::config::Config;
 use crate::frontmatter::Frontmatter;
 
 fn parse(content: &str) -> (AgentProfile, Vec<AgentDiagnostic>) {
@@ -336,6 +337,39 @@ fn malformed_model_policy_produces_diagnostic() {
     assert!(
         matches!(&diags[0], AgentDiagnostic::InvalidFieldValue { field, .. } if field == "model-policies[1].match")
     );
+}
+
+#[test]
+fn model_policy_rule_type_is_shared_across_profile_overlay_and_settings() {
+    let profile_content = "---\nmodel-policies:\n  - match:\n      alias: gpt55\n    override:\n      harness: codex\n---\n";
+    let (profile, diags) = parse(profile_content);
+    assert!(diags.is_empty());
+
+    let config: Config = toml::from_str(
+        r#"
+[agents.reviewer]
+
+[[agents.reviewer.model-policies]]
+match = { alias = "gpt55" }
+override = { harness = "codex" }
+
+[settings]
+
+[[settings.model-policies]]
+match = { alias = "gpt55" }
+override = { harness = "codex" }
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(profile.model_policies.len(), 1);
+    assert_eq!(config.agents["reviewer"].model_policies.len(), 1);
+    assert_eq!(config.settings.model_policies.len(), 1);
+    assert_eq!(
+        profile.model_policies[0],
+        config.agents["reviewer"].model_policies[0]
+    );
+    assert_eq!(profile.model_policies[0], config.settings.model_policies[0]);
 }
 
 // --- 3.1: fanout ---

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -225,14 +225,143 @@ pub struct ModelPolicyRule {
     pub overrides: serde_yaml::Mapping,
 }
 
-#[derive(Debug, Clone, Deserialize)]
-struct RawModelPolicyRule {
-    #[serde(rename = "match")]
-    match_clause: serde_yaml::Mapping,
-    #[serde(default, rename = "override")]
-    overrides: serde_yaml::Mapping,
-    #[serde(default, rename = "no-fallback")]
-    no_fallback: bool,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ModelPolicyRuleParseError {
+    RuleMustBeMapping { found: String },
+    MatchMissing,
+    MatchMustBeMapping { found: String },
+    MatchMustContainExactlyOne { found: String },
+    MatchKeyMustBeString { found: String },
+    UnknownMatchKey { key: String },
+    MatchValueMustBeString { key: String, found: String },
+    MatchValueEmpty { key: String },
+    OverrideMustBeMapping { found: String },
+    NoFallbackMustBeBoolean { found: String },
+}
+
+impl ModelPolicyRuleParseError {
+    fn deserialize_message(&self) -> String {
+        match self {
+            Self::MatchMustContainExactlyOne { .. }
+            | Self::MatchMissing
+            | Self::MatchMustBeMapping { .. } => {
+                "model policy `match` must contain exactly one of model, alias, model-glob"
+                    .to_string()
+            }
+            Self::MatchKeyMustBeString { .. } => {
+                "model policy `match` key must be a string".to_string()
+            }
+            Self::MatchValueMustBeString { .. } => {
+                "model policy `match` value must be a string".to_string()
+            }
+            Self::MatchValueEmpty { .. } => {
+                "model policy `match` value must be a non-empty string".to_string()
+            }
+            Self::UnknownMatchKey { key } => {
+                format!(
+                    "unknown model policy match key `{key}`; expected model, alias, or model-glob"
+                )
+            }
+            Self::OverrideMustBeMapping { .. } => {
+                "model policy `override` must be a mapping".to_string()
+            }
+            Self::NoFallbackMustBeBoolean { .. } => {
+                "model policy `no-fallback` must be a boolean".to_string()
+            }
+            Self::RuleMustBeMapping { .. } => "model policy rule must be a mapping".to_string(),
+        }
+    }
+}
+
+pub fn parse_model_policy_rule_value(
+    value: &serde_yaml::Value,
+) -> Result<ModelPolicyRule, ModelPolicyRuleParseError> {
+    let rule = value
+        .as_mapping()
+        .ok_or_else(|| ModelPolicyRuleParseError::RuleMustBeMapping {
+            found: format!("{value:?}"),
+        })?;
+
+    let match_value = rule.get(serde_yaml::Value::String("match".to_string()));
+    let match_mapping = match match_value {
+        Some(value) => {
+            value
+                .as_mapping()
+                .ok_or_else(|| ModelPolicyRuleParseError::MatchMustBeMapping {
+                    found: format!("{value:?}"),
+                })?
+        }
+        None => return Err(ModelPolicyRuleParseError::MatchMissing),
+    };
+
+    let mut entries = match_mapping.iter();
+    let Some((match_key, match_value)) = entries.next() else {
+        return Err(ModelPolicyRuleParseError::MatchMustContainExactlyOne {
+            found: format!("{match_mapping:?}"),
+        });
+    };
+    if entries.next().is_some() {
+        return Err(ModelPolicyRuleParseError::MatchMustContainExactlyOne {
+            found: format!("{match_mapping:?}"),
+        });
+    }
+
+    let key =
+        match_key
+            .as_str()
+            .ok_or_else(|| ModelPolicyRuleParseError::MatchKeyMustBeString {
+                found: format!("{match_key:?}"),
+            })?;
+    let value =
+        match_value
+            .as_str()
+            .ok_or_else(|| ModelPolicyRuleParseError::MatchValueMustBeString {
+                key: key.to_string(),
+                found: format!("{match_value:?}"),
+            })?;
+    let match_value = value.trim().to_string();
+    if match_value.is_empty() {
+        return Err(ModelPolicyRuleParseError::MatchValueEmpty {
+            key: key.to_string(),
+        });
+    }
+
+    let match_type = match key {
+        "model" => ModelPolicyMatchType::Model,
+        "alias" => ModelPolicyMatchType::Alias,
+        "model-glob" => ModelPolicyMatchType::ModelGlob,
+        _ => {
+            return Err(ModelPolicyRuleParseError::UnknownMatchKey {
+                key: key.to_string(),
+            });
+        }
+    };
+
+    let overrides = match rule.get(serde_yaml::Value::String("override".to_string())) {
+        None | Some(serde_yaml::Value::Null) => serde_yaml::Mapping::new(),
+        Some(value) => value.as_mapping().cloned().ok_or_else(|| {
+            ModelPolicyRuleParseError::OverrideMustBeMapping {
+                found: format!("{value:?}"),
+            }
+        })?,
+    };
+
+    let no_fallback = match rule.get(serde_yaml::Value::String("no-fallback".to_string())) {
+        None | Some(serde_yaml::Value::Null) => false,
+        Some(serde_yaml::Value::Bool(value)) => *value,
+        Some(value) => {
+            return Err(ModelPolicyRuleParseError::NoFallbackMustBeBoolean {
+                found: format!("{value:?}"),
+            });
+        }
+    };
+
+    Ok(ModelPolicyRule {
+        match_type,
+        match_value,
+        no_fallback,
+        overrides,
+    })
 }
 
 impl<'de> Deserialize<'de> for ModelPolicyRule {
@@ -240,50 +369,9 @@ impl<'de> Deserialize<'de> for ModelPolicyRule {
     where
         D: serde::Deserializer<'de>,
     {
-        let raw = RawModelPolicyRule::deserialize(deserializer)?;
-        let mut entries = raw.match_clause.iter();
-        let Some((match_key, match_value)) = entries.next() else {
-            return Err(serde::de::Error::custom(
-                "model policy `match` must contain exactly one of model, alias, model-glob",
-            ));
-        };
-        if entries.next().is_some() {
-            return Err(serde::de::Error::custom(
-                "model policy `match` must contain exactly one of model, alias, model-glob",
-            ));
-        }
-
-        let key = match_key
-            .as_str()
-            .ok_or_else(|| serde::de::Error::custom("model policy `match` key must be a string"))?;
-        let value = match_value
-            .as_str()
-            .ok_or_else(|| serde::de::Error::custom("model policy `match` value must be a string"))?
-            .trim()
-            .to_string();
-        if value.is_empty() {
-            return Err(serde::de::Error::custom(
-                "model policy `match` value must be a non-empty string",
-            ));
-        }
-
-        let match_type = match key {
-            "model" => ModelPolicyMatchType::Model,
-            "alias" => ModelPolicyMatchType::Alias,
-            "model-glob" => ModelPolicyMatchType::ModelGlob,
-            other => {
-                return Err(serde::de::Error::custom(format!(
-                    "unknown model policy match key `{other}`; expected model, alias, or model-glob"
-                )));
-            }
-        };
-
-        Ok(Self {
-            match_type,
-            match_value: value,
-            no_fallback: raw.no_fallback,
-            overrides: raw.overrides,
-        })
+        let value = serde_yaml::Value::deserialize(deserializer)?;
+        parse_model_policy_rule_value(&value)
+            .map_err(|err| serde::de::Error::custom(err.deserialize_message()))
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,6 +3,7 @@
 use std::path::{Path, PathBuf};
 
 use indexmap::IndexMap;
+use serde::ser::SerializeMap;
 use serde::{Deserialize, Serialize};
 
 use crate::diagnostic::{Diagnostic, DiagnosticCategory, DiagnosticLevel};
@@ -36,6 +37,8 @@ pub struct Config {
     pub settings: Settings,
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub models: IndexMap<String, crate::models::ModelAlias>,
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub agents: IndexMap<String, AgentOverlay>,
 }
 
 /// Package metadata.
@@ -179,6 +182,139 @@ impl ModelVisibility {
     }
 }
 
+/// Per-agent launch-bundle overlay policy in mars.toml `[agents.<name>]`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct AgentOverlay {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub harness: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approval: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sandbox: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub autocompact: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub autocompact_pct: Option<i64>,
+    #[serde(
+        default,
+        rename = "model-policies",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub model_policies: Vec<ModelPolicyRule>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum ModelPolicyMatchType {
+    Model,
+    Alias,
+    ModelGlob,
+}
+
+/// Shared model-policy rule type used by profile frontmatter, agent overlays,
+/// and settings-level model policies.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ModelPolicyRule {
+    pub match_type: ModelPolicyMatchType,
+    pub match_value: String,
+    pub no_fallback: bool,
+    pub overrides: serde_yaml::Mapping,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RawModelPolicyRule {
+    #[serde(rename = "match")]
+    match_clause: serde_yaml::Mapping,
+    #[serde(default, rename = "override")]
+    overrides: serde_yaml::Mapping,
+    #[serde(default, rename = "no-fallback")]
+    no_fallback: bool,
+}
+
+impl<'de> Deserialize<'de> for ModelPolicyRule {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = RawModelPolicyRule::deserialize(deserializer)?;
+        let mut entries = raw.match_clause.iter();
+        let Some((match_key, match_value)) = entries.next() else {
+            return Err(serde::de::Error::custom(
+                "model policy `match` must contain exactly one of model, alias, model-glob",
+            ));
+        };
+        if entries.next().is_some() {
+            return Err(serde::de::Error::custom(
+                "model policy `match` must contain exactly one of model, alias, model-glob",
+            ));
+        }
+
+        let key = match_key
+            .as_str()
+            .ok_or_else(|| serde::de::Error::custom("model policy `match` key must be a string"))?;
+        let value = match_value
+            .as_str()
+            .ok_or_else(|| serde::de::Error::custom("model policy `match` value must be a string"))?
+            .trim()
+            .to_string();
+        if value.is_empty() {
+            return Err(serde::de::Error::custom(
+                "model policy `match` value must be a non-empty string",
+            ));
+        }
+
+        let match_type = match key {
+            "model" => ModelPolicyMatchType::Model,
+            "alias" => ModelPolicyMatchType::Alias,
+            "model-glob" => ModelPolicyMatchType::ModelGlob,
+            other => {
+                return Err(serde::de::Error::custom(format!(
+                    "unknown model policy match key `{other}`; expected model, alias, or model-glob"
+                )));
+            }
+        };
+
+        Ok(Self {
+            match_type,
+            match_value: value,
+            no_fallback: raw.no_fallback,
+            overrides: raw.overrides,
+        })
+    }
+}
+
+impl Serialize for ModelPolicyRule {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        let match_key = match self.match_type {
+            ModelPolicyMatchType::Model => "model",
+            ModelPolicyMatchType::Alias => "alias",
+            ModelPolicyMatchType::ModelGlob => "model-glob",
+        };
+
+        let mut match_clause = serde_yaml::Mapping::new();
+        match_clause.insert(
+            serde_yaml::Value::String(match_key.to_string()),
+            serde_yaml::Value::String(self.match_value.clone()),
+        );
+        map.serialize_entry("match", &match_clause)?;
+        if !self.overrides.is_empty() {
+            map.serialize_entry("override", &self.overrides)?;
+        }
+        if self.no_fallback {
+            map.serialize_entry("no-fallback", &self.no_fallback)?;
+        }
+        map.end()
+    }
+}
+
 fn is_false(v: &bool) -> bool {
     !v
 }
@@ -191,6 +327,22 @@ fn is_false(v: &bool) -> bool {
 pub struct LocalConfig {
     #[serde(default)]
     pub overrides: IndexMap<SourceName, OverrideEntry>,
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub agents: IndexMap<String, AgentOverlay>,
+    #[serde(default, skip_serializing_if = "LocalSettings::is_empty")]
+    pub settings: LocalSettings,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct LocalSettings {
+    #[serde(default, rename = "model-policies")]
+    pub model_policies: Option<Vec<ModelPolicyRule>>,
+}
+
+impl LocalSettings {
+    fn is_empty(&self) -> bool {
+        self.model_policies.is_none()
+    }
 }
 
 /// Dev override — local path swap for a git source.
@@ -244,6 +396,12 @@ pub struct Settings {
     /// `MERIDIAN_MANAGED=1`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_emission: Option<AgentEmission>,
+    #[serde(
+        default,
+        rename = "model-policies",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub model_policies: Vec<ModelPolicyRule>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -266,6 +424,7 @@ impl Default for Settings {
             default_model: None,
             harness_order: None,
             agent_emission: None,
+            model_policies: Vec::new(),
         }
     }
 }
@@ -441,6 +600,28 @@ pub fn load_local(root: &Path) -> Result<LocalConfig, MarsError> {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(LocalConfig::default()),
         Err(e) => Err(ConfigError::Io(e).into()),
     }
+}
+
+pub fn merged_agent_overlays(
+    base: &IndexMap<String, AgentOverlay>,
+    local: &LocalConfig,
+) -> IndexMap<String, AgentOverlay> {
+    let mut merged = base.clone();
+    for (name, overlay) in &local.agents {
+        merged.insert(name.clone(), overlay.clone());
+    }
+    merged
+}
+
+pub fn merged_settings_model_policies(
+    settings: &Settings,
+    local: &LocalConfig,
+) -> Vec<ModelPolicyRule> {
+    local
+        .settings
+        .model_policies
+        .clone()
+        .unwrap_or_else(|| settings.model_policies.clone())
 }
 
 /// Merge config + local overrides into EffectiveConfig.
@@ -808,6 +989,19 @@ fn validate_save_roundtrip(original: &Config, reparsed: &Config) -> Result<(), M
                 "refusing to save config: settings.agent_emission changed during roundtrip ({:?} -> {:?})",
                 original.settings.agent_emission, reparsed.settings.agent_emission
             ),
+        }
+        .into());
+    }
+    if reparsed.settings.model_policies != original.settings.model_policies {
+        return Err(ConfigError::Invalid {
+            message: "refusing to save config: settings.model_policies changed during roundtrip"
+                .to_string(),
+        }
+        .into());
+    }
+    if reparsed.agents != original.agents {
+        return Err(ConfigError::Invalid {
+            message: "refusing to save config: agents changed during roundtrip".to_string(),
         }
         .into());
     }
@@ -1232,6 +1426,147 @@ path = "/home/dev/local-base"
     }
 
     #[test]
+    fn parse_agent_overlay_and_settings_model_policies() {
+        let config: Config = toml::from_str(
+            r#"
+[agents.tech-lead]
+model = "gpt55"
+harness = "codex"
+effort = "medium"
+approval = "default"
+sandbox = "default"
+autocompact = 1200
+autocompact_pct = 80
+
+[[agents.tech-lead.model-policies]]
+match = { alias = "gpt55" }
+override = { harness = "opencode", effort = "low" }
+no-fallback = true
+
+[settings]
+
+[[settings.model-policies]]
+match = { model-glob = "gpt-*" }
+override = { effort = "high" }
+"#,
+        )
+        .unwrap();
+
+        let overlay = config.agents.get("tech-lead").expect("tech-lead overlay");
+        assert_eq!(overlay.model.as_deref(), Some("gpt55"));
+        assert_eq!(overlay.harness.as_deref(), Some("codex"));
+        assert_eq!(overlay.autocompact, Some(1200));
+        assert_eq!(overlay.autocompact_pct, Some(80));
+        assert_eq!(overlay.model_policies.len(), 1);
+        assert_eq!(
+            overlay.model_policies[0].match_type,
+            ModelPolicyMatchType::Alias
+        );
+        assert_eq!(overlay.model_policies[0].match_value, "gpt55");
+        assert!(overlay.model_policies[0].no_fallback);
+
+        assert_eq!(config.settings.model_policies.len(), 1);
+        assert_eq!(
+            config.settings.model_policies[0].match_type,
+            ModelPolicyMatchType::ModelGlob
+        );
+        assert_eq!(config.settings.model_policies[0].match_value, "gpt-*");
+    }
+
+    #[test]
+    fn merged_agent_overlays_replace_by_agent_name() {
+        let mut base_agents = IndexMap::new();
+        base_agents.insert(
+            "tech-lead".to_string(),
+            AgentOverlay {
+                model: Some("gpt55".to_string()),
+                harness: Some("codex".to_string()),
+                effort: Some("high".to_string()),
+                ..AgentOverlay::default()
+            },
+        );
+        base_agents.insert(
+            "reviewer".to_string(),
+            AgentOverlay {
+                model: Some("gpt-5.4-mini".to_string()),
+                ..AgentOverlay::default()
+            },
+        );
+
+        let mut local_agents = IndexMap::new();
+        local_agents.insert(
+            "tech-lead".to_string(),
+            AgentOverlay {
+                model: Some("gptmini".to_string()),
+                ..AgentOverlay::default()
+            },
+        );
+        let local = LocalConfig {
+            agents: local_agents,
+            ..LocalConfig::default()
+        };
+
+        let merged = merged_agent_overlays(&base_agents, &local);
+        let replaced = merged.get("tech-lead").expect("tech-lead should exist");
+        assert_eq!(replaced.model.as_deref(), Some("gptmini"));
+        assert!(
+            replaced.harness.is_none(),
+            "local overlay must replace the base overlay block"
+        );
+        assert!(
+            replaced.effort.is_none(),
+            "local overlay replacement must not deep-merge base fields"
+        );
+        assert_eq!(
+            merged
+                .get("reviewer")
+                .and_then(|overlay| overlay.model.as_deref()),
+            Some("gpt-5.4-mini")
+        );
+    }
+
+    #[test]
+    fn merged_settings_model_policies_use_local_replacement_when_present() {
+        let mut base_override = serde_yaml::Mapping::new();
+        base_override.insert(
+            serde_yaml::Value::String("harness".to_string()),
+            serde_yaml::Value::String("codex".to_string()),
+        );
+        let base_rule = ModelPolicyRule {
+            match_type: ModelPolicyMatchType::Alias,
+            match_value: "gpt55".to_string(),
+            no_fallback: false,
+            overrides: base_override,
+        };
+
+        let mut local_override = serde_yaml::Mapping::new();
+        local_override.insert(
+            serde_yaml::Value::String("harness".to_string()),
+            serde_yaml::Value::String("opencode".to_string()),
+        );
+        let local_rule = ModelPolicyRule {
+            match_type: ModelPolicyMatchType::Alias,
+            match_value: "gpt55".to_string(),
+            no_fallback: false,
+            overrides: local_override,
+        };
+
+        let settings = Settings {
+            model_policies: vec![base_rule],
+            ..Settings::default()
+        };
+        let local = LocalConfig {
+            settings: LocalSettings {
+                model_policies: Some(vec![local_rule.clone()]),
+            },
+            ..LocalConfig::default()
+        };
+
+        let merged = merged_settings_model_policies(&settings, &local);
+        assert_eq!(merged, vec![local_rule]);
+    }
+
+    #[test]
     fn merge_with_empty_local() {
         let config = Config {
             dependencies: {
@@ -1297,6 +1632,7 @@ path = "/home/dev/local-base"
                 );
                 m
             },
+            ..LocalConfig::default()
         };
         let effective = merge(config, local).unwrap();
         let source = &effective.dependencies["base"];
@@ -1350,6 +1686,7 @@ path = "/home/dev/local-base"
                 );
                 m
             },
+            ..LocalConfig::default()
         };
 
         let (effective, _) = merge_with_root(config, local, &temp_root).unwrap();
@@ -2462,7 +2799,10 @@ skills = ["prompt-helper"]
                 path: PathBuf::from("C:\\Users\\dev\\local-pkg"),
             },
         );
-        let local = LocalConfig { overrides };
+        let local = LocalConfig {
+            overrides,
+            ..LocalConfig::default()
+        };
         let toml_str = toml::to_string_pretty(&local).unwrap();
         assert!(
             !toml_str.contains('\\'),

--- a/tests/launch_bundle.rs
+++ b/tests/launch_bundle.rs
@@ -239,6 +239,31 @@ fn build_launch_bundle_profile_model_beats_settings_default_model() {
 }
 
 #[test]
+fn build_launch_bundle_overlay_model_overrides_profile_model() {
+    routing::build_launch_bundle_overlay_model_overrides_profile_model();
+}
+
+#[test]
+fn build_launch_bundle_settings_model_policy_applies_with_provenance() {
+    routing::build_launch_bundle_settings_model_policy_applies_with_provenance();
+}
+
+#[test]
+fn build_launch_bundle_composed_model_policies_overlay_wins() {
+    routing::build_launch_bundle_composed_model_policies_overlay_wins();
+}
+
+#[test]
+fn build_launch_bundle_composed_model_policies_first_match_wins() {
+    routing::build_launch_bundle_composed_model_policies_first_match_wins();
+}
+
+#[test]
+fn build_launch_bundle_local_overlay_replaces_base_overlay_by_name() {
+    routing::build_launch_bundle_local_overlay_replaces_base_overlay_by_name();
+}
+
+#[test]
 fn build_launch_bundle_invalid_settings_default_harness_warns_and_falls_back_to_default() {
     routing::build_launch_bundle_invalid_settings_default_harness_warns_and_falls_back_to_default();
 }

--- a/tests/launch_bundle/routing.rs
+++ b/tests/launch_bundle/routing.rs
@@ -1852,6 +1852,236 @@ Review code changes."#;
     );
 }
 
+pub(crate) fn build_launch_bundle_overlay_model_overrides_profile_model() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = install_fake_harnesses(&temp, &["codex"]);
+    let agent_content = r#"---
+name: reviewer
+model: claude-opus-4-6
+---
+Review code changes."#;
+
+    let extra_toml = r#"[models.gpt55]
+model = "gpt-5"
+harness = "codex"
+
+[agents.reviewer]
+model = "gpt55""#;
+
+    let (server, project_root) =
+        setup_bundle_project(&temp, "bundle-source", agent_content, &[], extra_toml);
+
+    let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
+    cmd.args(["build", "launch-bundle", "--agent", "reviewer"]);
+    cmd.env("PATH", replace_path_with(&bin_dir));
+
+    let output = cmd.assert().success().get_output().clone();
+    let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert_eq!(bundle["routing"]["model_token"].as_str(), Some("gpt55"));
+    assert_eq!(bundle["routing"]["model"].as_str(), Some("gpt-5"));
+    assert_eq!(
+        bundle["provenance"]["model_source"].as_str(),
+        Some("overlay")
+    );
+}
+
+pub(crate) fn build_launch_bundle_settings_model_policy_applies_with_provenance() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = install_fake_harnesses(&temp, &["opencode"]);
+    let agent_content = r#"---
+name: reviewer
+model: gpt55
+---
+Review code changes."#;
+
+    let extra_toml = r#"[models.gpt55]
+model = "gpt-5"
+
+[[settings.model-policies]]
+match = { alias = "gpt55" }
+override = { harness = "opencode", effort = "medium" }"#;
+
+    let (server, project_root) =
+        setup_bundle_project(&temp, "bundle-source", agent_content, &[], extra_toml);
+
+    let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
+    cmd.args(["build", "launch-bundle", "--agent", "reviewer"]);
+    cmd.env("PATH", replace_path_with(&bin_dir));
+
+    let output = cmd.assert().success().get_output().clone();
+    let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert_eq!(bundle["routing"]["harness"].as_str(), Some("opencode"));
+    assert_eq!(
+        bundle["execution_policy"]["effort"].as_str(),
+        Some("medium")
+    );
+    assert_eq!(
+        bundle["provenance"]["harness_source"].as_str(),
+        Some("settings-model-policy")
+    );
+    assert_eq!(
+        bundle["provenance"]["effort_source"].as_str(),
+        Some("settings-model-policy")
+    );
+    assert_eq!(
+        bundle["provenance"]["matched_policy_rule"].as_str(),
+        Some("settings:0")
+    );
+}
+
+pub(crate) fn build_launch_bundle_composed_model_policies_overlay_wins() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = install_fake_harnesses(&temp, &["pi", "codex", "opencode"]);
+    let agent_content = r#"---
+name: reviewer
+model: gpt55
+model-policies:
+  - match:
+      alias: gpt55
+    override:
+      harness: codex
+      effort: high
+---
+Review code changes."#;
+
+    let extra_toml = r#"[models.gpt55]
+model = "gpt-5"
+
+[agents.reviewer]
+
+[[agents.reviewer.model-policies]]
+match = { alias = "gpt55" }
+override = { harness = "pi", effort = "medium" }
+
+[[settings.model-policies]]
+match = { alias = "gpt55" }
+override = { harness = "opencode", effort = "low" }"#;
+
+    let (server, project_root) =
+        setup_bundle_project(&temp, "bundle-source", agent_content, &[], extra_toml);
+
+    let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
+    cmd.args(["build", "launch-bundle", "--agent", "reviewer"]);
+    cmd.env("PATH", replace_path_with(&bin_dir));
+
+    let output = cmd.assert().success().get_output().clone();
+    let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert_eq!(bundle["routing"]["harness"].as_str(), Some("pi"));
+    assert_eq!(
+        bundle["execution_policy"]["effort"].as_str(),
+        Some("medium")
+    );
+    assert_eq!(
+        bundle["provenance"]["harness_source"].as_str(),
+        Some("overlay-model-policy")
+    );
+    assert_eq!(
+        bundle["provenance"]["effort_source"].as_str(),
+        Some("overlay-model-policy")
+    );
+    assert_eq!(
+        bundle["provenance"]["matched_policy_rule"].as_str(),
+        Some("overlay:0")
+    );
+}
+
+pub(crate) fn build_launch_bundle_composed_model_policies_first_match_wins() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = install_fake_harnesses(&temp, &["codex", "pi"]);
+    let agent_content = r#"---
+name: reviewer
+model: gpt55
+model-policies:
+  - match:
+      alias: gpt55
+    override:
+      harness: codex
+---
+Review code changes."#;
+
+    let extra_toml = r#"[models.gpt55]
+model = "gpt-5"
+
+[agents.reviewer]
+
+[[agents.reviewer.model-policies]]
+match = { alias = "not-gpt55" }
+override = { harness = "pi" }"#;
+
+    let (server, project_root) =
+        setup_bundle_project(&temp, "bundle-source", agent_content, &[], extra_toml);
+
+    let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
+    cmd.args(["build", "launch-bundle", "--agent", "reviewer"]);
+    cmd.env("PATH", replace_path_with(&bin_dir));
+
+    let output = cmd.assert().success().get_output().clone();
+    let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert_eq!(bundle["routing"]["harness"].as_str(), Some("codex"));
+    assert_eq!(
+        bundle["provenance"]["harness_source"].as_str(),
+        Some("profile-model-policy")
+    );
+    assert_eq!(
+        bundle["provenance"]["matched_policy_rule"].as_str(),
+        Some("profile:0")
+    );
+}
+
+pub(crate) fn build_launch_bundle_local_overlay_replaces_base_overlay_by_name() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = install_fake_harnesses(&temp, &["codex", "pi"]);
+    let agent_content = r#"---
+name: reviewer
+model: claude-opus-4-6
+---
+Review code changes."#;
+
+    let extra_toml = r#"[models.gpt55]
+model = "gpt-5"
+harness = "codex"
+
+[models.gptmini]
+model = "gpt-5.4-mini"
+harness = "pi"
+
+[agents.reviewer]
+model = "gpt55"
+harness = "codex"
+effort = "high""#;
+
+    let (server, project_root) =
+        setup_bundle_project(&temp, "bundle-source", agent_content, &[], extra_toml);
+    fs::write(
+        project_root.join("mars.local.toml"),
+        r#"[agents.reviewer]
+model = "gptmini""#,
+    )
+    .unwrap();
+
+    let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
+    cmd.args(["build", "launch-bundle", "--agent", "reviewer"]);
+    cmd.env("PATH", replace_path_with(&bin_dir));
+
+    let output = cmd.assert().success().get_output().clone();
+    let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert_eq!(bundle["routing"]["model_token"].as_str(), Some("gptmini"));
+    assert_eq!(bundle["routing"]["harness"].as_str(), Some("pi"));
+    assert_eq!(
+        bundle["provenance"]["model_source"].as_str(),
+        Some("overlay")
+    );
+    assert_eq!(
+        bundle["provenance"]["harness_source"].as_str(),
+        Some("alias")
+    );
+}
+
 fn install_fake_harnesses(temp: &TempDir, harnesses: &[&str]) -> PathBuf {
     let bin_dir = temp.path().join("harness-bin");
     fs::create_dir_all(&bin_dir).unwrap();


### PR DESCRIPTION
## Summary

Phase 2 of meridian-cli's [mars-routing-consolidation](https://github.com/haowjy/meridian-cli/pull/247). Moves agent overlay resolution from meridian into mars so the bundle response becomes the single resolved-truth value — eliminating the dual-resolver pattern.

## Schema additions

**`[agents.<name>]` overlay** (routing + execution-policy):

```toml
[agents.tech-lead]
model = "gpt55"
harness = "codex"
effort = "medium"
approval = "default"
sandbox = "default"
autocompact = 0
autocompact_pct = 80

[[agents.tech-lead.model-policies]]
match = { alias = "claude" }
override = { harness = "opencode", effort = "low" }
no-fallback = false
```

**`[[settings.model-policies]]`** (project-wide):

```toml
[[settings.model-policies]]
match = { alias = "gpt55" }
override = { harness = "codex", effort = "medium" }
no-fallback = true
```

## Resolution semantics

- **Precedence ladder** (D1): `CLI > ENV > overlay > overlay-model-policies > profile > profile-model-policies > settings-model-policies > alias > config-defaults`
- **Composition**: `compose_effective_policies()` walks overlay → profile → settings; first match wins
- **Execution-policy overlay slot**: overlay defaults slot between CLI and profile
- **mars.local.toml** (D5): name-keyed replacement for `[agents.<name>]`; local `settings.model-policies` replaces base list
- **Shared type** (D13): one `ModelPolicyRule` used across profile/overlay/settings

## Provenance additions

New source values (`overlay`, `overlay-model-policy`, `settings-model-policy`) and new `matched_policy_rule` key encoding `<layer>:<0-based-index>` (e.g. `overlay:0`, `profile:2`, `settings:1`).

## Default-empty behavior

Absent `[agents]` table = identical to today's resolution. Lets meridian migrate at its own pace.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo test`
- [x] `cargo build --release`
- [x] Unit tests for AgentOverlay parsing round-trip
- [x] Shared `ModelPolicyRule` serde across the three layers
- [x] `mars.local.toml` name-keyed replacement test
- [x] Integration: overlay model beats profile model → `provenance = overlay`
- [x] Integration: `[[settings.model-policies]]` match → `settings-model-policy` provenance
- [x] Integration: three-layer composition; overlay wins; `matched_policy_rule = "overlay:0"`

## Out of scope

- HarnessId enum unification (stays Python ⨉ Rust per design note)
- Meridian-side `AgentOverlayConfig` deletion (separate PR; consumes the rc this releases)
- Migration tooling for legacy `meridian.toml [agents]` (D11 — clear error in meridian)

🤖 Generated with [Claude Code](https://claude.com/claude-code)