### PR TITLE
fix(pi-probe): stderr output and wide list-models table (Pi 0.75+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Pi probe reads CLI output from stderr when stdout is empty (Pi 0.75+), fixing false `pi_incompatible` and empty `model_slugs` in routing and `mars models list`.
+- Pi `--list-models` space-separated tables with extra columns (context, max-out, …) now parse provider/model from the first two columns.
+
 ## [0.6.2] - 2026-05-22
 
 ## [0.6.1] - 2026-05-22

--- a/src/models/probes/.context/CONTEXT.md
+++ b/src/models/probes/.context/CONTEXT.md
@@ -9,17 +9,23 @@ Capability probing for OpenCode and Pi harnesses, with disk-backed caching.
 | `mod.rs` | Re-exports; `should_probe_opencode()` guard |
 | `opencode.rs` | OpenCode probe: provider/model availability via `opencode models ls` |
 | `opencode_cache.rs` | OpenCode probe cache at `~/.mars/cache/availability/opencode.json` |
-| `pi.rs` | Pi probe: binary present + `--version` exits 0 + `--help` has required tokens |
+| `pi.rs` | Pi probe: binary present + `--version` / `--help` / `--list-models` (stdout, stderr fallback) |
 | `pi_cache.rs` | Pi probe cache at `~/.mars/cache/availability/pi.json` |
 
 ## Contracts
 
 ### Pi probe semantics
 
-`PiProbeResult.compatible == true` means **all three** conditions passed:
-1. `pi` binary found on PATH
-2. `pi --version` exits 0
-3. All token groups in `PI_REQUIRED_HELP_TOKEN_GROUPS` are present in `pi --help` output
+`PiProbeResult.compatible == true` means probe subprocesses succeeded and **all** token groups in
+`PI_REQUIRED_HELP_TOKEN_GROUPS` appear in `pi --help` output (after stream merge below).
+
+Prerequisites: `pi` on PATH; `pi --version` and `pi --help` exit 0. `pi --list-models` must exit 0
+for a full probe; its output fills `model_slugs` (routing / `mars models list` Pi paths) but does
+**not** set `compatible` — empty slugs with `compatible: true` still yield no Pi runnable paths.
+
+**Stream merging:** probe subprocesses use stdout when non-empty after trim; otherwise stderr.
+Pi 0.75.x experimental builds emit `--help`, `--version`, and `--list-models` on stderr only.
+Older Pi builds that print to stdout are unchanged.
 
 A single missing token group → `compatible: false` → routing engine skips Pi
 (records `skip_reason: "pi_incompatible"`).

--- a/src/models/probes/pi.rs
+++ b/src/models/probes/pi.rs
@@ -131,14 +131,12 @@ fn run_command(
         .stdout
         .take()
         .ok_or_else(|| "stdout capture unavailable".to_string())?;
-    let stdout_reader = thread::spawn(move || {
-        let mut stdout = stdout;
-        let mut output = Vec::new();
-        stdout
-            .read_to_end(&mut output)
-            .map(|_| output)
-            .map_err(|error| format!("stdout read failed: {error}"))
-    });
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "stderr capture unavailable".to_string())?;
+    let stdout_reader = thread::spawn(move || read_stream_to_end(stdout, "stdout"));
+    let stderr_reader = thread::spawn(move || read_stream_to_end(stderr, "stderr"));
 
     match child
         .wait_timeout(timeout)
@@ -148,19 +146,45 @@ fn run_command(
             let stdout = stdout_reader
                 .join()
                 .map_err(|_| "stdout reader panicked".to_string())??;
-            String::from_utf8(stdout).map_err(|error| format!("invalid utf8: {error}"))
+            let stderr = stderr_reader
+                .join()
+                .map_err(|_| "stderr reader panicked".to_string())??;
+            effective_probe_output(stdout, stderr)
         }
         Some(status) => {
             let _ = stdout_reader.join();
+            let _ = stderr_reader.join();
             Err(format!("exit code {}", status.code().unwrap_or(-1)))
         }
         None => {
             let _ = child.kill();
             let _ = child.wait();
             let _ = stdout_reader.join();
+            let _ = stderr_reader.join();
             Err("timeout".to_string())
         }
     }
