### PR TITLE
Allow launch bundles without model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Launch-bundle model now optional; unset model routes to installed/default harness and leaves harness model empty for harness defaults.
+
 ## [0.6.0] - 2026-05-22
 
 ### Changed

--- a/src/build/.context/CONTEXT.md
+++ b/src/build/.context/CONTEXT.md
@@ -7,8 +7,10 @@ launch an agent with resolved routing, execution policy, tools, and prompt surfa
 
 ### Two launch-bundle modes
 
-1. **Ad-hoc mode** (`--model`, no `--agent`):
-   - Requires `--model`; `--agent` must be absent
+1. **Ad-hoc mode** (no `--agent`):
+   - `--model` is optional; when omitted, routing selects an installed/default
+     harness and leaves `routing.model`, `routing.model_token`, and
+     `routing.harness_model` empty so the harness can use its own default model
    - Works from a plain directory with **no `mars.toml`** — `can_run_without_project()`
      in `src/cli/mod.rs:248` supplies a synthetic `MarsContext` when project
      discovery fails and the exact ad-hoc condition is met
@@ -53,7 +55,6 @@ fn can_run_without_project(cmd: &Command, err: &MarsError) -> bool {
             Command::Build(build::BuildArgs {
                 command: build::BuildCommand::LaunchBundle(build::LaunchBundleArgs {
                     agent: None,
-                    model: Some(_),
                     ..
                 })
             }),
@@ -63,9 +64,9 @@ fn can_run_without_project(cmd: &Command, err: &MarsError) -> bool {
 }
 ```
 
-Only ad-hoc launch-bundle (`--agent` absent, `--model` present) bypasses project
-discovery. Every other command — including agent-mode launch-bundle — requires
-`mars.toml` in an ancestor directory.
+Only ad-hoc launch-bundle (`--agent` absent) bypasses project discovery. Every
+other command — including agent-mode launch-bundle — requires `mars.toml` in an
+ancestor directory.
 
 ### Warning accumulation pipeline
 
@@ -90,7 +91,7 @@ LaunchBundleRequest {agent, model, harness, effort, approval, sandbox, extra_ski
     │
     └─ resolve_policy()
            ├─ config::load_policy_resolution_config()  (aliases, harness_order, linked targets)
-           ├─ model::resolve_model()                   (alias → model_id + provider)
+           ├─ model::resolve_model()                   (alias → model_id + provider, or unset)
            ├─ harness::resolve_harness()               (route selection, provider/candidate eval)
            ├─ execution::resolve_execution_policy()    (effort, approval, sandbox, autocompact)
            └─ runnable::resolve_routing()              (populate Routing, warnings always empty)
@@ -111,8 +112,8 @@ gracefully (empty aliases, empty model cache).
 
 Ad-hoc mode exists because callers outside a Mars-managed project (e.g., Meridian CLI,
 scripting) need routing decisions without a full `mars sync` pipeline. The guard in
-`can_run_without_project` scopes this bypass narrowly — only `--model` + no `--agent`
-ad-hoc launch-bundles skip project discovery.
+`can_run_without_project` scopes this bypass narrowly — only no-`--agent`
+ad-hoc launch-bundles skip project discovery, with `--model` optional.
 
 Warning semantics are split between `warnings` (user-actionable) and routing/provenance
 fields (route metadata) because callers consume the bundle differently. A downstream

--- a/src/build/AGENTS.md
+++ b/src/build/AGENTS.md
@@ -19,8 +19,10 @@ LaunchBundle {routing, execution_policy, prompt_surface, tools, skills_metadata,
 
 ## Two Modes
 
-### Ad-hoc Mode (`--model`, no `--agent`)
+### Ad-hoc Mode (no `--agent`)
 - Works from a plain directory with **no `mars.toml`**
+- `--model` is optional; when omitted, the selected harness receives an empty
+  model field and uses its own default model
 - `can_run_without_project()` in `src/cli/mod.rs` supplies synthetic `MarsContext`
 - No skills loaded, no tools resolved (empty sets)
 
@@ -48,7 +50,7 @@ LaunchBundle {routing, execution_policy, prompt_surface, tools, skills_metadata,
 
 ```
 config::load_policy_resolution_config()  → aliases, harness_order, linked targets
-model::resolve_model()                   → alias → model_id + provider
+model::resolve_model()                   → alias → model_id + provider, or unset
 harness::resolve_harness()               → route selection, candidate eval
 execution::resolve_execution_policy()    → effort, approval, sandbox, autocompact
 runnable::resolve_routing()              → populate Routing (warnings always empty)

--- a/src/build/policy/model.rs
+++ b/src/build/policy/model.rs
@@ -4,7 +4,7 @@ use indexmap::IndexMap;
 
 use crate::build::policy::{PolicyInput, PolicySource};
 use crate::config::AgentOverlay;
-use crate::error::{ConfigError, MarsError};
+use crate::error::MarsError;
 use crate::models::{self, ModelAlias, ModelsCache};
 
 pub(super) struct ResolvedModel<'a> {
@@ -20,7 +20,7 @@ pub(super) struct ResolvedModel<'a> {
 
 /// Resolve model selection precedence for launch-bundle.
 ///
-/// Resolution order is `cli > profile > project > error` where project maps to
+/// Resolution order is `cli > overlay > profile > project > unset` where project maps to
 /// `settings.default_model` from `mars.toml`.
 pub(super) fn resolve_model<'a>(
     input: &PolicyInput<'_>,
@@ -38,12 +38,7 @@ pub(super) fn resolve_model<'a>(
                 Some(model) => (model.to_string(), PolicySource::Profile),
                 None => match input.config_default_model {
                     Some(model) => (model.to_string(), PolicySource::Project),
-                    None => {
-                        return Err(MarsError::Config(ConfigError::Invalid {
-                            message: "launch-bundle requires a model (set `model:` in the agent profile, set `settings.default_model` in mars.toml, or pass `--model`)"
-                                .to_string(),
-                        }));
-                    }
+                    None => (String::new(), PolicySource::Unset),
                 },
             },
         },
