### PR TITLE
Fix linked-target deletes when lock only tracks .mars (#65)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Cursor orchestration: `~/cursor-dev` (`/product-lead`, `work-coordination` skill
 
 **Mars must NEVER delete files it didn't create.** Orphan cleanup, removals, and overwrites in a linked target require a lock `OutputRecord` for that exact `(target_root, dest_path)` pair. A path tracked only under `.mars` does not authorize mutation under `.cursor` or other targets. Never scan-and-delete-unknown.
 
-The lock file (`mars.lock`) is the authority on what mars manages **per target**. If there is no matching record for that target, mars preserves existing local content (diagnostic: `target-unmanaged-collision`). Use `mars sync --force` or `mars link --force` to adopt unmanaged collisions and record ownership (`target-unmanaged-adopted`).
+The lock file (`mars.lock`) is the authority on what mars manages **per target**. Untracked local content in a linked target is preserved unless explicitly adopted — see `src/target_sync/.context/CONTEXT.md`.
 
 ### Atomic writes
 
@@ -132,48 +132,18 @@ During `resolve_graph`, model configs from all resolved dependencies are collect
 
 ## Harness Routing
 
-`src/harness/` + `src/routing/` + `src/config/targets.rs` + `src/models/probes/` form the unified routing architecture introduced in PR #51.
+`src/harness/`, `src/routing/`, `src/config/targets.rs`, and `src/models/probes/` share one routing architecture.
 
-### Single authority, single evaluator
+- **`harness::registry` is the ONLY harness-name authority** — no other module validates or normalizes harness names independently.
+- **`routing::evaluate_candidates()` is the ONLY candidate evaluator** — `mars models` and `mars build` must converge on the same route for the same inputs.
 
-- **`harness::registry` is the ONLY harness-name authority.** `registry::parse()`, `registry::is_known()`, `registry::provider_candidate_order()` — all harness identity flows through registry. No other module validates or normalizes harness names independently.
-- **`routing::evaluate_candidates()` is the ONLY candidate evaluator.** Both `mars models` and `mars build` converge on the same route for the same inputs. Parity is an invariant, not a coincidence.
-
-### Evaluation flow
-
-1. Build candidate list from `settings.harness_order` (ConfigOrder source) or `provider_candidate_order` (Provider source)
-2. Filter by `linked_harnesses` — only `KnownHarness` links filter; generic targets like `.agents` do not
-3. Per-candidate gate: installed check → native match + auth → OpenCode probe (`Likely`) → Pi probe (`Confirmed` if compatible) → Cursor (`Passthrough`)
-4. Fallback chain: config `default_harness` → first linked harness → hardcoded `claude`
-5. Link constraints block config-default and hardcoded fallbacks from routing outside known links
-
-### Confidence semantics
-
-| Confidence | Meaning |
-|---|---|
-| `Explicit` | Fixed selection from CLI/profile/alias |
-| `Confirmed` | Native provider match + authenticated, or compatible Pi probe |
-| `Likely` | OpenCode cached provider+model evidence |
-| `Passthrough` | Universal (Cursor), Pi without probe, fallback selections |
-
-### Link constraints
-
-Links from `settings.targets` are normalized via `config::targets::normalize_link()`. Only `LinkKind::KnownHarness` links produce `linked_harnesses` that gate routing candidates. `GenericTarget` (`.agents`, unknown names) and `PathLike` links are materialization targets only — invisible to routing.
-
-See `.context/CONTEXT.md` in `src/harness/`, `src/routing/`, `src/config/`, `src/models/probes/`, and `src/target_sync/` for detailed contracts.
+Details: `src/routing/.context/CONTEXT.md`, `src/harness/.context/CONTEXT.md`, `src/config/.context/CONTEXT.md`, `src/models/probes/.context/CONTEXT.md`.
 
 ## Managed Targets
 
-`src/target_sync/mod.rs` — copies content from `.mars/` canonical store to configured target directories.
+`src/target_sync/` copies from `.mars/` to configured target directories (`settings.targets`, default `[".agents"]`). File copies only — no symlinks. Non-fatal per-target; lock is written regardless of target sync outcome.
 
-- Targets configured via `settings.targets` in `mars.toml` (default: `[".agents"]`)
-- All targets get file copies — no symlinks anywhere in the pipeline
-- Orphan cleanup scopes to `old_lock.output_dest_paths_for_target(target_root)` — only removes paths Mars previously managed **in that target**
-- Deletes, Removed handling, and copy/install paths gate on `surface_ownership::may_delete` / `copy_decision` and `lock.contains_output(target_root, dest_path)`
-- Pre-existing untracked collisions are preserved; `mars sync --force` and `mars link --force` adopt and persist linked-target `OutputRecord`s
-- `mars link` fails by default when adoption would be required (suggests `--force` in the diagnostic)
-- Non-fatal per-target: errors on one target don't stop other targets from syncing
-- Target sync runs after `apply_plan` and before `finalize` — lock is written regardless of target sync outcome
+Per-target ownership, orphan cleanup, and collision/`--force` semantics: `src/target_sync/.context/CONTEXT.md`.
 
 ## Reconciliation Layer
 
@@ -187,7 +157,7 @@ See `.context/CONTEXT.md` in `src/harness/`, `src/routing/`, `src/config/`, `src
 `src/diagnostic.rs` — `DiagnosticCollector` threaded through the entire pipeline.
 
 - No `eprintln!` in library code — all warnings/info go through the collector
-- Machine-readable codes (e.g. `"shadow-collision"`, `"model-alias-conflict"`, `"target-sync-error"`, `"target-unmanaged-collision"`, `"target-unmanaged-adopted"`)
+- Machine-readable codes (e.g. `"shadow-collision"`, `"model-alias-conflict"`, `"target-sync-error"`)
 - CLI layer formats diagnostics for human or JSON output
 - Diagnostics are non-fatal — pipeline continues, report includes all collected diagnostics
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,9 +31,9 @@ Cursor orchestration: `~/cursor-dev` (`/product-lead`, `work-coordination` skill
 
 `.agents/`, `.claude/`, `.codex/`, `.cursor/` can contain hand-written content that mars didn't create. These are shared directories — mars writes into them but doesn't own them.
 
-**Mars must NEVER delete files it didn't create.** Orphan cleanup must only remove files whose `dest_path` was in the previous `mars.lock` but not in the current sync result. Never scan-and-delete-unknown.
+**Mars must NEVER delete files it didn't create.** Orphan cleanup, removals, and overwrites in a linked target require a lock `OutputRecord` for that exact `(target_root, dest_path)` pair. A path tracked only under `.mars` does not authorize mutation under `.cursor` or other targets. Never scan-and-delete-unknown.
 
-The lock file (`mars.lock`) is the authority on what mars manages. If it's not in the lock, mars doesn't touch it.
+The lock file (`mars.lock`) is the authority on what mars manages **per target**. If there is no matching record for that target, mars preserves existing local content (diagnostic: `target-unmanaged-collision`). Use `mars sync --force` or `mars link --force` to adopt unmanaged collisions and record ownership (`target-unmanaged-adopted`).
 
 ### Atomic writes
 
@@ -160,7 +160,7 @@ During `resolve_graph`, model configs from all resolved dependencies are collect
 
 Links from `settings.targets` are normalized via `config::targets::normalize_link()`. Only `LinkKind::KnownHarness` links produce `linked_harnesses` that gate routing candidates. `GenericTarget` (`.agents`, unknown names) and `PathLike` links are materialization targets only — invisible to routing.
 
-See `.context/CONTEXT.md` in `src/harness/`, `src/routing/`, `src/config/`, and `src/models/probes/` for detailed contracts.
+See `.context/CONTEXT.md` in `src/harness/`, `src/routing/`, `src/config/`, `src/models/probes/`, and `src/target_sync/` for detailed contracts.
 
 ## Managed Targets
 
@@ -168,7 +168,10 @@ See `.context/CONTEXT.md` in `src/harness/`, `src/routing/`, `src/config/`, and 
 
 - Targets configured via `settings.targets` in `mars.toml` (default: `[".agents"]`)
 - All targets get file copies — no symlinks anywhere in the pipeline
-- Orphan cleanup uses the previous lock to identify mars-managed files, only removes those
+- Orphan cleanup scopes to `old_lock.output_dest_paths_for_target(target_root)` — only removes paths Mars previously managed **in that target**
+- Deletes, Removed handling, and copy/install paths gate on `surface_ownership::may_delete` / `copy_decision` and `lock.contains_output(target_root, dest_path)`
+- Pre-existing untracked collisions are preserved; `mars sync --force` and `mars link --force` adopt and persist linked-target `OutputRecord`s
+- `mars link` fails by default when adoption would be required (suggests `--force` in the diagnostic)
 - Non-fatal per-target: errors on one target don't stop other targets from syncing
 - Target sync runs after `apply_plan` and before `finalize` — lock is written regardless of target sync outcome
 
@@ -184,7 +187,7 @@ See `.context/CONTEXT.md` in `src/harness/`, `src/routing/`, `src/config/`, and 
 `src/diagnostic.rs` — `DiagnosticCollector` threaded through the entire pipeline.
 
 - No `eprintln!` in library code — all warnings/info go through the collector
-- Machine-readable codes (e.g. `"shadow-collision"`, `"model-alias-conflict"`, `"target-sync-error"`)
+- Machine-readable codes (e.g. `"shadow-collision"`, `"model-alias-conflict"`, `"target-sync-error"`, `"target-unmanaged-collision"`, `"target-unmanaged-adopted"`)
 - CLI layer formats diagnostics for human or JSON output
 - Diagnostics are non-fatal — pipeline continues, report includes all collected diagnostics
 
@@ -194,6 +197,7 @@ See `.context/CONTEXT.md` in `src/harness/`, `src/routing/`, `src/config/`, and 
 |---|---|
 | `src/sync/` | Pipeline orchestration + typed phase functions |
 | `src/target_sync/` | Copy from `.mars/` to managed target directories |
+| `src/surface_ownership/` | Per-target delete/copy gating for linked targets; shared by target sync, native reconcile, and dual-surface compile |
 | `src/reconcile/` | Shared atomic fs operations (Layer 1) + state-based reconciliation (Layer 2) |
 | `src/models/` | Model catalog, auto-resolve, cache, no builtins |
 | `src/models/probes/` | OpenCode and Pi capability probing with disk cache. Compatible Pi → `Confirmed` confidence |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Launch-bundle model now optional; unset model routes to installed/default harness and leaves harness model empty for harness defaults.
 - Default to RC release when no release label present on merged PR (previously skipped release entirely).
 
+### Fixed
+- Linked-target sync no longer deletes or overwrites hand-written files when the lock only tracks the same path under `.mars`. Orphan cleanup, Removed handling, and copy paths now require a per-target `OutputRecord`. Pre-existing untracked collisions are preserved with `target-unmanaged-collision`; `mars sync --force` and `mars link --force` adopt them and record ownership (`target-unmanaged-adopted`). Closes #60.
+
 ## [0.6.0] - 2026-05-22
 
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,11 +12,11 @@ Mars installs into a `.mars/` canonical store, tracks ownership in `mars.lock`, 
 
 **Canonical store** (`.mars/`) is where Mars installs resolved content. Gitignored. Rebuilt by `mars sync` from sources + lock.
 
-**Managed root** is the directory Mars copies content into from `.mars/` (default: `.agents/`, configurable via `settings.managed_root`). The managed root may contain non-mars content — mars only manages files it created (tracked in the lock). Additional tool directories (`.claude/`, `.cursor/`) can be added as targets via `mars link`.
+**Managed root** is the directory Mars copies content into from `.mars/` (default: `.agents/`, configurable via `settings.managed_root`). The managed root may contain non-mars content — Mars only mutates paths it tracks in the lock for that target. Additional tool directories (`.claude/`, `.cursor/`) can be added as targets via `mars link`.
 
 **`--root`** points at the project root to override auto-detection. Mars resolves from the directory containing `mars.toml`.
 
-**Lock file** (`mars.lock`) records every managed item with its source, version, and content checksums. It is the authority for what Mars manages. See [internals/lock-file.md](internals/lock-file.md) for format details.
+**Lock file** (`mars.lock`) records every managed item with its source, version, and content checksums. Lock v2 tracks outputs per `(target_root, dest_path)` — ownership in `.cursor` is independent from the same path under `.mars/`. See [internals/lock-file.md](internals/lock-file.md) for format details.
 
 **Filters** control which items from a source get installed: include specific agents/skills, exclude items, or restrict to agents-only or skills-only. See [config/mars-toml.md](config/mars-toml.md).
 

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -291,17 +291,18 @@ mars link <target> [--force]
 
 | Flag | Description |
 |---|---|
-| `--force` | Replace whatever exists (data may be lost) |
+| `--force` | Adopt untracked collisions in the linked target (overwrite + record in lock) |
 
 **Behavior:**
 - Adds `<target>` as a managed target directory and copies content from `.mars/` into it
-- Conflict-aware: scans target before mutating. If conflicts exist, reports all problems and aborts (zero mutations)
-- Persists the target in `mars.toml [settings] targets`
+- Persists the target in `mars.toml [settings] targets` and updates `mars.lock` with per-target output records
+- If a path in the target exists on disk but is not tracked for that `target_root`, Mars preserves it and emits `target-unmanaged-collision` (exit 2). Run `mars link <target> --force` to adopt and record ownership (`target-unmanaged-adopted`)
+- Materialization depends on target and `agent_emission` (e.g. `.cursor` receives skills/MCP, not native agent files)
 
 ```bash
-mars link .claude            # Copy agents/ and skills/ into .claude/
-mars link .cursor            # Copy to another tool
-mars link .claude --force    # Replace whatever exists
+mars link .claude            # Copy managed content into .claude/
+mars link .cursor            # Copy skills/MCP into .cursor (experimental)
+mars link .claude --force    # Adopt untracked collisions in .claude/
 ```
 
 ---

--- a/docs/dev/troubleshooting.md
+++ b/docs/dev/troubleshooting.md
@@ -131,10 +131,10 @@ mars unlink .claude          # Remove old link
 mars link .claude            # Re-create correct link
 ```
 
-Or with force:
+If link fails with an unmanaged collision (hand-written file at a path Mars wants to manage):
 
 ```bash
-mars link .claude --force    # Replace whatever exists
+mars link .claude --force    # Adopt collision and record ownership in mars.lock
 ```
 
 ### "override `X` references a dependency not in mars.toml"

--- a/docs/internals/lock-file.md
+++ b/docs/internals/lock-file.md
@@ -40,7 +40,7 @@ dest_path = "skills/review"
 
 | Field | Type | Description |
 |---|---|---|
-| `version` | integer | Schema version (currently `1`) |
+| `version` | integer | Schema version (`2` is current; `1` is legacy) |
 | `dependencies` | table | Resolved source entries |
 | `items` | table | Installed items with checksums |
 
@@ -102,6 +102,18 @@ source_checksum = "sha256:..."
 installed_checksum = "sha256:..."
 dest_path = "skills/local-skill"
 ```
+
+## Lock v2 and per-target outputs
+
+Current locks use `version = 2`. Items are keyed by stable id (e.g. `agent/coder`) and may have multiple `[[items."…".outputs]]` rows:
+
+| Field | Description |
+|---|---|
+| `target_root` | Target directory Mars wrote to (e.g. `.mars`, `.cursor`, `.agents`) |
+| `dest_path` | Path relative to that target root |
+| `installed_checksum` | SHA-256 of content at that target path |
+
+Mars may delete or overwrite a path in a linked target only when the previous lock contains a matching `(target_root, dest_path)`. The same `dest_path` under `.mars` does not imply ownership under `.cursor`. See `src/target_sync/.context/CONTEXT.md`.
 
 ## Building the Lock
 

--- a/docs/internals/sync-pipeline.md
+++ b/docs/internals/sync-pipeline.md
@@ -212,7 +212,7 @@ Copies content from `.mars/` canonical store to each configured target directory
 - Targets include the managed root (default: `.agents/`) plus any additional directories added via `mars link` (`settings.targets`)
 - All targets get file copies
 - Uses `reconcile::fs_ops` for atomic operations (tmp+rename)
-- Orphan cleanup: uses the previous lock to identify mars-managed files in each target, removes only those that are no longer in the current apply outcomes
+- Orphan cleanup: scoped per target via `output_dest_paths_for_target(target_root)` — only removes paths Mars previously managed **in that target** (`target_root` + `dest_path` on lock `OutputRecord`). A `.mars`-only record does not authorize deletes under `.cursor` or other targets. Untracked collisions are preserved unless `mars sync --force` adopts them (see `src/target_sync/.context/CONTEXT.md`)
 - Non-fatal per-target: errors on one target are recorded in `TargetSyncOutcome` but don't stop other targets from syncing
 
 ### 7. Finalize (`finalize`)

--- a/scripts/smoke-target-scoped.sh
+++ b/scripts/smoke-target-scoped.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+WORKTREE="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$WORKTREE"
+cargo build -q
+MARS="$WORKTREE/target/debug/mars"
+SCRATCH=$(mktemp -d)
+echo "SCRATCH=$SCRATCH"
+PASS=0
+FAIL=0
+pass() { echo "PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL+1)); }
+
+# --- SMOKE 1: .cursor + never preserves hand-written agents ---
+mkdir -p "$SCRATCH/src/agents"
+echo '# Design lead from Mars' > "$SCRATCH/src/agents/design-lead.md"
+PROJ1="$SCRATCH/smoke1"
+mkdir -p "$PROJ1"
+cat > "$PROJ1/mars.toml" << EOF
+[settings]
+targets = [".cursor"]
+agent_emission = "never"
+
+[dependencies.src]
+path = "../src"
+EOF
+cd "$PROJ1"
+"$MARS" sync --root . >/dev/null 2>&1
+test -d .mars && pass "SMOKE1: initial sync creates .mars" || fail "SMOKE1: no .mars"
+mkdir -p .cursor/agents
+echo '# custom' > .cursor/agents/cursor-only-test.md
+echo '# hand-written' > .cursor/agents/design-lead.md
+"$MARS" sync --root . >/dev/null 2>&1
+if [ "$(cat .cursor/agents/design-lead.md)" = "# hand-written" ]; then
+  pass "SMOKE1: design-lead preserved after second sync"
+else
+  fail "SMOKE1: design-lead changed: $(cat .cursor/agents/design-lead.md)"
+fi
+test -f .cursor/agents/cursor-only-test.md && pass "SMOKE1: cursor-only-test preserved" || fail "SMOKE1: cursor-only-test missing"
+
+# --- SMOKE 2: link .agents collision (integration-style: no never) ---
+mkdir -p "$SCRATCH/src2/agents"
+echo '# Coder from Mars' > "$SCRATCH/src2/agents/coder.md"
+PROJ2="$SCRATCH/smoke2"
+mkdir -p "$PROJ2"
+cat > "$PROJ2/mars.toml" << EOF
+[dependencies.base]
+path = "../src2"
+EOF
+cd "$PROJ2"
+"$MARS" sync --root . >/dev/null 2>&1
+mkdir -p .agents/agents
+echo '# hand-written' > .agents/agents/coder.md
+set +e
+"$MARS" link .agents --root . >/dev/null 2>&1
+LINK_EXIT=$?
+set -e
+if [ "$LINK_EXIT" -ne 0 ]; then
+  pass "SMOKE2a: link .agents without --force exits non-zero ($LINK_EXIT)"
+else
+  fail "SMOKE2a: link .agents without --force should fail (got 0)"
+fi
+if [ "$(cat .agents/agents/coder.md)" = "# hand-written" ]; then
+  pass "SMOKE2a: hand-written coder preserved after failed link"
+else
+  fail "SMOKE2a: coder overwritten before force"
+fi
+"$MARS" link .agents --force --root . >/dev/null 2>&1
+if [ "$(cat .agents/agents/coder.md)" = "# Coder from Mars" ]; then
+  pass "SMOKE2b: link --force adopts collision (content from Mars)"
+else
+  fail "SMOKE2b: coder content after force: $(cat .agents/agents/coder.md)"
+fi
+if grep -q 'target_root = ".agents"' mars.lock 2>/dev/null; then
+  pass "SMOKE2b: lock records target_root = .agents"
+else
+  fail "SMOKE2b: no target_root = .agents in mars.lock"
+fi
+
+# --- SMOKE 3: sync --force overwrites divergent .agents file ---
+PROJ3="$SCRATCH/smoke3"
+mkdir -p "$PROJ3"
+cat > "$PROJ3/mars.toml" << EOF
+[settings]
+targets = [".agents"]
+
+[dependencies.base]
+path = "../src2"
+EOF
+cd "$PROJ3"
+"$MARS" sync --root . >/dev/null 2>&1
+echo '# Hand-edited' > .agents/agents/coder.md
+"$MARS" sync --root . >/dev/null 2>&1
+if [ "$(cat .agents/agents/coder.md)" = "# Hand-edited" ]; then
+  pass "SMOKE3a: sync without --force preserves divergent .agents file"
+else
+  fail "SMOKE3a: divergent file overwritten without force"
+fi
+"$MARS" sync --force --root . >/dev/null 2>&1
+if [ "$(cat .agents/agents/coder.md)" = "# Coder from Mars" ]; then
+  pass "SMOKE3b: sync --force restores canonical .agents content"
+else
+  fail "SMOKE3b: content after force: $(cat .agents/agents/coder.md)"
+fi
+
+echo ""
+echo "=== SUMMARY: $PASS passed, $FAIL failed (scratch: $SCRATCH) ==="
+exit "$FAIL"

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -13,7 +13,7 @@ mars.toml + mars.lock (committed, project root)
 ```
 
 - **`.mars/` is a cache, not the source of truth.** Committed targets + `mars.lock` are the authority. Fresh clone rebuilds `.mars/` from sources.
-- **Mars never deletes files it didn't create.** Lock file is the authority on what mars manages. Orphan cleanup only removes files whose `dest_path` was in the previous lock.
+- **Mars never deletes files it didn't create.** Lock file is the authority on what mars manages **per target** via `(target_root, dest_path)` on each `OutputRecord`. Orphan cleanup only removes paths previously managed in that target.
 - **All writes are atomic** (tmp+rename). Crash mid-write leaves old file intact.
 
 ## Dependency Direction
@@ -36,6 +36,7 @@ cli → sync → compiler → target adapters
 - `compiler/` compiles IR into target state, handles dual-surface emission
 - `target/` per-target compilation adapters (`.claude`, `.codex`, etc.)
 - `target_sync/` copies from `.mars/` to configured target directories
+- `surface_ownership/` gates linked-target deletes and copy/install on per-target lock records
 - `models/` model catalog, alias resolution, auto-resolve against cached catalog
 - `routing/` harness candidate evaluation — single evaluator for all routing
 - `harness/` canonical harness vocabulary (registry) + capability snapshot (host)
@@ -57,7 +58,7 @@ cli → sync → compiler → target adapters
 
 - **Never add a second candidate evaluator** — `routing::evaluate_candidates()` is the only one. Both `mars models` and `mars build` call it.
 - **Never validate harness names outside `harness::registry`** — `registry::parse()` and `registry::is_known()` are the only authorities.
-- **Never scan-and-delete unknown files in targets** — only remove files tracked in the lock.
+- **Never scan-and-delete unknown files in targets** — only remove files tracked in the lock for that `(target_root, dest_path)`.
 - **Never use `eprintln!` in library code** — all diagnostics go through `DiagnosticCollector`.
 - **Never hardcode model aliases in the binary** — all aliases come from packages or consumer config.
 

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -13,7 +13,7 @@ mars.toml + mars.lock (committed, project root)
 ```
 
 - **`.mars/` is a cache, not the source of truth.** Committed targets + `mars.lock` are the authority. Fresh clone rebuilds `.mars/` from sources.
-- **Mars never deletes files it didn't create.** Lock file is the authority on what mars manages **per target** via `(target_root, dest_path)` on each `OutputRecord`. Orphan cleanup only removes paths previously managed in that target.
+- **Mars never deletes files it didn't create.** Per-target lock ownership — see root `AGENTS.md` Critical Invariants and `target_sync/.context/CONTEXT.md`.
 - **All writes are atomic** (tmp+rename). Crash mid-write leaves old file intact.
 
 ## Dependency Direction
@@ -58,7 +58,7 @@ cli → sync → compiler → target adapters
 
 - **Never add a second candidate evaluator** — `routing::evaluate_candidates()` is the only one. Both `mars models` and `mars build` call it.
 - **Never validate harness names outside `harness::registry`** — `registry::parse()` and `registry::is_known()` are the only authorities.
-- **Never scan-and-delete unknown files in targets** — only remove files tracked in the lock for that `(target_root, dest_path)`.
+- **Never scan-and-delete unknown files in targets** — only remove paths tracked in the lock for that target; see `target_sync/.context/CONTEXT.md`.
 - **Never use `eprintln!` in library code** — all diagnostics go through `DiagnosticCollector`.
 - **Never hardcode model aliases in the binary** — all aliases come from packages or consumer config.
 

--- a/src/cli/AGENTS.md
+++ b/src/cli/AGENTS.md
@@ -28,7 +28,7 @@ Three bypass conditions:
 | Package mgmt | `add`, `remove`, `upgrade`, `outdated`, `why` | Mutate mars.toml + lock |
 | Sync | `sync`, `repair` | Make reality match config |
 | Build | `validate`, `export`, `build` | Dry-run or produce artifacts |
-| Config | `link`, `unlink`, `override`, `resolve` | Target/dev settings |
+| Config | `link`, `unlink`, `override`, `resolve` | Target/dev settings; `link --force` adopts unmanaged collisions and persists lock |
 | Models | `models` | Alias resolution, catalog cache |
 | Diagnostics | `doctor`, `check`, `list`, `version` | Read-only inspection |
 | Init | `init` | Bootstrap project |

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -121,6 +121,7 @@ pub fn run(args: &InitArgs, explicit_root: Option<&Path>, json: bool) -> Result<
         for link_target in &args.link {
             let link_args = super::link::LinkArgs {
                 target: link_target.clone(),
+                force: false,
             };
             super::link::run(&link_args, &ctx, json)?;
         }

--- a/src/cli/link.rs
+++ b/src/cli/link.rs
@@ -7,10 +7,10 @@
 use crate::diagnostic::{Diagnostic, DiagnosticCategory, DiagnosticCollector, DiagnosticLevel};
 use crate::error::MarsError;
 use crate::lock::{ItemId, ItemKind, LockFile};
+use crate::surface_ownership::CollisionAdoptHint;
 use crate::sync::apply::{ActionOutcome, ActionTaken};
 use crate::types::ItemName;
 use crate::types::managed_cmd;
-use std::collections::HashSet;
 
 use super::output;
 
@@ -19,16 +19,24 @@ use super::output;
 pub struct LinkArgs {
     /// Target directory to materialize (e.g. `.claude`).
     pub target: String,
+    /// Adopt untracked collisions in the linked target (overwrite + record in lock).
+    #[arg(long)]
+    pub force: bool,
 }
 
 /// Run `mars link`.
 pub fn run(args: &LinkArgs, ctx: &super::MarsContext, json: bool) -> Result<i32, MarsError> {
     let parsed_target = super::target::normalize_target_name(&args.target)?;
     let target_name = crate::config::migrations::link::normalize_link(&parsed_target).target;
-    link_target(ctx, &target_name, json)
+    link_target(ctx, &target_name, args.force, json)
 }
 
-fn link_target(ctx: &super::MarsContext, target_name: &str, json: bool) -> Result<i32, MarsError> {
+fn link_target(
+    ctx: &super::MarsContext,
+    target_name: &str,
+    force: bool,
+    json: bool,
+) -> Result<i32, MarsError> {
     let config_path = ctx.project_root.join("mars.toml");
     if !config_path.exists() {
         return Err(MarsError::Link {
@@ -79,24 +87,39 @@ fn link_target(ctx: &super::MarsContext, target_name: &str, json: bool) -> Resul
     } else {
         &outcomes
     };
-    let previous_managed_paths = lock
-        .all_output_dest_paths()
-        .map(|dest_path| dest_path.to_string())
-        .collect::<HashSet<String>>();
 
     let mut diag = DiagnosticCollector::new();
+    let target_sync_ctx = crate::target_sync::TargetSyncContext {
+        old_lock: &lock,
+        force,
+        collision_hint: CollisionAdoptHint::LinkForce,
+    };
     let target_outcomes = crate::target_sync::sync_managed_targets(
         &ctx.project_root,
         &mars_dir,
         &[target_name.to_string()],
         sync_outcomes,
-        &previous_managed_paths,
-        true,
+        &target_sync_ctx,
         &mut diag,
     );
     let mut diagnostics = diag.drain();
     if let Some(diagnostic) = deprecated_agents_target_diagnostic(target_name) {
         diagnostics.push(diagnostic);
+    }
+
+    if !force
+        && diagnostics
+            .iter()
+            .any(|d| d.code == "target-unmanaged-collision")
+    {
+        return Err(MarsError::Link {
+            target: target_name.to_string(),
+            message: format!(
+                "unmanaged collision in `{target_name}` — hand-written files would be skipped; \
+                 run `{}` to adopt",
+                managed_cmd(&format!("mars link {target_name} --force")),
+            ),
+        });
     }
 
     let Some(outcome) = target_outcomes.first() else {
@@ -112,6 +135,10 @@ fn link_target(ctx: &super::MarsContext, target_name: &str, json: bool) -> Resul
             message: outcome.errors.join("; "),
         });
     }
+
+    let mut new_lock = lock;
+    crate::lock::apply_target_sync_outputs(&mut new_lock, &target_outcomes);
+    crate::lock::write(&ctx.project_root, &new_lock)?;
 
     if settings_changed {
         config.settings.targets = Some(targets);
@@ -151,7 +178,7 @@ fn deprecated_agents_target_diagnostic(target_name: &str) -> Option<Diagnostic> 
 }
 
 fn lock_items_as_sync_outcomes(lock: &LockFile) -> Vec<ActionOutcome> {
-    lock.flat_items()
+    lock.canonical_flat_items()
         .into_iter()
         .map(|(dest_path, item)| ActionOutcome {
             item_id: ItemId {

--- a/src/compiler/AGENTS.md
+++ b/src/compiler/AGENTS.md
@@ -87,8 +87,13 @@ reconcile_native_agent_surfaces(policy, project_root, mars_dir, &outcomes, false
 let policy = agent_surface_policy(Some(&AgentEmission::Auto), true); // meridian → SuppressAll
 ```
 
+## Linked-target writes
+
+Native reconcile and dual-surface compile gate deletes and copies through `surface_ownership` (same rules as `target_sync`). See `src/target_sync/.context/CONTEXT.md`.
+
 ## See Also
 
 - `src/sync/AGENTS.md` — orchestrates the compiler
 - `src/target/AGENTS.md` — per-target adapters the compiler uses
+- `src/target_sync/.context/CONTEXT.md` — per-target lock ownership and collision semantics
 - `src/compiler/agents/mod.rs` — AgentProfile schema details

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -74,12 +74,23 @@ pub fn compile(
         &ctx.project_root,
         &mars_dir,
         &applied.applied.outcomes,
+        &applied.planned.targeted.resolved.loaded.old_lock,
         request.options.dry_run,
         diag,
     );
-    if matches!(agent_surface_policy, AgentSurfacePolicy::EmitAll) {
-        dual_surface_compile(&ctx.project_root, &mars_dir, request.options.dry_run, diag);
-    }
+    let compiled_native_outputs = if matches!(agent_surface_policy, AgentSurfacePolicy::EmitAll) {
+        dual_surface_compile(
+            &ctx.project_root,
+            &mars_dir,
+            &applied.planned.targeted.resolved.loaded.old_lock,
+            request.options.force,
+            crate::surface_ownership::CollisionAdoptHint::SyncForce,
+            request.options.dry_run,
+            diag,
+        )
+    } else {
+        Vec::new()
+    };
 
     // Phase 5.1 / 5.2 / 5.3: MCP and hooks config-entry compilation.
     // Discovers MCP server and hook items from all packages, validates env refs,
@@ -91,6 +102,7 @@ pub fn compile(
     // Phase 6: copy from canonical store to managed target directories.
     let mut synced = sync_targets(ctx, applied, request, agent_surface_policy, diag);
     synced.config_entries = config_entry_records;
+    synced.compiled_native_outputs = compiled_native_outputs;
 
     // Phase 7: write lock file, build report.
     finalize(ctx, synced, request, diag)
@@ -144,13 +156,14 @@ fn reconcile_native_agent_surfaces(
     project_root: &Path,
     mars_dir: &Path,
     outcomes: &[crate::sync::apply::ActionOutcome],
+    old_lock: &crate::lock::LockFile,
     dry_run: bool,
     diag: &mut DiagnosticCollector,
 ) {
     use crate::lock::ItemKind;
 
     if matches!(policy, AgentSurfacePolicy::SuppressAll) {
-        remove_current_native_agent_surfaces(project_root, mars_dir, dry_run, diag);
+        remove_current_native_agent_surfaces(project_root, mars_dir, old_lock, dry_run, diag);
     }
 
     for outcome in outcomes {
@@ -161,13 +174,14 @@ fn reconcile_native_agent_surfaces(
         }
 
         let agent_name = outcome.dest_path.item_name(ItemKind::Agent);
-        remove_native_agent_shapes(project_root, &agent_name, dry_run, diag);
+        remove_native_agent_shapes(project_root, &agent_name, old_lock, dry_run, diag);
     }
 }
 
 fn remove_current_native_agent_surfaces(
     project_root: &Path,
     mars_dir: &Path,
+    old_lock: &crate::lock::LockFile,
     dry_run: bool,
     diag: &mut DiagnosticCollector,
 ) {
@@ -212,13 +226,14 @@ fn remove_current_native_agent_surfaces(
                 .and_then(|s| s.to_str())
                 .unwrap_or("unknown")
         });
-        remove_native_agent_shapes(project_root, agent_name, dry_run, diag);
+        remove_native_agent_shapes(project_root, agent_name, old_lock, dry_run, diag);
     }
 }
 
 fn remove_native_agent_shapes(
     project_root: &Path,
     agent_name: &str,
+    old_lock: &crate::lock::LockFile,
     dry_run: bool,
     diag: &mut DiagnosticCollector,
 ) {
@@ -227,6 +242,10 @@ fn remove_native_agent_shapes(
     for harness in HarnessKind::all() {
         let target = harness.target_dir();
         for extension in ["md", "toml"] {
+            let dest_rel = format!("agents/{agent_name}.{extension}");
+            if !old_lock.contains_output(target, &dest_rel) {
+                continue;
+            }
             let native_path = project_root
                 .join(target)
                 .join("agents")
@@ -261,18 +280,22 @@ fn remove_native_agent_shapes(
 fn dual_surface_compile(
     project_root: &Path,
     mars_dir: &Path,
+    old_lock: &crate::lock::LockFile,
+    force: bool,
+    collision_hint: crate::surface_ownership::CollisionAdoptHint,
     dry_run: bool,
     diag: &mut DiagnosticCollector,
-) {
+) -> Vec<(String, String, crate::types::ContentHash)> {
     use crate::compiler::agents::HarnessKind;
     use crate::compiler::agents::lower::lower_for_harness;
     use crate::compiler::agents::parse_agent_content;
+    use crate::surface_ownership::{self, SurfaceCopyDecision};
 
     let agents_dir = mars_dir.join("agents");
     let Ok(entries) = std::fs::read_dir(&agents_dir) else {
-        // .mars/agents/ doesn't exist yet (e.g., first dry-run or empty project).
-        return;
+        return Vec::new();
     };
+    let mut records = Vec::new();
 
     for entry in entries.flatten() {
         let path = entry.path();
@@ -361,6 +384,31 @@ fn dual_surface_compile(
             _ => format!("{agent_name}.md"),
         };
         let native_path = native_agents_dir.join(&file_name);
+        let dest_rel = format!("agents/{file_name}");
+        let target_dir = harness.target_dir();
+        let dest_exists = surface_ownership::target_dest_exists(&native_path);
+        match surface_ownership::copy_decision(old_lock, target_dir, &dest_rel, dest_exists, force)
+        {
+            SurfaceCopyDecision::SkipUnmanagedCollision => {
+                surface_ownership::warn_unmanaged_collision(
+                    target_dir,
+                    &dest_rel,
+                    collision_hint,
+                    diag,
+                );
+                continue;
+            }
+            SurfaceCopyDecision::Proceed => {
+                if dest_exists && force && !old_lock.contains_output(target_dir, &dest_rel) {
+                    surface_ownership::warn_unmanaged_adopted(
+                        target_dir,
+                        &dest_rel,
+                        collision_hint,
+                        diag,
+                    );
+                }
+            }
+        }
 
         // Write native artifact (atomic tmp+rename) — skipped on dry runs.
         if !dry_run {
@@ -377,9 +425,14 @@ fn dual_surface_compile(
                     "dual-surface-write",
                     format!("could not write {}: {e}", native_path.display()),
                 );
+            } else {
+                let checksum =
+                    crate::types::ContentHash::from(crate::hash::hash_bytes(&lowered.bytes));
+                records.push((target_dir.to_string(), dest_rel, checksum));
             }
         }
     }
+    records
 }
 
 #[cfg(test)]
@@ -387,7 +440,7 @@ mod skill_surface_tests {
     use super::*;
     use crate::compiler::agents::HarnessKind;
     use crate::diagnostic::DiagnosticCollector;
-    use crate::lock::{ItemId, ItemKind};
+    use crate::lock::{ItemId, ItemKind, LockFile, LockedItemV2, OutputRecord};
     use crate::sync::apply::{ActionOutcome, ActionTaken};
     use crate::types::{DestPath, ItemName};
     use tempfile::TempDir;
@@ -424,6 +477,29 @@ mod skill_surface_tests {
         );
     }
 
+    fn lock_with_target_outputs(targets: &[&str], dest: &str, checksum: &str) -> LockFile {
+        let mut lock = LockFile::empty();
+        let outputs = targets
+            .iter()
+            .map(|target| OutputRecord {
+                target_root: (*target).to_string(),
+                dest_path: dest.into(),
+                installed_checksum: checksum.into(),
+            })
+            .collect();
+        lock.items.insert(
+            "agent/coder".to_string(),
+            LockedItemV2 {
+                source: "test".into(),
+                kind: ItemKind::Agent,
+                version: None,
+                source_checksum: "sha256:src".into(),
+                outputs,
+            },
+        );
+        lock
+    }
+
     fn agent_outcome(name: &str, action: ActionTaken) -> ActionOutcome {
         ActionOutcome {
             item_id: ItemId {
@@ -448,12 +524,29 @@ mod skill_surface_tests {
             std::fs::write(agents_dir.join("coder.toml"), "old = true\n").unwrap();
         }
 
+        let tracked_targets: Vec<&str> =
+            HarnessKind::all().iter().map(|h| h.target_dir()).collect();
+        let mut lock =
+            lock_with_target_outputs(&tracked_targets, "agents/coder.md", "sha256:coder");
+        for target in &tracked_targets {
+            lock.items
+                .get_mut("agent/coder")
+                .unwrap()
+                .outputs
+                .push(OutputRecord {
+                    target_root: (*target).to_string(),
+                    dest_path: "agents/coder.toml".into(),
+                    installed_checksum: "sha256:coder-toml".into(),
+                });
+        }
+
         let mut diag = DiagnosticCollector::new();
         reconcile_native_agent_surfaces(
             AgentSurfacePolicy::EmitAll,
             dir.path(),
             &dir.path().join(".mars"),
             &[agent_outcome("coder", ActionTaken::Removed)],
+            &lock,
             false,
             &mut diag,
         );
@@ -496,12 +589,17 @@ mod skill_surface_tests {
         }
 
         let mut diag = DiagnosticCollector::new();
+        let lock = lock_with_target_outputs(
+            &[".claude", ".codex", ".opencode"],
+            "agents/coder.md",
+            "sha256:coder",
+        );
         reconcile_native_agent_surfaces(
             AgentSurfacePolicy::SuppressAll,
             dir.path(),
             &dir.path().join(".mars"),
-            // No removed outcomes — suppression removes current agents regardless
             &[agent_outcome("coder", ActionTaken::Installed)],
+            &lock,
             false,
             &mut diag,
         );
@@ -512,6 +610,36 @@ mod skill_surface_tests {
                 "native agent should be removed under SuppressAll for target {target}"
             );
         }
+    }
+
+    #[test]
+    fn reconcile_suppress_all_preserves_untracked_native_agents() {
+        let dir = TempDir::new().unwrap();
+
+        let mars_agents = dir.path().join(".mars").join("agents");
+        std::fs::create_dir_all(&mars_agents).unwrap();
+        std::fs::write(
+            mars_agents.join("coder.md"),
+            "---\nname: coder\n---\n# Coder\n",
+        )
+        .unwrap();
+
+        let agents_dir = dir.path().join(".cursor").join("agents");
+        std::fs::create_dir_all(&agents_dir).unwrap();
+        std::fs::write(agents_dir.join("coder.md"), "# hand-written\n").unwrap();
+
+        let mut diag = DiagnosticCollector::new();
+        reconcile_native_agent_surfaces(
+            AgentSurfacePolicy::SuppressAll,
+            dir.path(),
+            &dir.path().join(".mars"),
+            &[agent_outcome("coder", ActionTaken::Installed)],
+            &LockFile::empty(),
+            false,
+            &mut diag,
+        );
+
+        assert!(dir.path().join(".cursor/agents/coder.md").exists());
     }
 
     #[test]
@@ -528,8 +656,8 @@ mod skill_surface_tests {
             AgentSurfacePolicy::EmitAll,
             dir.path(),
             &dir.path().join(".mars"),
-            // Agent is Installed (not Removed) — should be preserved
             &[agent_outcome("coder", ActionTaken::Installed)],
+            &LockFile::empty(),
             false,
             &mut diag,
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod reconcile;
 pub mod resolve;
 pub mod routing;
 pub mod source;
+pub(crate) mod surface_ownership;
 pub mod sync;
 pub mod target;
 pub mod target_sync;

--- a/src/lock/mod.rs
+++ b/src/lock/mod.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use indexmap::IndexMap;
@@ -97,6 +97,56 @@ impl LockFile {
         self.items
             .values()
             .flat_map(|item| item.outputs.iter().map(|o| &o.dest_path))
+    }
+
+    /// Dest paths previously managed under a specific target root.
+    pub fn output_dest_paths_for_target(&self, target_root: &str) -> HashSet<String> {
+        self.items
+            .values()
+            .flat_map(|item| item.outputs.iter())
+            .filter(|output| output.target_root == target_root)
+            .map(|output| output.dest_path.to_string())
+            .collect()
+    }
+
+    /// Whether the lock records ownership of `dest_path` under `target_root`.
+    pub fn contains_output(&self, target_root: &str, dest_path: &str) -> bool {
+        self.items.values().any(|item| {
+            item.outputs.iter().any(|output| {
+                output.target_root == target_root
+                    && crate::target::dest_paths_equivalent(output.dest_path.as_str(), dest_path)
+            })
+        })
+    }
+
+    /// Flat view of canonical `.mars` outputs only.
+    pub fn canonical_flat_items(&self) -> Vec<(DestPath, LockedItem)> {
+        self.flat_items_for_target(CANONICAL_TARGET_ROOT)
+    }
+
+    /// Flat view of outputs materialized under `target_root`.
+    pub fn flat_items_for_target(&self, target_root: &str) -> Vec<(DestPath, LockedItem)> {
+        self.items
+            .values()
+            .flat_map(|item_v2| {
+                item_v2.outputs.iter().filter_map(|output| {
+                    if output.target_root != target_root {
+                        return None;
+                    }
+                    Some((
+                        output.dest_path.clone(),
+                        LockedItem {
+                            source: item_v2.source.clone(),
+                            kind: item_v2.kind,
+                            version: item_v2.version.clone(),
+                            source_checksum: item_v2.source_checksum.clone(),
+                            installed_checksum: output.installed_checksum.clone(),
+                            dest_path: output.dest_path.clone(),
+                        },
+                    ))
+                })
+            })
+            .collect()
     }
 
     /// Flat view of all items as owned `(dest_path, LockedItem)` pairs.
@@ -256,6 +306,8 @@ pub use crate::types::{ItemId, ItemKind};
 const LOCK_FILE: &str = "mars.lock";
 /// Current lock file schema version.
 const LOCK_VERSION: u32 = 2;
+/// Canonical materialization root for `.mars/` apply outcomes.
+pub const CANONICAL_TARGET_ROOT: &str = ".mars";
 
 // ---------------------------------------------------------------------------
 // V1 wire type — used only for reading legacy lock files.
@@ -638,6 +690,82 @@ pub fn build(
     })
 }
 
+/// Merge per-target sync results into a built lock file.
+pub fn apply_target_sync_outputs(
+    lock: &mut LockFile,
+    target_outcomes: &[crate::target_sync::TargetSyncOutcome],
+) {
+    for outcome in target_outcomes {
+        for dest_path in &outcome.removed_dest_paths {
+            remove_target_output(lock, &outcome.target, dest_path);
+        }
+        for synced in &outcome.synced_outputs {
+            upsert_target_output(
+                lock,
+                &outcome.target,
+                &synced.dest_path,
+                &synced.installed_checksum,
+            );
+        }
+    }
+}
+
+/// Record native harness outputs produced by dual-surface compile.
+pub fn apply_compiled_native_outputs(
+    lock: &mut LockFile,
+    records: &[(String, String, ContentHash)],
+) {
+    for (target_root, dest_path, installed_checksum) in records {
+        upsert_target_output(lock, target_root, dest_path, installed_checksum);
+    }
+}
+
+fn upsert_target_output(
+    lock: &mut LockFile,
+    target_root: &str,
+    dest_path: &str,
+    installed_checksum: &ContentHash,
+) {
+    let dest = DestPath::from(dest_path);
+    for item in lock.items.values_mut() {
+        if !item.outputs.iter().any(|output| {
+            crate::target::dest_paths_equivalent(output.dest_path.as_str(), dest_path)
+        }) {
+            continue;
+        }
+
+        if let Some(output) = item.outputs.iter_mut().find(|output| {
+            output.target_root == target_root
+                && crate::target::dest_paths_equivalent(output.dest_path.as_str(), dest_path)
+        }) {
+            output.installed_checksum = installed_checksum.clone();
+            return;
+        }
+
+        item.outputs.push(OutputRecord {
+            target_root: target_root.to_string(),
+            dest_path: dest,
+            installed_checksum: installed_checksum.clone(),
+        });
+        item.outputs.sort_by(|a, b| {
+            a.target_root
+                .cmp(&b.target_root)
+                .then_with(|| a.dest_path.as_str().cmp(b.dest_path.as_str()))
+        });
+        return;
+    }
+}
+
+fn remove_target_output(lock: &mut LockFile, target_root: &str, dest_path: &str) {
+    for item in lock.items.values_mut() {
+        item.outputs.retain(|output| {
+            !(output.target_root == target_root
+                && crate::target::dest_paths_equivalent(output.dest_path.as_str(), dest_path))
+        });
+    }
+    lock.items.retain(|_, item| !item.outputs.is_empty());
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -1012,6 +1140,113 @@ installed_checksum = "sha256:222"
 
         assert!(index.contains_dest_path(&DestPath::from("agents/coder.md")));
         assert!(!index.contains_dest_path(&DestPath::from("agents/nobody.md")));
+    }
+
+    #[test]
+    fn output_dest_paths_for_target_filters_by_target_root() {
+        let mut lock = sample_lock();
+        lock.items
+            .get_mut("agent/coder")
+            .unwrap()
+            .outputs
+            .push(OutputRecord {
+                target_root: ".cursor".to_string(),
+                dest_path: "agents/coder.md".into(),
+                installed_checksum: "sha256:cursor".into(),
+            });
+
+        let mars_paths = lock.output_dest_paths_for_target(".mars");
+        assert!(mars_paths.contains("agents/coder.md"));
+        assert!(mars_paths.contains("skills/review"));
+
+        let cursor_paths = lock.output_dest_paths_for_target(".cursor");
+        assert_eq!(cursor_paths.len(), 1);
+        assert!(cursor_paths.contains("agents/coder.md"));
+        assert!(lock.output_dest_paths_for_target(".claude").is_empty());
+    }
+
+    #[test]
+    fn contains_output_matches_target_root_and_dest_path() {
+        let mut lock = sample_lock();
+        assert!(lock.contains_output(".mars", "agents/coder.md"));
+        assert!(!lock.contains_output(".cursor", "agents/coder.md"));
+
+        lock.items
+            .get_mut("agent/coder")
+            .unwrap()
+            .outputs
+            .push(OutputRecord {
+                target_root: ".cursor".to_string(),
+                dest_path: "agents/coder.md".into(),
+                installed_checksum: "sha256:cursor".into(),
+            });
+        assert!(lock.contains_output(".cursor", "agents/coder.md"));
+        assert!(!lock.contains_output(".cursor", "agents/missing.md"));
+    }
+
+    #[test]
+    fn apply_target_sync_outputs_upserts_and_removes_target_records() {
+        let mut lock = sample_lock();
+        apply_target_sync_outputs(
+            &mut lock,
+            &[crate::target_sync::TargetSyncOutcome {
+                target: ".cursor".to_string(),
+                items_synced: 1,
+                items_removed: 0,
+                errors: Vec::new(),
+                synced_outputs: vec![crate::target_sync::TargetSyncedOutput {
+                    dest_path: "agents/coder.md".to_string(),
+                    installed_checksum: "sha256:cursor".into(),
+                }],
+                removed_dest_paths: Vec::new(),
+            }],
+        );
+        assert!(lock.contains_output(".cursor", "agents/coder.md"));
+
+        apply_target_sync_outputs(
+            &mut lock,
+            &[crate::target_sync::TargetSyncOutcome {
+                target: ".cursor".to_string(),
+                items_synced: 0,
+                items_removed: 1,
+                errors: Vec::new(),
+                synced_outputs: Vec::new(),
+                removed_dest_paths: vec!["agents/coder.md".to_string()],
+            }],
+        );
+        assert!(!lock.contains_output(".cursor", "agents/coder.md"));
+        assert!(lock.contains_output(".mars", "agents/coder.md"));
+    }
+
+    #[test]
+    fn canonical_flat_items_excludes_linked_target_outputs() {
+        let mut lock = sample_lock();
+        lock.items
+            .get_mut("agent/coder")
+            .unwrap()
+            .outputs
+            .push(OutputRecord {
+                target_root: ".cursor".to_string(),
+                dest_path: "agents/coder.md".into(),
+                installed_checksum: "sha256:cursor".into(),
+            });
+
+        let canonical = lock.canonical_flat_items();
+        assert_eq!(canonical.len(), 2);
+        assert!(
+            canonical
+                .iter()
+                .any(|(dp, _)| dp.as_str() == "agents/coder.md")
+        );
+        assert!(
+            canonical
+                .iter()
+                .all(|(_, item)| { lock.contains_output(".mars", item.dest_path.as_str()) })
+        );
+
+        let cursor = lock.flat_items_for_target(".cursor");
+        assert_eq!(cursor.len(), 1);
+        assert_eq!(cursor[0].0.as_str(), "agents/coder.md");
     }
 
     #[test]

--- a/src/surface_ownership.rs
+++ b/src/surface_ownership.rs
@@ -1,0 +1,161 @@
+//! Per-target surface ownership — gate linked-target mutations on lock records.
+//!
+//! For linked targets (`.cursor`, `.claude`, etc.), Mars may delete or overwrite
+//! only when the lock has an [`OutputRecord`](crate::lock::OutputRecord) for
+//! `(target_root, dest_path)`. `.mars`-only records do not imply ownership
+//! elsewhere.
+
+use std::path::Path;
+
+use crate::diagnostic::DiagnosticCollector;
+use crate::lock::LockFile;
+use crate::types::managed_cmd;
+
+/// Which command's `--force` flag would adopt an untracked collision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CollisionAdoptHint {
+    SyncForce,
+    LinkForce,
+}
+
+/// Whether a copy/install to a linked target may proceed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SurfaceCopyDecision {
+    /// Dest is missing, tracked, or `--force` adopt applies.
+    Proceed,
+    /// Dest exists but is not tracked for this target — preserve local content.
+    SkipUnmanagedCollision,
+}
+
+/// Whether `dest` exists on disk (file, directory, or symlink).
+pub fn target_dest_exists(dest: &Path) -> bool {
+    dest.exists() || dest.symlink_metadata().is_ok()
+}
+
+/// Whether Mars may delete `dest_path` under `target_root`.
+pub fn may_delete(old_lock: &LockFile, target_root: &str, dest_path: &str) -> bool {
+    old_lock.contains_output(target_root, dest_path)
+}
+
+/// Decide whether Mars may copy/install to a linked target path.
+pub fn copy_decision(
+    old_lock: &LockFile,
+    target_root: &str,
+    dest_path: &str,
+    dest_exists: bool,
+    force: bool,
+) -> SurfaceCopyDecision {
+    if !dest_exists {
+        return SurfaceCopyDecision::Proceed;
+    }
+    if old_lock.contains_output(target_root, dest_path) {
+        return SurfaceCopyDecision::Proceed;
+    }
+    if force {
+        return SurfaceCopyDecision::Proceed;
+    }
+    SurfaceCopyDecision::SkipUnmanagedCollision
+}
+
+/// Emit `target-unmanaged-collision` when an untracked existing file is preserved.
+pub fn warn_unmanaged_collision(
+    target_name: &str,
+    dest_rel: &str,
+    hint: CollisionAdoptHint,
+    diag: &mut DiagnosticCollector,
+) {
+    let adopt_cmd: String = match hint {
+        CollisionAdoptHint::SyncForce => managed_cmd("mars sync --force").into_owned(),
+        CollisionAdoptHint::LinkForce => {
+            let inner = format!("mars link {target_name} --force");
+            managed_cmd(&inner).into_owned()
+        }
+    };
+    diag.warn(
+        "target-unmanaged-collision",
+        format!(
+            "target `{target_name}` item `{dest_rel}` exists locally but is not tracked by Mars \
+             (preserved local content; run `{adopt_cmd}` to adopt)"
+        ),
+    );
+}
+
+/// Emit `target-unmanaged-adopted` when `--force` takes over an untracked collision.
+pub fn warn_unmanaged_adopted(
+    target_name: &str,
+    dest_rel: &str,
+    hint: CollisionAdoptHint,
+    diag: &mut DiagnosticCollector,
+) {
+    let _ = hint;
+    diag.warn(
+        "target-unmanaged-adopted",
+        format!(
+            "target `{target_name}` item `{dest_rel}` existed but was not tracked by Mars; \
+             adopting with `--force`"
+        ),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lock::{ItemKind, LockFile, LockedItemV2, OutputRecord};
+    use indexmap::IndexMap;
+
+    fn lock_with_output(target_root: &str, dest_path: &str) -> LockFile {
+        LockFile {
+            version: 2,
+            dependencies: IndexMap::new(),
+            items: IndexMap::from([(
+                "agent/coder".to_string(),
+                LockedItemV2 {
+                    source: "test".into(),
+                    kind: ItemKind::Agent,
+                    version: None,
+                    source_checksum: "sha256:src".into(),
+                    outputs: vec![OutputRecord {
+                        target_root: target_root.to_string(),
+                        dest_path: dest_path.into(),
+                        installed_checksum: "sha256:inst".into(),
+                    }],
+                },
+            )]),
+            config_entries: Default::default(),
+        }
+    }
+
+    #[test]
+    fn copy_decision_proceeds_when_dest_missing() {
+        let lock = LockFile::empty();
+        assert_eq!(
+            copy_decision(&lock, ".cursor", "agents/coder.md", false, false),
+            SurfaceCopyDecision::Proceed
+        );
+    }
+
+    #[test]
+    fn copy_decision_skips_untracked_collision_without_force() {
+        let lock = lock_with_output(".mars", "agents/coder.md");
+        assert_eq!(
+            copy_decision(&lock, ".cursor", "agents/coder.md", true, false),
+            SurfaceCopyDecision::SkipUnmanagedCollision
+        );
+    }
+
+    #[test]
+    fn copy_decision_proceeds_when_target_tracked() {
+        let lock = lock_with_output(".cursor", "agents/coder.md");
+        assert_eq!(
+            copy_decision(&lock, ".cursor", "agents/coder.md", true, false),
+            SurfaceCopyDecision::Proceed
+        );
+    }
+
+    #[test]
+    fn may_delete_requires_per_target_output_record() {
+        let lock = lock_with_output(".mars", "agents/coder.md");
+        assert!(!may_delete(&lock, ".cursor", "agents/coder.md"));
+        assert!(may_delete(&lock, ".mars", "agents/coder.md"));
+    }
+}

--- a/src/sync/AGENTS.md
+++ b/src/sync/AGENTS.md
@@ -78,4 +78,4 @@ let request = SyncRequest {
 - `src/resolve/AGENTS.md` — dependency resolution (Phase 2)
 - `src/compiler/AGENTS.md` — compilation (Phases 3-5)
 - `src/target_sync/` — target directory copying (Phase 6)
-- `.context/` — none (pipeline is self-documenting via phase structs)
+- `src/target_sync/.context/CONTEXT.md` — per-target ownership, orphan cleanup, collision diagnostics

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -127,6 +127,7 @@ pub(crate) struct SyncedState {
     pub applied: AppliedState,
     pub target_outcomes: Vec<crate::target_sync::TargetSyncOutcome>,
     pub config_entries: BTreeMap<String, BTreeMap<String, crate::lock::ConfigEntryRecord>>,
+    pub compiled_native_outputs: Vec<(String, String, ContentHash)>,
 }
 
 /// Execute the unified sync pipeline.
@@ -502,6 +503,7 @@ pub(crate) fn sync_targets(
             applied,
             target_outcomes: Vec::new(),
             config_entries: BTreeMap::new(),
+            compiled_native_outputs: Vec::new(),
         };
     }
 
@@ -514,15 +516,7 @@ pub(crate) fn sync_targets(
         .effective
         .settings
         .managed_targets();
-    let previous_managed_paths = applied
-        .planned
-        .targeted
-        .resolved
-        .loaded
-        .old_lock
-        .all_output_dest_paths()
-        .map(|dest_path| dest_path.to_string())
-        .collect::<HashSet<String>>();
+    let old_lock = &applied.planned.targeted.resolved.loaded.old_lock;
 
     let outcomes;
     let target_outcomes_source = if matches!(
@@ -535,13 +529,17 @@ pub(crate) fn sync_targets(
         &applied.applied.outcomes
     };
 
+    let target_sync_ctx = crate::target_sync::TargetSyncContext {
+        old_lock,
+        force: request.options.force,
+        collision_hint: crate::surface_ownership::CollisionAdoptHint::SyncForce,
+    };
     let target_outcomes = crate::target_sync::sync_managed_targets(
         &ctx.project_root,
         &mars_dir,
         &targets,
         target_outcomes_source,
-        &previous_managed_paths,
-        request.options.force,
+        &target_sync_ctx,
         diag,
     );
 
@@ -549,6 +547,7 @@ pub(crate) fn sync_targets(
         applied,
         target_outcomes,
         config_entries: BTreeMap::new(),
+        compiled_native_outputs: Vec::new(),
     }
 }
 
@@ -567,12 +566,14 @@ pub(crate) fn finalize(
 
     // Write lock file (D21 — regardless of target sync outcome).
     if !request.options.dry_run {
-        let new_lock = crate::lock::build(
+        let mut new_lock = crate::lock::build(
             graph,
             &state.applied.applied,
             old_lock,
             state.config_entries,
         )?;
+        crate::lock::apply_target_sync_outputs(&mut new_lock, &state.target_outcomes);
+        crate::lock::apply_compiled_native_outputs(&mut new_lock, &state.compiled_native_outputs);
         crate::lock::write(project_root, &new_lock)?;
 
         // Persist dependency-only model aliases so `mars models list` can load

--- a/src/target/AGENTS.md
+++ b/src/target/AGENTS.md
@@ -23,7 +23,7 @@ The adapter boundary isolates all per-target branching here, keeping shared comp
 | `CodexAdapter` | `.codex` | `codex` | TOML-based config |
 | `OpencodeAdapter` | `.opencode` | `opencode` | OpenCode format |
 | `PiAdapter` | `.pi` | `pi` | Pi format |
-| `CursorAdapter` | `.cursor` | `cursor` | Experimental |
+| `CursorAdapter` | `.cursor` | `cursor` | Experimental; agents not materialized (`default_dest_path` is `None` for agents — skills/MCP only) |
 
 ## TargetAdapter Trait
 

--- a/src/target_sync/.context/CONTEXT.md
+++ b/src/target_sync/.context/CONTEXT.md
@@ -1,0 +1,77 @@
+# src/target_sync/
+
+Copies compiled content from `.mars/` to configured target directories and performs
+per-target orphan cleanup. Ownership rules live in `src/surface_ownership.rs` and
+are shared with native reconcile (`src/compiler/mod.rs`) and `mars link`.
+
+## Contracts
+
+### Per-target lock ownership
+
+Lock v2 `OutputRecord` entries carry `target_root` + `dest_path`. Mars may delete,
+remove-on-`Removed`, or overwrite a path in a linked target **only** when the
+previous lock contains a matching record for that exact pair.
+
+**Invariant:** A path tracked only under `.mars` does **not** authorize mutation
+under `.cursor`, `.claude`, or any other target root.
+
+Use `LockFile::contains_output(target_root, dest_path)` at mutation sites.
+Orphan cleanup scopes to `output_dest_paths_for_target(target_root)` — never
+`all_output_dest_paths()` joined against every target.
+
+### `surface_ownership` — shared gating
+
+| Function | Use |
+|---|---|
+| `may_delete(old_lock, target_root, dest_path)` | Orphan cleanup, Removed deletes, native reconcile deletes |
+| `copy_decision(...)` | Copy/install when dest already exists |
+| `warn_unmanaged_collision(...)` | Preserve untracked collision; hint correct `--force` command |
+| `warn_unmanaged_adopted(...)` | `--force` took ownership; lock will record the target output |
+
+`CollisionAdoptHint` selects the diagnostic hint:
+- `SyncForce` → suggests `mars sync --force`
+- `LinkForce` → suggests `mars link <target> --force`
+
+### Unmanaged collision semantics
+
+When dest exists on disk but the lock has no `(target_root, dest_path)` record:
+
+| Command | Default | `--force` |
+|---|---|---|
+| `mars sync` | Preserve local file; emit `target-unmanaged-collision` | Overwrite/adopt; emit `target-unmanaged-adopted`; record lock |
+| `mars link` | Fail (exit 2); emit `target-unmanaged-collision` | Adopt; persist linked-target outputs in lock |
+
+### Lock finalization after target sync
+
+`sync_managed_targets` returns `synced_outputs` and `removed_dest_paths` per target.
+`finalize()` merges these via `apply_target_sync_outputs` and
+`apply_compiled_native_outputs` so linked-target records persist in `mars.lock`.
+
+`lock.canonical_flat_items()` is for `.mars`-only views (e.g. `mars link` seed
+state). Do not use bare `dest_path` iterators for linked-target ownership checks.
+
+## Diagnostic codes
+
+| Code | Meaning |
+|---|---|
+| `target-unmanaged-collision` | Untracked existing file preserved; run suggested `--force` to adopt |
+| `target-unmanaged-adopted` | `--force` adopted an untracked collision; lock updated |
+
+## Consumers
+
+```
+surface_ownership.rs  ←── single rule set
+        ↑
+target_sync/mod.rs    ← orphan cleanup, Removed, copy/install
+compiler/mod.rs       ← reconcile_native_agent_surfaces, dual_surface_compile
+cli/link.rs           ← link collision fail/adopt + lock persist
+sync/mod.rs           ← passes old_lock + CollisionAdoptHint::SyncForce
+```
+
+## Regression tests
+
+- `sync_preserves_handwritten_cursor_agents_when_lock_only_tracks_mars` (integration)
+- `sync_preserves_handwritten_collision_when_lock_only_tracks_mars` (unit)
+- `link_fails_on_unmanaged_collision_without_force` / `link_force_adopts_unmanaged_collision_and_records_lock` (integration)
+
+Manual smoke: `tests/smoke/manual/target-scoped-linked-targets.md`

--- a/src/target_sync/mod.rs
+++ b/src/target_sync/mod.rs
@@ -10,7 +10,9 @@ use std::path::Path;
 
 use crate::diagnostic::DiagnosticCollector;
 use crate::error::MarsError;
+use crate::lock::LockFile;
 use crate::reconcile::fs_ops;
+use crate::surface_ownership::{self, CollisionAdoptHint, SurfaceCopyDecision};
 use crate::sync::apply::{ActionOutcome, ActionTaken};
 use crate::types::ContentHash;
 use crate::types::managed_cmd;
@@ -20,6 +22,13 @@ use crate::types::managed_cmd;
 pub struct ManagedTarget {
     /// Target directory path relative to project root (e.g. ".claude").
     pub path: String,
+}
+
+/// A linked-target output recorded during sync for lock persistence.
+#[derive(Debug, Clone)]
+pub struct TargetSyncedOutput {
+    pub dest_path: String,
+    pub installed_checksum: ContentHash,
 }
 
 /// Result of syncing content to a single target directory.
@@ -33,6 +42,17 @@ pub struct TargetSyncOutcome {
     pub items_removed: usize,
     /// Non-fatal errors encountered during sync.
     pub errors: Vec<String>,
+    /// Outputs successfully copied to this target (for lock persistence).
+    pub synced_outputs: Vec<TargetSyncedOutput>,
+    /// Dest paths removed from this target (for lock persistence).
+    pub removed_dest_paths: Vec<String>,
+}
+
+/// Per-run target sync options shared across all linked targets.
+pub struct TargetSyncContext<'a> {
+    pub old_lock: &'a LockFile,
+    pub force: bool,
+    pub collision_hint: CollisionAdoptHint,
 }
 
 /// Sync all managed targets from .mars/ canonical store.
@@ -48,23 +68,14 @@ pub fn sync_managed_targets(
     mars_dir: &Path,
     targets: &[String],
     outcomes: &[ActionOutcome],
-    previous_managed_paths: &HashSet<String>,
-    force: bool,
+    ctx: &TargetSyncContext<'_>,
     diag: &mut DiagnosticCollector,
 ) -> Vec<TargetSyncOutcome> {
     let mut results = Vec::new();
 
     for target_name in targets {
         let target_root = project_root.join(target_name);
-        match sync_one_target(
-            mars_dir,
-            &target_root,
-            target_name,
-            outcomes,
-            previous_managed_paths,
-            force,
-            diag,
-        ) {
+        match sync_one_target(mars_dir, &target_root, target_name, outcomes, ctx, diag) {
             Ok(outcome) => {
                 if !outcome.errors.is_empty() {
                     for err in &outcome.errors {
@@ -86,6 +97,8 @@ pub fn sync_managed_targets(
                     items_synced: 0,
                     items_removed: 0,
                     errors: vec![e.to_string()],
+                    synced_outputs: Vec::new(),
+                    removed_dest_paths: Vec::new(),
                 });
             }
         }
@@ -94,24 +107,26 @@ pub fn sync_managed_targets(
     results
 }
 
-/// Sync a single target directory from .mars/ canonical store.
 fn sync_one_target(
     mars_dir: &Path,
     target_root: &Path,
     target_name: &str,
     outcomes: &[ActionOutcome],
-    previous_managed_paths: &HashSet<String>,
-    force: bool,
+    ctx: &TargetSyncContext<'_>,
     diag: &mut DiagnosticCollector,
 ) -> Result<TargetSyncOutcome, MarsError> {
+    let old_lock = ctx.old_lock;
+    let force = ctx.force;
+    let collision_hint = ctx.collision_hint;
     let mut items_synced = 0;
     let mut items_removed = 0;
     let mut errors = Vec::new();
+    let mut synced_outputs = Vec::new();
+    let mut removed_dest_paths = Vec::new();
+    let previous_managed_paths = old_lock.output_dest_paths_for_target(target_name);
 
-    // Ensure target directory exists
     std::fs::create_dir_all(target_root)?;
 
-    // Track expected paths for orphan cleanup
     let mut expected_paths: HashSet<String> = HashSet::new();
     let target_registry = crate::target::TargetRegistry::new();
     let target_adapter = target_registry.get(target_name);
@@ -128,9 +143,6 @@ fn sync_one_target(
 
     for outcome in outcomes {
         if outcome.item_id.kind == crate::lock::ItemKind::BootstrapDoc {
-            // Package-level bootstrap docs are Meridian-only canonical content.
-            // Skill-level bootstrap docs still reach native targets as ordinary
-            // files inside skill directories.
             continue;
         }
         let dest_rel = outcome.dest_path.as_str();
@@ -138,30 +150,34 @@ fn sync_one_target(
         {
             if matches!(outcome.action, ActionTaken::Removed) {
                 let target_path = target_root.join(dest_rel);
-                if target_path.exists() || target_path.symlink_metadata().is_ok() {
-                    if let Err(e) = fs_ops::safe_remove(&target_path) {
-                        errors.push(format!("failed to remove {dest_rel}: {e}"));
-                    } else {
-                        items_removed += 1;
-                    }
+                if remove_target_path_if_managed(
+                    &target_path,
+                    target_name,
+                    dest_rel,
+                    old_lock,
+                    &mut errors,
+                ) {
+                    items_removed += 1;
+                    removed_dest_paths.push(dest_rel.to_string());
                 }
             }
             continue;
         }
         match &outcome.action {
             ActionTaken::Removed => {
-                // Remove from target too
                 let target_path = target_root.join(dest_rel);
-                if target_path.exists() || target_path.symlink_metadata().is_ok() {
-                    if let Err(e) = fs_ops::safe_remove(&target_path) {
-                        errors.push(format!("failed to remove {dest_rel}: {e}"));
-                    } else {
-                        items_removed += 1;
-                    }
+                if remove_target_path_if_managed(
+                    &target_path,
+                    target_name,
+                    dest_rel,
+                    old_lock,
+                    &mut errors,
+                ) {
+                    items_removed += 1;
+                    removed_dest_paths.push(dest_rel.to_string());
                 }
             }
             ActionTaken::Skipped => {
-                // Item is unchanged in .mars/ — still expected in target
                 expected_paths.insert(dest_rel.to_string());
                 let source = mars_dir.join(dest_rel);
                 let dest = target_root.join(dest_rel);
@@ -169,38 +185,58 @@ fn sync_one_target(
                     let should_refresh_native_skill = outcome.item_id.kind
                         == crate::lock::ItemKind::Skill
                         && native_skill_variant_key.is_some();
-                    if force || !dest.exists() || should_refresh_native_skill {
-                        let previous_target_hash = if should_refresh_native_skill && dest.exists() {
-                            crate::hash::compute_hash(&dest, outcome.item_id.kind).ok()
-                        } else {
-                            None
-                        };
-                        match copy_item_to_target(
-                            &source,
+                    let dest_exists = surface_ownership::target_dest_exists(&dest);
+                    let wants_copy = force || !dest_exists || should_refresh_native_skill;
+                    if wants_copy {
+                        if should_copy_to_target(
                             &dest,
-                            outcome.item_id.kind,
-                            outcome.item_id.name.as_str(),
-                            native_skill_variant_key.as_deref(),
+                            target_name,
+                            dest_rel,
+                            old_lock,
+                            force,
+                            collision_hint,
                             diag,
                         ) {
-                            Ok(()) => {
-                                items_synced += 1;
-                                if let Some(previous_target_hash) = previous_target_hash
-                                    && let Ok(current_target_hash) =
-                                        crate::hash::compute_hash(&dest, outcome.item_id.kind)
-                                    && previous_target_hash != current_target_hash
-                                {
-                                    diag.warn(
-                                        "target-native-projection-repaired",
-                                        format!(
-                                            "repaired diverged native projection: {target_name}/{dest_rel}/SKILL.md"
-                                        ),
+                            let previous_target_hash = if should_refresh_native_skill && dest_exists
+                            {
+                                crate::hash::compute_hash(&dest, outcome.item_id.kind).ok()
+                            } else {
+                                None
+                            };
+                            match copy_item_to_target(
+                                &source,
+                                &dest,
+                                outcome.item_id.kind,
+                                outcome.item_id.name.as_str(),
+                                native_skill_variant_key.as_deref(),
+                                diag,
+                            ) {
+                                Ok(()) => {
+                                    items_synced += 1;
+                                    record_synced_output(
+                                        &mut synced_outputs,
+                                        &dest,
+                                        dest_rel,
+                                        outcome.item_id.kind,
                                     );
+                                    if let Some(previous_target_hash) = previous_target_hash
+                                        && let Ok(current_target_hash) =
+                                            crate::hash::compute_hash(&dest, outcome.item_id.kind)
+                                        && previous_target_hash != current_target_hash
+                                    {
+                                        diag.warn(
+                                            "target-native-projection-repaired",
+                                            format!(
+                                                "repaired diverged native projection: {target_name}/{dest_rel}/SKILL.md"
+                                            ),
+                                        );
+                                    }
                                 }
+                                Err(e) => errors.push(format!("failed to copy {dest_rel}: {e}")),
                             }
-                            Err(e) => errors.push(format!("failed to copy {dest_rel}: {e}")),
                         }
                     } else if native_skill_variant_key.is_none()
+                        && old_lock.contains_output(target_name, dest_rel)
                         && let Some(expected_checksum) = &outcome.installed_checksum
                     {
                         match crate::hash::compute_hash(&dest, outcome.item_id.kind) {
@@ -222,16 +258,31 @@ fn sync_one_target(
                                 errors.push(format!("failed to verify {dest_rel} checksum: {e}"))
                             }
                         }
+                    } else if dest_exists && !old_lock.contains_output(target_name, dest_rel) {
+                        surface_ownership::warn_unmanaged_collision(
+                            target_name,
+                            dest_rel,
+                            collision_hint,
+                            diag,
+                        );
                     }
                 }
             }
             _ => {
-                // Installed, Updated, Merged, Conflicted, Kept
-                // All of these mean content exists in .mars/ and should be copied to target
                 expected_paths.insert(dest_rel.to_string());
                 let source = mars_dir.join(dest_rel);
                 let dest = target_root.join(dest_rel);
-                if source.exists() || source.symlink_metadata().is_ok() {
+                if (source.exists() || source.symlink_metadata().is_ok())
+                    && should_copy_to_target(
+                        &dest,
+                        target_name,
+                        dest_rel,
+                        old_lock,
+                        force,
+                        collision_hint,
+                        diag,
+                    )
+                {
                     match copy_item_to_target(
                         &source,
                         &dest,
@@ -240,7 +291,15 @@ fn sync_one_target(
                         native_skill_variant_key.as_deref(),
                         diag,
                     ) {
-                        Ok(()) => items_synced += 1,
+                        Ok(()) => {
+                            items_synced += 1;
+                            record_synced_output(
+                                &mut synced_outputs,
+                                &dest,
+                                dest_rel,
+                                outcome.item_id.kind,
+                            );
+                        }
                         Err(e) => errors.push(format!("failed to copy {dest_rel}: {e}")),
                     }
                 }
@@ -248,11 +307,11 @@ fn sync_one_target(
         }
     }
 
-    // Orphan cleanup: scan target for items not in expected set
     let orphan_removed = cleanup_orphans(
         target_root,
         &expected_paths,
-        previous_managed_paths,
+        &previous_managed_paths,
+        &mut removed_dest_paths,
         &mut errors,
     );
     items_removed += orphan_removed;
@@ -262,7 +321,79 @@ fn sync_one_target(
         items_synced,
         items_removed,
         errors,
+        synced_outputs,
+        removed_dest_paths,
     })
+}
+
+fn should_copy_to_target(
+    dest: &Path,
+    target_name: &str,
+    dest_rel: &str,
+    old_lock: &LockFile,
+    force: bool,
+    collision_hint: CollisionAdoptHint,
+    diag: &mut DiagnosticCollector,
+) -> bool {
+    let dest_exists = surface_ownership::target_dest_exists(dest);
+    match surface_ownership::copy_decision(old_lock, target_name, dest_rel, dest_exists, force) {
+        SurfaceCopyDecision::Proceed => {
+            if dest_exists && force && !old_lock.contains_output(target_name, dest_rel) {
+                surface_ownership::warn_unmanaged_adopted(
+                    target_name,
+                    dest_rel,
+                    collision_hint,
+                    diag,
+                );
+            }
+            true
+        }
+        SurfaceCopyDecision::SkipUnmanagedCollision => {
+            surface_ownership::warn_unmanaged_collision(
+                target_name,
+                dest_rel,
+                collision_hint,
+                diag,
+            );
+            false
+        }
+    }
+}
+
+fn remove_target_path_if_managed(
+    target_path: &Path,
+    target_name: &str,
+    dest_rel: &str,
+    old_lock: &LockFile,
+    errors: &mut Vec<String>,
+) -> bool {
+    if !surface_ownership::target_dest_exists(target_path) {
+        return false;
+    }
+    if !surface_ownership::may_delete(old_lock, target_name, dest_rel) {
+        return false;
+    }
+    match fs_ops::safe_remove(target_path) {
+        Ok(()) => true,
+        Err(e) => {
+            errors.push(format!("failed to remove {dest_rel}: {e}"));
+            false
+        }
+    }
+}
+
+fn record_synced_output(
+    synced_outputs: &mut Vec<TargetSyncedOutput>,
+    dest: &Path,
+    dest_rel: &str,
+    kind: crate::lock::ItemKind,
+) {
+    if let Ok(checksum) = crate::hash::compute_hash(dest, kind) {
+        synced_outputs.push(TargetSyncedOutput {
+            dest_path: dest_rel.to_string(),
+            installed_checksum: ContentHash::from(checksum),
+        });
+    }
 }
 
 /// Copy an item (file or directory) from .mars/ to a target directory.
@@ -317,6 +448,7 @@ fn cleanup_orphans(
     target_root: &Path,
     expected: &HashSet<String>,
     previous_managed_paths: &HashSet<String>,
+    removed_dest_paths: &mut Vec<String>,
     errors: &mut Vec<String>,
 ) -> usize {
     let mut removed = 0;
@@ -348,6 +480,7 @@ fn cleanup_orphans(
             errors.push(format!("failed to remove orphan {managed_path}: {e}"));
         } else {
             removed += 1;
+            removed_dest_paths.push(managed_path.clone());
         }
     }
 
@@ -359,6 +492,8 @@ mod tests {
     use super::*;
     use crate::diagnostic::DiagnosticCollector;
     use crate::hash;
+    use crate::lock::{ItemKind, LockFile, LockedItemV2, OutputRecord};
+    use crate::surface_ownership::CollisionAdoptHint;
     use crate::sync::apply::{ActionOutcome, ActionTaken};
     use crate::types::{DestPath, ItemName};
     use tempfile::TempDir;
@@ -377,11 +512,56 @@ mod tests {
         }
     }
 
-    fn managed_paths(paths: &[&str]) -> HashSet<String> {
-        paths
-            .iter()
-            .map(|p| (*p).to_string())
-            .collect::<HashSet<String>>()
+    fn lock_with_target_outputs(target: &str, outputs: &[(&str, &str)]) -> LockFile {
+        let mut lock = LockFile::empty();
+        for (dest, checksum) in outputs {
+            let name = dest.rsplit('/').next().unwrap_or("item");
+            lock.items.insert(
+                format!("agent/{name}"),
+                LockedItemV2 {
+                    source: "test".into(),
+                    kind: ItemKind::Agent,
+                    version: None,
+                    source_checksum: "sha256:src".into(),
+                    outputs: vec![OutputRecord {
+                        target_root: target.to_string(),
+                        dest_path: (*dest).into(),
+                        installed_checksum: (*checksum).into(),
+                    }],
+                },
+            );
+        }
+        lock
+    }
+
+    fn lock_with_skill_target_outputs(target: &str, outputs: &[(&str, &str)]) -> LockFile {
+        let mut lock = LockFile::empty();
+        for (dest, checksum) in outputs {
+            let name = dest.rsplit('/').next().unwrap_or("item");
+            lock.items.insert(
+                format!("skill/{name}"),
+                LockedItemV2 {
+                    source: "test".into(),
+                    kind: ItemKind::Skill,
+                    version: None,
+                    source_checksum: "sha256:src".into(),
+                    outputs: vec![OutputRecord {
+                        target_root: target.to_string(),
+                        dest_path: (*dest).into(),
+                        installed_checksum: (*checksum).into(),
+                    }],
+                },
+            );
+        }
+        lock
+    }
+
+    fn target_sync_ctx<'a>(old_lock: &'a LockFile, force: bool) -> TargetSyncContext<'a> {
+        TargetSyncContext {
+            old_lock,
+            force,
+            collision_hint: CollisionAdoptHint::SyncForce,
+        }
     }
 
     fn make_skipped_with_checksum(dest: &str, checksum: &str) -> ActionOutcome {
@@ -408,8 +588,7 @@ mod tests {
             &mars_dir,
             &[".agents".to_string()],
             &outcomes,
-            &managed_paths(&[]),
-            false,
+            &target_sync_ctx(&LockFile::empty(), false),
             &mut diag,
         );
 
@@ -441,8 +620,10 @@ mod tests {
             &mars_dir,
             &[".agents".to_string()],
             &outcomes,
-            &managed_paths(&["agents/old.md"]),
-            false,
+            &target_sync_ctx(
+                &lock_with_target_outputs(".agents", &[("agents/old.md", "sha256:old")]),
+                false,
+            ),
             &mut diag,
         );
 
@@ -472,8 +653,10 @@ mod tests {
             &mars_dir,
             &[".agents".to_string()],
             &outcomes,
-            &managed_paths(&["agents/orphan.md"]),
-            false,
+            &target_sync_ctx(
+                &lock_with_target_outputs(".agents", &[("agents/orphan.md", "sha256:orphan")]),
+                false,
+            ),
             &mut diag,
         );
 
@@ -502,8 +685,7 @@ mod tests {
             &mars_dir,
             &[".agents".to_string()],
             &outcomes,
-            &managed_paths(&[]),
-            false,
+            &target_sync_ctx(&LockFile::empty(), false),
             &mut diag,
         );
 
@@ -531,8 +713,10 @@ mod tests {
             &mars_dir,
             &[".agents".to_string()],
             &outcomes,
-            &managed_paths(&["agents/coder.md"]),
-            false,
+            &target_sync_ctx(
+                &lock_with_target_outputs(".agents", &[("agents/coder.md", "sha256:coder")]),
+                false,
+            ),
             &mut diag,
         );
 
@@ -558,8 +742,7 @@ mod tests {
             &mars_dir,
             &[".agents".to_string(), ".custom-target".to_string()],
             &outcomes,
-            &managed_paths(&[]),
-            false,
+            &target_sync_ctx(&LockFile::empty(), false),
             &mut diag,
         );
 
@@ -589,8 +772,7 @@ mod tests {
                 ".pi".to_string(),
             ],
             &outcomes,
-            &managed_paths(&[]),
-            false,
+            &target_sync_ctx(&LockFile::empty(), false),
             &mut diag,
         );
 
@@ -618,8 +800,7 @@ mod tests {
             &mars_dir,
             &[".custom-target".to_string()],
             &outcomes,
-            &managed_paths(&[]),
-            false,
+            &target_sync_ctx(&LockFile::empty(), false),
             &mut diag,
         );
 
@@ -646,8 +827,7 @@ mod tests {
             &mars_dir,
             &[".agents".to_string()],
             &outcomes,
-            &managed_paths(&[]),
-            false,
+            &target_sync_ctx(&LockFile::empty(), false),
             &mut diag,
         );
 
@@ -687,8 +867,16 @@ mod tests {
             &mars_dir,
             &[".claude".to_string()],
             &outcomes,
-            &managed_paths(&["skills/planning", "skills/orphan"]),
-            false,
+            &target_sync_ctx(
+                &lock_with_skill_target_outputs(
+                    ".claude",
+                    &[
+                        ("skills/planning", "sha256:planning"),
+                        ("skills/orphan", "sha256:orphan"),
+                    ],
+                ),
+                false,
+            ),
             &mut diag,
         );
 
@@ -721,10 +909,20 @@ mod tests {
                 .to_string(),
         );
 
+        let previous = lock_with_target_outputs(
+            ".agents",
+            &[
+                ("agents/coder.md", "sha256:coder"),
+                ("agents/orphan.md", "sha256:orphan"),
+            ],
+        );
+        let previous_paths = previous.output_dest_paths_for_target(".agents");
+        let mut removed_dest_paths = Vec::new();
         let removed = cleanup_orphans(
             &target_root,
             &expected,
-            &managed_paths(&["agents/coder.md", "agents/orphan.md"]),
+            &previous_paths,
+            &mut removed_dest_paths,
             &mut Vec::new(),
         );
 
@@ -751,8 +949,7 @@ mod tests {
             &mars_dir,
             &[".agents".to_string()],
             &outcomes,
-            &managed_paths(&[]),
-            false,
+            &target_sync_ctx(&LockFile::empty(), false),
             &mut diag,
         );
 
@@ -763,8 +960,10 @@ mod tests {
             &mars_dir,
             &[".agents".to_string()],
             &outcomes2,
-            &managed_paths(&["agents/coder.md"]),
-            false,
+            &target_sync_ctx(
+                &lock_with_target_outputs(".agents", &[("agents/coder.md", "sha256:coder")]),
+                false,
+            ),
             &mut diag,
         );
 
@@ -792,8 +991,10 @@ mod tests {
             &mars_dir,
             &[".agents".to_string()],
             &outcomes,
-            &managed_paths(&["agents/coder.md"]),
-            true,
+            &target_sync_ctx(
+                &lock_with_target_outputs(".agents", &[("agents/coder.md", "sha256:coder")]),
+                true,
+            ),
             &mut diag,
         );
 
@@ -821,8 +1022,10 @@ mod tests {
             &mars_dir,
             &[".agents".to_string()],
             &outcomes,
-            &managed_paths(&["agents/coder.md"]),
-            false,
+            &target_sync_ctx(
+                &lock_with_target_outputs(".agents", &[("agents/coder.md", "sha256:coder")]),
+                false,
+            ),
             &mut diag,
         );
 
@@ -850,8 +1053,10 @@ mod tests {
             &mars_dir,
             &[".agents".to_string()],
             &outcomes,
-            &managed_paths(&["agents/coder.md"]),
-            false,
+            &target_sync_ctx(
+                &lock_with_target_outputs(".agents", &[("agents/coder.md", "sha256:coder")]),
+                false,
+            ),
             &mut diag,
         );
 
@@ -866,6 +1071,160 @@ mod tests {
             diagnostics
                 .iter()
                 .any(|d| d.code == "target-divergent" && d.message.contains("agents/coder.md"))
+        );
+    }
+
+    #[test]
+    fn sync_preserves_handwritten_collision_when_lock_only_tracks_mars() {
+        let dir = TempDir::new().unwrap();
+        let mars_dir = dir.path().join(".mars");
+        let target = dir.path().join(".cursor");
+
+        std::fs::create_dir_all(mars_dir.join("agents")).unwrap();
+        std::fs::write(mars_dir.join("agents/design-lead.md"), "# Canonical").unwrap();
+        std::fs::create_dir_all(target.join("agents")).unwrap();
+        std::fs::write(target.join("agents/cursor-only-test.md"), "# custom").unwrap();
+        std::fs::write(target.join("agents/design-lead.md"), "# hand-written").unwrap();
+
+        let mut lock = LockFile::empty();
+        lock.items.insert(
+            "agent/design-lead".to_string(),
+            LockedItemV2 {
+                source: "test".into(),
+                kind: ItemKind::Agent,
+                version: None,
+                source_checksum: "sha256:src".into(),
+                outputs: vec![OutputRecord {
+                    target_root: ".mars".to_string(),
+                    dest_path: "agents/design-lead.md".into(),
+                    installed_checksum: "sha256:mars".into(),
+                }],
+            },
+        );
+
+        let outcomes = vec![make_outcome("agents/design-lead.md", ActionTaken::Removed)];
+        let mut diag = DiagnosticCollector::new();
+
+        let results = sync_managed_targets(
+            dir.path(),
+            &mars_dir,
+            &[".cursor".to_string()],
+            &outcomes,
+            &target_sync_ctx(&lock, false),
+            &mut diag,
+        );
+
+        assert_eq!(results[0].items_removed, 0);
+        assert!(target.join("agents/cursor-only-test.md").exists());
+        assert!(target.join("agents/design-lead.md").exists());
+        assert_eq!(
+            std::fs::read_to_string(target.join("agents/design-lead.md")).unwrap(),
+            "# hand-written"
+        );
+    }
+
+    #[test]
+    fn sync_installed_does_not_overwrite_untracked_collision_in_linked_target() {
+        let dir = TempDir::new().unwrap();
+        let mars_dir = dir.path().join(".mars");
+        let target = dir.path().join(".agents");
+
+        std::fs::create_dir_all(mars_dir.join("agents")).unwrap();
+        std::fs::write(mars_dir.join("agents/coder.md"), "# Canonical").unwrap();
+        std::fs::create_dir_all(target.join("agents")).unwrap();
+        std::fs::write(target.join("agents/coder.md"), "# hand-written").unwrap();
+
+        let mut lock = LockFile::empty();
+        lock.items.insert(
+            "agent/coder".to_string(),
+            LockedItemV2 {
+                source: "test".into(),
+                kind: ItemKind::Agent,
+                version: None,
+                source_checksum: "sha256:src".into(),
+                outputs: vec![OutputRecord {
+                    target_root: ".mars".to_string(),
+                    dest_path: "agents/coder.md".into(),
+                    installed_checksum: "sha256:mars".into(),
+                }],
+            },
+        );
+
+        let outcomes = vec![make_outcome("agents/coder.md", ActionTaken::Installed)];
+        let mut diag = DiagnosticCollector::new();
+
+        let results = sync_managed_targets(
+            dir.path(),
+            &mars_dir,
+            &[".agents".to_string()],
+            &outcomes,
+            &target_sync_ctx(&lock, false),
+            &mut diag,
+        );
+
+        assert_eq!(results[0].items_synced, 0);
+        assert_eq!(
+            std::fs::read_to_string(target.join("agents/coder.md")).unwrap(),
+            "# hand-written"
+        );
+        let diagnostics = diag.drain();
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.code == "target-unmanaged-collision")
+        );
+    }
+
+    #[test]
+    fn sync_force_adopts_untracked_collision_in_linked_target() {
+        let dir = TempDir::new().unwrap();
+        let mars_dir = dir.path().join(".mars");
+        let target = dir.path().join(".agents");
+
+        std::fs::create_dir_all(mars_dir.join("agents")).unwrap();
+        std::fs::write(mars_dir.join("agents/coder.md"), "# Canonical").unwrap();
+        std::fs::create_dir_all(target.join("agents")).unwrap();
+        std::fs::write(target.join("agents/coder.md"), "# hand-written").unwrap();
+
+        let mut lock = LockFile::empty();
+        lock.items.insert(
+            "agent/coder".to_string(),
+            LockedItemV2 {
+                source: "test".into(),
+                kind: ItemKind::Agent,
+                version: None,
+                source_checksum: "sha256:src".into(),
+                outputs: vec![OutputRecord {
+                    target_root: ".mars".to_string(),
+                    dest_path: "agents/coder.md".into(),
+                    installed_checksum: "sha256:mars".into(),
+                }],
+            },
+        );
+
+        let outcomes = vec![make_outcome("agents/coder.md", ActionTaken::Installed)];
+        let mut diag = DiagnosticCollector::new();
+
+        let results = sync_managed_targets(
+            dir.path(),
+            &mars_dir,
+            &[".agents".to_string()],
+            &outcomes,
+            &target_sync_ctx(&lock, true),
+            &mut diag,
+        );
+
+        assert_eq!(results[0].items_synced, 1);
+        assert_eq!(
+            std::fs::read_to_string(target.join("agents/coder.md")).unwrap(),
+            "# Canonical"
+        );
+        assert!(!results[0].synced_outputs.is_empty());
+        let diagnostics = diag.drain();
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.code == "target-unmanaged-adopted")
         );
     }
 }

--- a/tests/smoke/manual/target-scoped-linked-targets.md
+++ b/tests/smoke/manual/target-scoped-linked-targets.md
@@ -1,0 +1,40 @@
+# Smoke: target-scoped linked-target ownership (#60)
+
+Run from a scratch project using the worktree binary (no install):
+
+```bash
+cd /path/to/mars-agents.worktrees/target-orphan-cleanup
+MARS=$(pwd)/target/debug/mars
+cargo build -q
+```
+
+## Sync preserves hand-written `.cursor` agents
+
+```bash
+tmpdir=$(mktemp -d)
+cd "$tmpdir"
+echo '[settings]
+targets = [".cursor"]
+agent_emission = "never"
+
+[dependencies.base]
+path = "/path/to/local/source"
+' > mars.toml
+
+$MARS sync
+mkdir -p .cursor/agents
+echo '# custom' > .cursor/agents/cursor-only-test.md
+echo '# hand-written' > .cursor/agents/design-lead.md
+$MARS sync
+cat .cursor/agents/design-lead.md   # expect: # hand-written
+```
+
+## Link fails without `--force` on collision
+
+```bash
+$MARS sync
+mkdir -p .agents/agents
+echo '# hand-written' > .agents/agents/coder.md
+$MARS link .agents            # expect: non-zero exit
+$MARS link .agents --force    # expect: success + lock records .agents/agents/coder.md
+```

--- a/tests/smoke/manual/target-scoped-linked-targets.md
+++ b/tests/smoke/manual/target-scoped-linked-targets.md
@@ -31,10 +31,25 @@ cat .cursor/agents/design-lead.md   # expect: # hand-written
 
 ## Link fails without `--force` on collision
 
+Uses default agent emission (not `never`) so link materializes agents into the target.
+
 ```bash
+# mars.toml: [dependencies.base] path = ... only (no agent_emission = "never")
 $MARS sync
 mkdir -p .agents/agents
 echo '# hand-written' > .agents/agents/coder.md
 $MARS link .agents            # expect: non-zero exit
-$MARS link .agents --force    # expect: success + lock records .agents/agents/coder.md
+$MARS link .agents --force    # expect: success; mars.lock has target_root = ".agents" for agents/coder.md
 ```
+
+## Sync `--force` overwrites divergent managed file
+
+```bash
+# mars.toml: targets = [".agents"], [dependencies.base] path = ...
+$MARS sync
+echo '# Hand-edited' > .agents/agents/coder.md
+$MARS sync                    # expect: preserves Hand-edited
+$MARS sync --force            # expect: restores Mars canonical content
+```
+
+Or run all checks: `scripts/smoke-target-scoped.sh` from the worktree root.

--- a/tests/sync_behavior.rs
+++ b/tests/sync_behavior.rs
@@ -1098,3 +1098,198 @@ fn lock_dependency_version(project_root: &Path, source_name: &str) -> Option<Str
         .and_then(toml::Value::as_str)
         .map(ToOwned::to_owned)
 }
+
+#[test]
+fn sync_preserves_handwritten_cursor_agents_when_lock_only_tracks_mars() {
+    let dir = TempDir::new().unwrap();
+    let source = create_source(
+        &dir,
+        "base",
+        &[("design-lead", "# Design lead from Mars")],
+        &[],
+    );
+
+    let project = dir.child("project");
+    project.create_dir_all().unwrap();
+    project
+        .child("mars.toml")
+        .write_str(&format!(
+            r#"[settings]
+targets = [".cursor"]
+agent_emission = "never"
+
+[dependencies.base]
+path = "{}"
+"#,
+            source.display().to_string().replace('\\', "/")
+        ))
+        .unwrap();
+
+    mars()
+        .args(["sync", "--root", project.path().to_str().unwrap()])
+        .assert()
+        .success();
+
+    fs::create_dir_all(project.child(".cursor/agents").path()).unwrap();
+    fs::write(
+        project.child(".cursor/agents/cursor-only-test.md").path(),
+        "# custom\n",
+    )
+    .unwrap();
+    fs::write(
+        project.child(".cursor/agents/design-lead.md").path(),
+        "# hand-written\n",
+    )
+    .unwrap();
+
+    mars()
+        .args(["sync", "--root", project.path().to_str().unwrap()])
+        .assert()
+        .success();
+
+    assert!(project.child(".cursor/agents/cursor-only-test.md").exists());
+    assert!(project.child(".cursor/agents/design-lead.md").exists());
+    assert_eq!(
+        fs::read_to_string(project.child(".cursor/agents/design-lead.md").path()).unwrap(),
+        "# hand-written\n"
+    );
+}
+
+#[test]
+fn sync_preserves_handwritten_cursor_agent_with_agent_emission_always() {
+    let dir = TempDir::new().unwrap();
+    let source = create_source(
+        &dir,
+        "base",
+        &[("design-lead", "# Design lead from Mars")],
+        &[],
+    );
+
+    let project = dir.child("project");
+    project.create_dir_all().unwrap();
+    project
+        .child("mars.toml")
+        .write_str(&format!(
+            r#"[settings]
+targets = [".cursor"]
+agent_emission = "always"
+
+[dependencies.base]
+path = "{}"
+"#,
+            source.display().to_string().replace('\\', "/")
+        ))
+        .unwrap();
+
+    mars()
+        .args(["sync", "--root", project.path().to_str().unwrap()])
+        .assert()
+        .success();
+
+    fs::create_dir_all(project.child(".cursor/agents").path()).unwrap();
+    fs::write(
+        project.child(".cursor/agents/design-lead.md").path(),
+        "# hand-written\n",
+    )
+    .unwrap();
+
+    mars()
+        .args(["sync", "--root", project.path().to_str().unwrap()])
+        .assert()
+        .success();
+
+    assert_eq!(
+        fs::read_to_string(project.child(".cursor/agents/design-lead.md").path()).unwrap(),
+        "# hand-written\n"
+    );
+}
+
+#[test]
+fn link_fails_on_unmanaged_collision_without_force() {
+    let dir = TempDir::new().unwrap();
+    let source = create_source(&dir, "base", &[("coder", "# Coder from Mars")], &[]);
+
+    let project = dir.child("project");
+    project.create_dir_all().unwrap();
+    project
+        .child("mars.toml")
+        .write_str(&format!(
+            "[dependencies.base]\npath = \"{}\"\n",
+            source.display().to_string().replace('\\', "/")
+        ))
+        .unwrap();
+
+    mars()
+        .args(["sync", "--root", project.path().to_str().unwrap()])
+        .assert()
+        .success();
+
+    fs::create_dir_all(project.child(".agents/agents").path()).unwrap();
+    fs::write(
+        project.child(".agents/agents/coder.md").path(),
+        "# hand-written\n",
+    )
+    .unwrap();
+
+    mars()
+        .args([
+            "link",
+            ".agents",
+            "--root",
+            project.path().to_str().unwrap(),
+        ])
+        .assert()
+        .failure();
+
+    assert_eq!(
+        fs::read_to_string(project.child(".agents/agents/coder.md").path()).unwrap(),
+        "# hand-written\n"
+    );
+}
+
+#[test]
+fn link_force_adopts_unmanaged_collision_and_records_lock() {
+    let dir = TempDir::new().unwrap();
+    let source = create_source(&dir, "base", &[("coder", "# Coder from Mars")], &[]);
+
+    let project = dir.child("project");
+    project.create_dir_all().unwrap();
+    project
+        .child("mars.toml")
+        .write_str(&format!(
+            "[dependencies.base]\npath = \"{}\"\n",
+            source.display().to_string().replace('\\', "/")
+        ))
+        .unwrap();
+
+    mars()
+        .args(["sync", "--root", project.path().to_str().unwrap()])
+        .assert()
+        .success();
+
+    fs::create_dir_all(project.child(".agents/agents").path()).unwrap();
+    fs::write(
+        project.child(".agents/agents/coder.md").path(),
+        "# hand-written\n",
+    )
+    .unwrap();
+
+    mars()
+        .args([
+            "link",
+            ".agents",
+            "--force",
+            "--root",
+            project.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    assert_eq!(
+        fs::read_to_string(project.child(".agents/agents/coder.md").path()).unwrap(),
+        "# Coder from Mars"
+    );
+
+    let lock = mars_agents::lock::load(project.path()).unwrap();
+    assert!(lock.contains_output(".agents", "agents/coder.md"));
+}


### PR DESCRIPTION
## Why

`mars sync` deletes hand-written files in linked targets (e.g. `.cursor/agents/design-lead.md`) when the lock only tracks the same path under `.mars`. That violates the Mars guarantee that it must never delete files it didn't create. Closes #60.

## Goal

Linked targets (`.cursor`, `.claude`, etc.) are only mutable when the lock has a matching per-target `(target_root, dest_path)` record. Pre-existing untracked collisions are preserved by default; `mars sync --force` and `mars link --force` adopt them and record ownership.

## Summary

- Gate linked-target orphan cleanup, removals, and copies on per-target lock records so `.mars`-only ownership does not authorize deletes/overwrites in linked targets.
- Add shared `surface_ownership` rules used by target sync, native reconcile, and dual-surface compile; collision hints suggest `mars sync --force` vs `mars link --force` in the right context.
- `mars link --force` adopts unmanaged collisions, persists linked-target `OutputRecord`s, and fails by default when adoption would be required.
- Extend lock API for per-target output tracking and lock finalization with multi-target outputs.

## Work Item

mars-target-orphan-cleanup

## Changes

- New `src/surface_ownership.rs` centralizes delete/copy gating and collision warnings.
- `src/lock/mod.rs`: `output_dest_paths_for_target`, `contains_output`, `apply_target_sync_outputs`, `apply_compiled_native_outputs`, `canonical_flat_items`.
- `src/target_sync/mod.rs`: per-target orphan scope; `TargetSyncContext`; gate Removed + copy paths; `--force` adopt semantics.
- `src/sync/mod.rs`, `src/compiler/mod.rs`: pass `old_lock`; gate native reconcile and dual-surface compile writes.
- `src/cli/link.rs`: add `--force`; fail link on unmanaged collision without force; persist lock after successful link.
- 12 new unit tests + 4 integration tests; manual smoke guide at `tests/smoke/manual/target-scoped-linked-targets.md`.
- `CHANGELOG.md` updated under `[Unreleased]`.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test --lib` (1171 passed)
- [x] Integration: `sync_preserves_handwritten_cursor_agents_when_lock_only_tracks_mars`
- [x] Integration: `sync_preserves_handwritten_cursor_agent_with_agent_emission_always`
- [x] Integration: `link_fails_on_unmanaged_collision_without_force`
- [x] Integration: `link_force_adopts_unmanaged_collision_and_records_lock`
- [x] Manual smoke via `cargo run` (sync preserves hand-written agents; link fail/force adopt)
- [ ] CI pending on rebased branch

## Knowledge Updates

- `AGENTS.md`, `src/AGENTS.md` — per-target invariant; qi-layer pointers to `.context/`
- `src/target_sync/.context/CONTEXT.md` — ownership contracts, diagnostics, consumers
- `src/sync/AGENTS.md`, `src/cli/AGENTS.md`, `src/compiler/AGENTS.md`, `src/target/AGENTS.md` — cross-refs
- `docs/cli/commands.md`, `docs/internals/sync-pipeline.md`, `docs/internals/lock-file.md`, `docs/README.md`, `docs/dev/troubleshooting.md` — user-facing behavior for #60
- `tests/smoke/manual/target-scoped-linked-targets.md`, `scripts/smoke-target-scoped.sh` — manual smoke (9/9 passed on HEAD)

KB / Meridian work item `mars-target-orphan-cleanup`: update from `meridian-cli` after merge (this repo has no `[context.kb]`).

## Spawn Trace

- Cursor agent — implemented target-scoped linked-target ownership fix (#60)

## Release Label Guide

Set one `release:*` label on this PR:

- `release:patch` or `release:stable` — create the next stable patch release after merge
- `release:rc` — create the next RC release after merge
- `release:skip` — no release for this merge

No `release:*` label means no auto-release.
Unknown `release:*` labels default to RC.

## Post-Merge Automation

After merge to `main`, CI (`.github/workflows/release-on-main.yml`) will:

1. Read the PR release label
2. Skip when no `release:*` label is present or when `release:skip` is present
3. Compute the next stable or RC version from existing `v*` tags
4. Update Cargo/PyPI/npm package versions + promote `CHANGELOG.md` `[Unreleased]`
5. Commit `release: vX.Y.Z` or `release: vX.Y.Z-rc.N`, create/push the matching tag
6. Run `.github/workflows/release.yml` from the tag

## Cleanup

After merge, clean merged worktrees with:

```bash
scripts/prune-worktrees.sh
```