+}
+
+fn read_stream_to_end(mut stream: impl Read, label: &'static str) -> Result<Vec<u8>, String> {
+    let mut output = Vec::new();
+    stream
+        .read_to_end(&mut output)
+        .map(|_| output)
+        .map_err(|error| format!("{label} read failed: {error}"))
+}
+
+/// Pi 0.75+ may print CLI text to stderr only; prefer stdout when non-empty.
+fn effective_probe_output(stdout: Vec<u8>, stderr: Vec<u8>) -> Result<String, String> {
+    let stdout =
+        String::from_utf8(stdout).map_err(|error| format!("invalid utf8 stdout: {error}"))?;
+    let stderr =
+        String::from_utf8(stderr).map_err(|error| format!("invalid utf8 stderr: {error}"))?;
+    Ok(if stdout.trim().is_empty() {
+        stderr
+    } else {
+        stdout
+    })
 }
 
 fn first_non_empty_line(output: &str) -> Option<String> {
@@ -230,9 +254,6 @@ fn parse_table_row(line: &str) -> Option<(String, String)> {
     };
 
     if columns.len() < 2 {
-        return None;
-    }
-    if !has_table_separators && columns.len() != 2 {
         return None;
     }
 
@@ -391,6 +412,51 @@ mod tests {
         let model_slugs = parse_models_output(output);
         assert!(model_slugs.contains("openai/gpt-5.4"));
         assert!(model_slugs.contains("anthropic/claude-sonnet-4.7"));
+    }
+
+    #[test]
+    fn effective_probe_output_uses_stderr_when_stdout_empty() {
+        let merged = effective_probe_output(Vec::new(), b"0.75.4\n".to_vec()).unwrap();
+        assert_eq!(merged.trim(), "0.75.4");
+    }
+
+    #[test]
+    fn effective_probe_output_prefers_stdout_when_nonempty() {
+        let merged = effective_probe_output(b"0.4.2\n".to_vec(), b"0.75.4\n".to_vec()).unwrap();
+        assert_eq!(merged.trim(), "0.4.2");
+    }
+
+    #[test]
+    fn classify_help_tokens_accepts_stderr_only_help_surface() {
+        let help = "--mode rpc --model --append-system-prompt --session --fork --session-dir --no-extensions --no-skills --no-context-files --no-prompt-templates -e --extension";
+        let stderr_only = effective_probe_output(Vec::new(), help.as_bytes().to_vec()).unwrap();
+        let (present, missing) = classify_help_tokens(&stderr_only);
+        assert_eq!(missing, Vec::<String>::new());
+        assert!(present.contains(&"--mode".to_string()));
+    }
+
+    #[test]
+    fn parse_models_output_parses_space_separated_multi_column_table() {
+        let output = "\
+provider      model                context  max-out\n\
+openai-codex  gpt-5.4-mini         272K     128K\n\
+openai-codex  gpt-5.4              272K     128K\n";
+
+        let model_slugs = parse_models_output(output);
+        assert!(model_slugs.contains("openai-codex/gpt-5.4-mini"));
+        assert!(model_slugs.contains("openai-codex/gpt-5.4"));
+    }
+
+    #[test]
+    fn parse_models_output_accepts_stderr_only_list_models_table() {
+        let table = r#"
+| Provider | Model |
+| --- | --- |
+| openai-codex | gpt-5.4-mini |
+"#;
+        let stderr_only = effective_probe_output(Vec::new(), table.as_bytes().to_vec()).unwrap();
+        let model_slugs = parse_models_output(&stderr_only);
+        assert!(model_slugs.contains("openai-codex/gpt-5.4-mini"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Pi probe uses stderr when stdout is empty (`pi --version`, `--help`, `--list-models` on Pi 0.75+).
- Parse space-separated `--list-models` tables with extra columns (provider + model from first two columns).

Fixes false `pi_incompatible`, empty `model_slugs`, and missing Pi paths in `mars models list` / `meridian mars models list --all`.

## Test plan
- [x] `cargo test --lib models::probes::pi::tests`
- [x] `mars build launch-bundle --harness pi --model openai-codex/gpt-5.4-mini` (debug binary)
- [ ] After merge + release **0.6.3**: `rm ~/.mars/cache/availability/pi.json`; verify meridian venv `mars` and `meridian spawn --harness pi`