@@ -102,4 +97,68 @@ fn provider_constraint_for_alias(alias: &ModelAlias) -> Option<String> {
 pub(super) fn load_models_cache(project_root: &Path) -> Result<ModelsCache, MarsError> {
     let mars_dir = project_root.join(".mars");
     models::read_cache(&mars_dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::compiler::agents::{AgentProfile, HarnessOverrides};
+
+    fn empty_profile() -> AgentProfile {
+        AgentProfile {
+            name: None,
+            description: None,
+            harness: None,
+            model: None,
+            mode: None,
+            model_invocable: true,
+            approval: None,
+            sandbox: None,
+            effort: None,
+            autocompact: None,
+            autocompact_pct: None,
+            skills: Vec::new(),
+            tools: Vec::new(),
+            tools_denied: Vec::new(),
+            disallowed_tools: Vec::new(),
+            mcp_tools: Vec::new(),
+            harness_overrides: HarnessOverrides::default(),
+            model_policies: Vec::new(),
+            fanout: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn resolve_model_returns_unset_when_no_model_source_exists() {
+        let profile = empty_profile();
+        let input = PolicyInput {
+            project_root: Path::new("."),
+            agent: None,
+            profile: &profile,
+            model_override: None,
+            config_default_model: None,
+            harness_override: None,
+            effort_override: None,
+            approval_override: None,
+            sandbox_override: None,
+        };
+        let aliases = IndexMap::new();
+        let cache = ModelsCache {
+            models: Vec::new(),
+            fetched_at: None,
+        };
+
+        let resolved =
+            resolve_model(&input, None, &aliases, &cache).expect("missing model is allowed");
+
+        assert_eq!(resolved.model_token, "");
+        assert_eq!(resolved.model_source, PolicySource::Unset);
+        assert_eq!(resolved.model, "");
+        assert!(resolved.alias.is_none());
+        assert!(!resolved.alias_resolution_failed);
+        assert_eq!(resolved.provider_for_order, None);
+        assert_eq!(resolved.provider_constraint, None);
+        assert!(resolved.warnings.is_empty());
+    }
 }

--- a/src/build/policy/runnable.rs
+++ b/src/build/policy/runnable.rs
@@ -135,4 +135,36 @@ mod tests {
 
         assert_eq!(resolution.routing.harness_model, "gpt-5.4-mini".to_string());
     }
+
+    #[test]
+    fn empty_model_keeps_empty_harness_model_for_harness_default() {
+        let resolution = resolve_routing(RoutingInput {
+            model: String::new(),
+            model_token: String::new(),
+            harness: "claude".to_string(),
+            selection_kind: "auto".to_string(),
+            match_evidence: "passthrough".to_string(),
+            provider: None,
+            opencode_probe_result: None,
+            alias_resolution_failed: false,
+            route_trace: RoutingTrace {
+                source: crate::routing::RouteSource::Provider,
+                selection_kind: crate::routing::SelectionKind::Auto,
+                match_evidence: MatchEvidence::Passthrough,
+                harness: "claude".to_string(),
+                harness_order_position: None,
+                candidates_tried: vec!["claude".to_string()],
+                assessments: Vec::new(),
+                diagnostics: Vec::new(),
+            },
+        });
+
+        assert_eq!(resolution.routing.model, "");
+        assert_eq!(resolution.routing.model_token, "");
+        assert_eq!(resolution.routing.harness_model, "");
+        assert_eq!(
+            resolution.routing.harness_model_source,
+            "passthrough".to_string()
+        );
+    }
 }

--- a/src/cli/AGENTS.md
+++ b/src/cli/AGENTS.md
@@ -19,7 +19,7 @@ The CLI layer is **policy** — what to do, which model, what output. Library mo
 Three bypass conditions:
 1. **Root-free**: `init`, `check`, `cache` — no project needed
 2. **Auto-init**: `add`, `link` — creates mars.toml if missing
-3. **Ad-hoc launch**: `build launch-bundle --model <x>` (no `--agent`) — works in plain directory
+3. **Ad-hoc launch**: `build launch-bundle` (no `--agent`, optional `--model <x>`) — works in plain directory
 
 ## Command Categories
 

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -99,7 +99,7 @@ impl SandboxArg {
 #[derive(Debug, clap::Args)]
 pub struct LaunchBundleArgs {
     /// Agent name from `.mars/agents/<name>.md`.
-    /// Omit for ad-hoc mode; then `--model` is required.
+    /// Omit for ad-hoc mode; without `--model`, the resolved harness uses its default model.
     #[arg(long)]
     pub agent: Option<String>,
 
@@ -135,12 +135,6 @@ pub fn run(args: &BuildArgs, ctx: &MarsContext, _json: bool) -> Result<i32, Mars
 }
 
 fn run_launch_bundle(args: &LaunchBundleArgs, ctx: &MarsContext) -> Result<i32, MarsError> {
-    if args.agent.is_none() && args.model.is_none() {
-        return Err(MarsError::InvalidRequest {
-            message: "ad-hoc launch-bundle requires --model".to_string(),
-        });
-    }
-
     let bundle = build_launch_bundle(
         ctx,
         LaunchBundleRequest {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -254,7 +254,6 @@ fn can_run_without_project(cmd: &Command, err: &MarsError) -> bool {
             Command::Build(build::BuildArgs {
                 command: build::BuildCommand::LaunchBundle(build::LaunchBundleArgs {
                     agent: None,
-                    model: Some(_),
                     ..
                 })
             }),

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -308,6 +308,17 @@ where
 
             candidate_pairs
         }
+    } else if input.model_id.trim().is_empty() {
+        filter_candidates_by_links(
+            models::harness::VALID_HARNESSES
+                .iter()
+                .map(|harness| (*harness).to_string())
+                .collect(),
+            linked_harnesses_set.as_ref(),
+        )
+        .into_iter()
+        .map(|harness| (harness, None))
+        .collect::<Vec<_>>()
     } else {
         let provider_for_order = input.provider_for_order.unwrap_or("unknown");
         filter_candidates_by_links(
@@ -485,6 +496,19 @@ where
             chosen_model: None,
             match_evidence: None,
             skip_reason: Some("provider_constraint_unsatisfied"),
+        };
+    }
+
+    if input.model_id.trim().is_empty() {
+        return CandidateAssessment {
+            harness: harness.to_string(),
+            installed: true,
+            candidate_slugs: Vec::new(),
+            filtered_slugs: Vec::new(),
+            chosen_slug: None,
+            chosen_model: None,
+            match_evidence: Some(MatchEvidence::Passthrough),
+            skip_reason: None,
         };
     }
 

--- a/tests/launch_bundle.rs
+++ b/tests/launch_bundle.rs
@@ -52,13 +52,13 @@ fn build_launch_bundle_rejects_prompt_file_flag() {
 }
 
 #[test]
-fn build_launch_bundle_fails_when_no_model_available() {
-    schema::build_launch_bundle_fails_when_no_model_available();
+fn build_launch_bundle_uses_installed_harness_default_when_no_model_available() {
+    schema::build_launch_bundle_uses_installed_harness_default_when_no_model_available();
 }
 
 #[test]
-fn build_launch_bundle_ad_hoc_requires_model() {
-    schema::build_launch_bundle_ad_hoc_requires_model();
+fn build_launch_bundle_ad_hoc_without_model_uses_installed_harness_default() {
+    schema::build_launch_bundle_ad_hoc_without_model_uses_installed_harness_default();
 }
 
 #[test]

--- a/tests/launch_bundle/schema.rs
+++ b/tests/launch_bundle/schema.rs
@@ -287,8 +287,9 @@ Review code changes."#;
         .stderr(predicates::str::contains("--prompt-file"));
 }
 
-pub(crate) fn build_launch_bundle_fails_when_no_model_available() {
+pub(crate) fn build_launch_bundle_uses_installed_harness_default_when_no_model_available() {
     let temp = TempDir::new().unwrap();
+    let bin_dir = install_fake_harnesses(temp.path(), &["codex"]);
     let agent_content = r#"---
 name: reviewer
 ---
@@ -299,32 +300,45 @@ Review code changes."#;
 
     let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
     cmd.args(["build", "launch-bundle", "--agent", "reviewer"]);
-    cmd.assert()
-        .failure()
-        .code(2)
-        .stderr(predicates::str::contains("requires a model"))
-        .stderr(predicates::str::contains("settings.default_model"));
+    cmd.env("PATH", replace_path_with(&bin_dir));
+
+    let output = cmd.assert().success().get_output().clone();
+    let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert_eq!(bundle["routing"]["model_token"].as_str(), Some(""));
+    assert_eq!(bundle["routing"]["model"].as_str(), Some(""));
+    assert_eq!(bundle["routing"]["harness"].as_str(), Some("codex"));
+    assert_eq!(bundle["routing"]["harness_model"].as_str(), Some(""));
+    assert_eq!(
+        bundle["routing"]["harness_model_source"].as_str(),
+        Some("passthrough")
+    );
+    assert_eq!(bundle["provenance"]["model_source"].as_str(), Some("unset"));
 }
 
-pub(crate) fn build_launch_bundle_ad_hoc_requires_model() {
+pub(crate) fn build_launch_bundle_ad_hoc_without_model_uses_installed_harness_default() {
     let temp = TempDir::new().unwrap();
-    let agent_content = r#"---
-name: reviewer
-model: claude-opus-4-6
----
-Review code changes."#;
+    let server = MockServer::start();
+    let bin_dir = install_fake_harnesses(temp.path(), &["claude"]);
+    let project = temp.child("plain-project");
+    project.create_dir_all().unwrap();
 
-    let (server, project_root) =
-        setup_bundle_project(&temp, "bundle-source", agent_content, &[], "");
-
-    let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
+    let mut cmd = mars();
+    configure_assert_cmd(&mut cmd, temp.path(), &server.url(API_PATH));
+    cmd.current_dir(project.path())
+        .env("PATH", replace_path_with(&bin_dir));
     cmd.args(["build", "launch-bundle"]);
-    cmd.assert()
-        .failure()
-        .code(2)
-        .stderr(predicates::str::contains(
-            "ad-hoc launch-bundle requires --model",
-        ));
+
+    let output = cmd.assert().success().get_output().clone();
+    let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert!(bundle["agent"].is_null());
+    assert_field_absent_or_null(&bundle, "agent_body");
+    assert_eq!(bundle["routing"]["model_token"].as_str(), Some(""));
+    assert_eq!(bundle["routing"]["model"].as_str(), Some(""));
+    assert_eq!(bundle["routing"]["harness"].as_str(), Some("claude"));
+    assert_eq!(bundle["routing"]["harness_model"].as_str(), Some(""));
+    assert_eq!(bundle["provenance"]["model_source"].as_str(), Some("unset"));
 }
 
 pub(crate) fn build_launch_bundle_resolves_model_alias_from_consumer_config() {


### PR DESCRIPTION
## Summary
- `mars build launch-bundle` no longer requires a model to be specified
- When no model is set (cli, overlay, profile, or project default), returns empty model fields with `PolicySource::Unset` instead of hard-erroring
- Harness candidate evaluation handles empty model — picks first installed harness via passthrough
- Downstream harness adapters receive empty `harness_model`, letting the harness use its own default

This unblocks ad-hoc spawns (`meridian spawn "do something"`) where no agent or model is specified and the user just wants to use whatever harness is installed.

## Test plan
- [x] `cargo test` — 1161 tests pass
- [x] `cargo clippy` — clean
- [x] Smoke: `mars build launch-bundle --harness claude --root <project>` with no model → `harness: claude`, empty model, 0 warnings
- [x] Smoke: `mars build launch-bundle --root <project>` (fully ad-hoc) → picks installed claude, empty model, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)