### PR TITLE
Suppress denied tool passthrough warnings, expand Claude tool registry

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -27,7 +27,8 @@ check_release_tag_auth() {
 while read -r local_ref local_sha remote_ref remote_sha; do
   case "$remote_ref" in
     refs/heads/*)
-      needs_full=1
+      # Skip deletion pushes — preflight only matters when pushing code.
+      [[ "$local_sha" != "$ZERO_SHA" ]] && needs_full=1
       ;;
     refs/tags/v*)
       check_release_tag_auth "$remote_ref" "$local_sha" "$remote_sha"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 - Launch-bundle tool projection now warns unknown tool names only in `tools.allowed` for first-class harnesses; unknown `tools.disallowed` entries are dropped silently.
+- Claude tool registry covers full Claude Code tool surface: Cron, AskUser, Notifications, PlanMode, Worktree, LSP, Monitor, SendUserFile, ScheduleWakeup, RemoteTrigger, ToolSearch, and Task sub-tool aliases.
 
 ## [0.5.0] - 2026-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Launch-bundle tool projection now warns unknown tool names only in `tools.allowed` for first-class harnesses; unknown `tools.disallowed` entries are dropped silently.
+
 ## [0.5.0] - 2026-05-22
 
 ## [0.4.8] - 2026-05-22

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -169,9 +169,18 @@ fn resolve_bundle_tools(
     let effective_tools = profile.effective_tool_policy(&harness_kind);
     let mut warnings = Vec::new();
 
-    let allowed = normalize_and_dedupe_tools(&effective_tools.allowed, harness, &mut warnings);
-    let disallowed =
-        normalize_and_dedupe_tools(&effective_tools.disallowed, harness, &mut warnings);
+    let allowed = normalize_and_dedupe_tools(
+        &effective_tools.allowed,
+        harness,
+        ToolPolicyKind::Allowed,
+        &mut warnings,
+    );
+    let disallowed = normalize_and_dedupe_tools(
+        &effective_tools.disallowed,
+        harness,
+        ToolPolicyKind::Disallowed,
+        &mut warnings,
+    );
 
     Ok((
         ToolsSpec {
@@ -186,6 +195,7 @@ fn resolve_bundle_tools(
 fn normalize_and_dedupe_tools(
     tools: &[String],
     harness: &str,
+    kind: ToolPolicyKind,
     warnings: &mut Vec<String>,
 ) -> Vec<String> {
     let mut seen = std::collections::HashSet::new();
@@ -194,9 +204,12 @@ fn normalize_and_dedupe_tools(
     for tool in tools {
         let normalized = normalize_tool_for_harness(tool, harness);
         if normalized.status == ToolProjectionStatus::Unknown && is_first_class_harness(harness) {
-            warnings.push(format!(
-                "tool '{tool}' is not a known {harness} tool; passing through verbatim"
-            ));
+            match kind {
+                ToolPolicyKind::Allowed => warnings.push(format!(
+                    "tool '{tool}' is not a known {harness} tool; passing through verbatim"
+                )),
+                ToolPolicyKind::Disallowed => continue,
+            }
         }
 
         let trimmed = normalized.name.trim();
@@ -209,6 +222,12 @@ fn normalize_and_dedupe_tools(
     }
 
     projected
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ToolPolicyKind {
+    Allowed,
+    Disallowed,
 }
 
 fn resolve_effective_skills(

--- a/src/build/tool_normalize.rs
+++ b/src/build/tool_normalize.rs
@@ -76,11 +76,28 @@ fn canonical_claude_tool(key: &str) -> Option<&'static str> {
         "glob" | "find" => Some("Glob"),
         "grep" | "search" | "rg" => Some("Grep"),
         "notebook" | "jupyter" => Some("Notebook"),
-        "task" | "task_tool" => Some("Task"),
+        "task" | "task_tool" | "taskcreate" | "task_create" | "taskget" | "task_get"
+        | "tasklist" | "task_list" | "taskoutput" | "task_output" | "taskstop" | "task_stop"
+        | "taskupdate" | "task_update" => Some("Task"),
         "web_search" | "websearch" => Some("WebSearch"),
         "web_fetch" | "webfetch" => Some("WebFetch"),
         "todo_read" | "todoread" => Some("TodoRead"),
         "todo_write" | "todowrite" => Some("TodoWrite"),
+        "cron" | "croncreate" | "cron_create" | "crondelete" | "cron_delete" | "cronlist"
+        | "cron_list" => Some("Cron"),
+        "ask_user" | "askuser" | "askuserquestion" | "ask_user_question" => Some("AskUser"),
+        "notifications" | "pushnotification" | "push_notification" => Some("Notifications"),
+        "plan_mode" | "planmode" | "enterplanmode" | "enter_plan_mode" | "exitplanmode"
+        | "exit_plan_mode" => Some("PlanMode"),
+        "worktree" | "enterworktree" | "enter_worktree" | "exitworktree" | "exit_worktree" => {
+            Some("Worktree")
+        }
+        "lsp" => Some("LSP"),
+        "monitor" => Some("Monitor"),
+        "send_user_file" | "senduserfile" => Some("SendUserFile"),
+        "schedule_wakeup" | "schedulewakeup" => Some("ScheduleWakeup"),
+        "remote_trigger" | "remotetrigger" => Some("RemoteTrigger"),
+        "tool_search" | "toolsearch" => Some("ToolSearch"),
         _ => None,
     }
 }

--- a/tests/launch_bundle/tool_policy.rs
+++ b/tests/launch_bundle/tool_policy.rs
@@ -120,6 +120,7 @@ name: reviewer
 model: claude-opus-4-6
 tools:
   plan_mode: deny
+  unknown_allow: allow
   notebook: allow
 mcp-tools:
   - plugin:context7:context7
@@ -143,11 +144,11 @@ Review code changes."#;
     let output = cmd.assert().success().get_output().clone();
     let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
 
-    assert_eq!(bundle["tools"]["allowed"], serde_json::json!(["Notebook"]));
     assert_eq!(
-        bundle["tools"]["disallowed"],
-        serde_json::json!(["plan_mode"])
+        bundle["tools"]["allowed"],
+        serde_json::json!(["unknown_allow", "Notebook"])
     );
+    assert_eq!(bundle["tools"]["disallowed"], serde_json::json!([]));
     assert_eq!(
         bundle["tools"]["mcp"],
         serde_json::json!(["plugin:context7:context7"])
@@ -156,6 +157,12 @@ Review code changes."#;
         .as_array()
         .expect("warnings should be an array");
     assert!(warnings.iter().any(|warning| {
+        warning
+            .as_str()
+            .unwrap_or_default()
+            .contains("tool 'unknown_allow' is not a known claude tool")
+    }));
+    assert!(!warnings.iter().any(|warning| {
         warning
             .as_str()
             .unwrap_or_default()
@@ -173,6 +180,7 @@ tools:
   Bash: allow
   read: allow
   Write: allow
+  unknown_allow: allow
   edit: deny
   Agent: deny
   web_search: allow
@@ -199,17 +207,23 @@ Review code changes."#;
     let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(
         bundle["tools"]["allowed"],
-        serde_json::json!(["bash", "read", "write", "browser", "fetch"])
+        serde_json::json!(["bash", "read", "write", "unknown_allow", "browser", "fetch"])
     );
     assert_eq!(
         bundle["tools"]["disallowed"],
-        serde_json::json!(["edit", "agent", "plan_mode"])
+        serde_json::json!(["edit", "agent"])
     );
 
     let warnings = bundle["warnings"]
         .as_array()
         .expect("warnings should be an array");
     assert!(warnings.iter().any(|warning| {
+        warning
+            .as_str()
+            .unwrap_or_default()
+            .contains("tool 'unknown_allow' is not a known opencode tool")
+    }));
+    assert!(!warnings.iter().any(|warning| {
         warning
             .as_str()
             .unwrap_or_default()

--- a/tests/launch_bundle/tool_policy.rs
+++ b/tests/launch_bundle/tool_policy.rs
@@ -148,7 +148,10 @@ Review code changes."#;
         bundle["tools"]["allowed"],
         serde_json::json!(["unknown_allow", "Notebook"])
     );
-    assert_eq!(bundle["tools"]["disallowed"], serde_json::json!([]));
+    assert_eq!(
+        bundle["tools"]["disallowed"],
+        serde_json::json!(["PlanMode"])
+    );
     assert_eq!(
         bundle["tools"]["mcp"],
         serde_json::json!(["plugin:context7:context7"])


### PR DESCRIPTION
## Summary
- Unknown tools in `tools.disallowed` are now silently dropped for first-class harnesses instead of emitting noisy "passing through verbatim" warnings on every spawn
- Unknown tools in `tools.allowed` still warn (catches typos)
- Claude tool canonical registry now covers full Claude Code tool surface: Cron, AskUser, Notifications, PlanMode, Worktree, LSP, Monitor, SendUserFile, ScheduleWakeup, RemoteTrigger, ToolSearch, and Task sub-tool aliases
- Pre-push hook no longer runs full preflight on `git push --delete`

## Test plan
- [x] `cargo test` — 1147 unit + 86 integration tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [ ] Smoke: spawn with `--dry-run` on claude/opencode/codex, verify no spurious tool warnings for deny-list entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)