### PR TITLE
Implement probe-backed cursor model routing and availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Cursor probe: `cursor agent --list-models` probe backed routing. Cursor changes from `UniversalPassthrough` to `ProbeBacked`; cursor models show `availability: runnable` when probe succeeds.
+- Cursor probe cache: TTL cache (`cursor-probe.json`) with stale/miss/hit/unavailable outcomes and background refresh via `mars models __refresh-probe --target cursor`.
+- Cursor prefix routing: `candidate_slugs` in launch bundle routing section carries all catalog slugs matching the requested model prefix; supports Python-side effort resolution.
+- `classify_cursor` in availability layer: `CursorProbe`, `CursorProbeNegative`, `CursorProbeUnknown` sources in `AvailabilitySource`.
+- Graceful degradation: no probe result, probe failure, or empty catalog all fall through to passthrough behavior (same as previous `UniversalPassthrough`).
+
+### Changed
+- Cursor harness changes from `HarnessClass::UniversalPassthrough` to `HarnessClass::ProbeBacked` in registry.
+
 ## [0.6.2] - 2026-05-22
 
 ## [0.6.1] - 2026-05-22

--- a/src/build/bundle.rs
+++ b/src/build/bundle.rs
@@ -30,6 +30,7 @@ pub struct Routing {
     pub harness_model: String,
     pub harness_model_source: String,
     pub harness_model_confidence: String,
+    pub candidate_slugs: Vec<String>,
     pub route_trace: crate::routing::report::RouteDecisionReport,
 }
 

--- a/src/build/policy/harness.rs
+++ b/src/build/policy/harness.rs
@@ -9,8 +9,7 @@ use crate::compiler::agents::HarnessKind;
 use crate::config::AgentOverlay;
 use crate::error::{ConfigError, MarsError};
 use crate::models::ModelAlias;
-use crate::models::probes::OpenCodeProbeResult;
-use crate::models::probes::PiProbeResult;
+use crate::models::probes::{CursorProbeResult, OpenCodeProbeResult, PiProbeResult};
 use crate::routing::{self, RoutingInput};
 
 #[derive(Debug)]
@@ -35,6 +34,7 @@ pub(super) struct HarnessEvidence<'a> {
     pub(super) linked_harnesses: Option<&'a [String]>,
     pub(super) opencode_probe_result: Option<&'a OpenCodeProbeResult>,
     pub(super) pi_probe_result: Option<&'a PiProbeResult>,
+    pub(super) cursor_probe_result: Option<&'a CursorProbeResult>,
 }
 
 pub(super) fn resolve_harness(
@@ -97,6 +97,7 @@ pub(super) fn resolve_harness(
                     linked_harnesses: evidence.linked_harnesses,
                     opencode_probe_result: evidence.opencode_probe_result,
                     pi_probe_result: evidence.pi_probe_result,
+                    cursor_probe_result: evidence.cursor_probe_result,
                 },
                 &selection.value,
             );
@@ -290,6 +291,7 @@ fn evaluate_candidates(
         linked_harnesses: evidence.linked_harnesses,
         opencode_probe_result: evidence.opencode_probe_result,
         pi_probe_result: evidence.pi_probe_result,
+        cursor_probe_result: evidence.cursor_probe_result,
     })
 }
 
@@ -456,6 +458,7 @@ mod tests {
             linked_harnesses: None,
             opencode_probe_result: None,
             pi_probe_result: None,
+            cursor_probe_result: None,
         }
     }
 
@@ -569,6 +572,7 @@ mod tests {
             linked_harnesses: None,
             opencode_probe_result: Some(&opencode_probe),
             pi_probe_result: None,
+            cursor_probe_result: None,
         };
 
         let resolution = resolve_harness(&input, None, None, None, evidence)
@@ -639,6 +643,7 @@ mod tests {
             linked_harnesses: None,
             opencode_probe_result: None,
             pi_probe_result: None,
+            cursor_probe_result: None,
         };
 
         let error = resolve_harness(&input, None, None, None, evidence)

--- a/src/build/policy/mod.rs
+++ b/src/build/policy/mod.rs
@@ -190,6 +190,7 @@ pub fn resolve_policy(input: PolicyInput<'_>) -> Result<ResolvedPolicy, MarsErro
     let installed_harnesses = capability_snapshot.installed_harnesses();
     let opencode_probe_result = capability_snapshot.opencode.result();
     let pi_probe_result = capability_snapshot.pi.result();
+    let cursor_probe_result = capability_snapshot.cursor.result();
 
     let harness_resolution = harness::resolve_harness(
         &model_input,
@@ -208,6 +209,7 @@ pub fn resolve_policy(input: PolicyInput<'_>) -> Result<ResolvedPolicy, MarsErro
                 .then_some(resolution_config.linked_harnesses.as_slice()),
             opencode_probe_result,
             pi_probe_result,
+            cursor_probe_result,
         },
     )?;
 

--- a/src/build/policy/runnable.rs
+++ b/src/build/policy/runnable.rs
@@ -56,6 +56,12 @@ pub(super) fn resolve_routing(input: RoutingInput<'_>) -> RoutingResolution {
             runnable.confidence = crate::models::availability::RunnableConfidence::Confirmed;
         }
     }
+    let candidate_slugs = route_trace
+        .assessments
+        .iter()
+        .find(|assessment| assessment.harness == harness)
+        .map(|assessment| assessment.candidate_slugs.clone())
+        .unwrap_or_default();
 
     RoutingResolution {
         routing: Routing {
@@ -67,6 +73,7 @@ pub(super) fn resolve_routing(input: RoutingInput<'_>) -> RoutingResolution {
             harness_model: runnable.harness_model_id,
             harness_model_source: runnable.source.label().to_string(),
             harness_model_confidence: runnable.confidence.label().to_string(),
+            candidate_slugs,
             route_trace: route_trace.to_report(),
         },
         warnings: Vec::new(),

--- a/src/cli/models.rs
+++ b/src/cli/models.rs
@@ -12,8 +12,10 @@ use crate::harness::host::{
     CapabilityCollectionOptions, CapabilitySnapshot, collect_capability_snapshot,
 };
 use crate::models::availability::{AvailabilityStatus, ModelAvailability};
+use crate::models::probes::CursorProbeResult;
 use crate::models::probes::OpenCodeProbeResult;
 use crate::models::probes::PiProbeResult;
+use crate::models::probes::cursor_cache;
 use crate::models::probes::opencode_cache::{self, CachedProbeOutcome};
 use crate::models::probes::pi_cache;
 use crate::models::{self, HarnessSource, ModelAlias, ModelSpec};
@@ -194,12 +196,14 @@ fn run_list(args: &ListArgs, ctx: &MarsContext, json: bool) -> Result<i32, MarsE
     let is_offline = capability_snapshot.offline;
     let opencode_probe_result = capability_snapshot.opencode.result().cloned();
     let pi_probe_result = capability_snapshot.pi.result().cloned();
+    let cursor_probe_result = capability_snapshot.cursor.result().cloned();
     let visibility = effective_visibility(ctx, args);
     if args.all {
         let availability_ctx = AvailabilityContext {
             installed: &installed,
             opencode_probe_result: opencode_probe_result.as_ref(),
             pi_probe_result: pi_probe_result.as_ref(),
+            cursor_probe_result: cursor_probe_result.as_ref(),
             is_offline,
             routing_settings: &routing_settings,
         };
@@ -223,6 +227,7 @@ fn run_list(args: &ListArgs, ctx: &MarsContext, json: bool) -> Result<i32, MarsE
         &mut diag,
         opencode_probe_result.as_ref(),
         pi_probe_result.as_ref(),
+        cursor_probe_result.as_ref(),
     );
     apply_routing_settings_to_resolved_aliases(
         &mut resolved,
@@ -230,6 +235,7 @@ fn run_list(args: &ListArgs, ctx: &MarsContext, json: bool) -> Result<i32, MarsE
         &installed,
         opencode_probe_result.as_ref(),
         pi_probe_result.as_ref(),
+        cursor_probe_result.as_ref(),
         &routing_settings,
     );
     annotate_resolved_availability(
@@ -237,6 +243,7 @@ fn run_list(args: &ListArgs, ctx: &MarsContext, json: bool) -> Result<i32, MarsE
         &installed,
         opencode_probe_result.as_ref(),
         pi_probe_result.as_ref(),
+        cursor_probe_result.as_ref(),
         is_offline,
     );
     if !args.unavailable {
@@ -289,6 +296,7 @@ fn run_list(args: &ListArgs, ctx: &MarsContext, json: bool) -> Result<i32, MarsE
             &mut out,
             opencode_probe_result.as_ref(),
             pi_probe_result.as_ref(),
+            cursor_probe_result.as_ref(),
         );
         if let Some(warning) = cache_warning.as_deref() {
             out["cache_warning"] = serde_json::json!(warning);
@@ -346,6 +354,7 @@ struct AvailabilityContext<'a> {
     installed: &'a HashSet<String>,
     opencode_probe_result: Option<&'a OpenCodeProbeResult>,
     pi_probe_result: Option<&'a PiProbeResult>,
+    cursor_probe_result: Option<&'a CursorProbeResult>,
     is_offline: bool,
     routing_settings: &'a ResolvedRoutingSettings,
 }
@@ -356,6 +365,7 @@ struct ResolveRuntime<'a> {
     installed: &'a HashSet<String>,
     probe_outcome: CachedProbeOutcome,
     pi_probe_result: Option<&'a PiProbeResult>,
+    cursor_probe_result: Option<&'a CursorProbeResult>,
     routing_settings: &'a ResolvedRoutingSettings,
 }
 
@@ -366,6 +376,7 @@ struct RouteTraceInput<'a> {
     installed: &'a HashSet<String>,
     opencode_probe_result: Option<&'a OpenCodeProbeResult>,
     pi_probe_result: Option<&'a PiProbeResult>,
+    cursor_probe_result: Option<&'a CursorProbeResult>,
     routing_settings: &'a ResolvedRoutingSettings,
 }
 
@@ -446,6 +457,7 @@ fn run_list_all(
             &mut out,
             availability_ctx.opencode_probe_result,
             availability_ctx.pi_probe_result,
+            availability_ctx.cursor_probe_result,
         );
         if let Some(warning) = cache_warning.as_deref() {
             out["cache_warning"] = serde_json::json!(warning);
@@ -495,10 +507,12 @@ fn run_list_catalog(input: ListCatalogInput<'_>) -> Result<i32, MarsError> {
     let is_offline = capability_snapshot.offline || args.no_refresh_models;
     let probe_result = capability_snapshot.opencode.result().cloned();
     let pi_probe_result = capability_snapshot.pi.result().cloned();
+    let cursor_probe_result = capability_snapshot.cursor.result().cloned();
     let availability_ctx = AvailabilityContext {
         installed: &installed,
         opencode_probe_result: probe_result.as_ref(),
         pi_probe_result: pi_probe_result.as_ref(),
+        cursor_probe_result: cursor_probe_result.as_ref(),
         is_offline,
         routing_settings,
     };
@@ -532,7 +546,12 @@ fn run_list_catalog(input: ListCatalogInput<'_>) -> Result<i32, MarsError> {
             "models": entries,
             "cache_available": cache.fetched_at.is_some(),
         });
-        add_probe_results_json(&mut out, probe_result.as_ref(), pi_probe_result.as_ref());
+        add_probe_results_json(
+            &mut out,
+            probe_result.as_ref(),
+            pi_probe_result.as_ref(),
+            cursor_probe_result.as_ref(),
+        );
         if let Some(warning) = cache_warning.as_deref() {
             out["cache_warning"] = serde_json::json!(warning);
         }
@@ -706,6 +725,7 @@ fn model_entry_for_cached(
         availability_ctx.installed,
         availability_ctx.opencode_probe_result,
         availability_ctx.pi_probe_result,
+        availability_ctx.cursor_probe_result,
         availability_ctx.routing_settings,
     );
 
@@ -729,6 +749,7 @@ fn model_entry_for_cached(
             availability_ctx.installed,
             availability_ctx.opencode_probe_result,
             availability_ctx.pi_probe_result,
+            availability_ctx.cursor_probe_result,
             availability_ctx.is_offline,
         )),
     }
@@ -750,6 +771,7 @@ fn model_entry_for_pinned(
         availability_ctx.installed,
         availability_ctx.opencode_probe_result,
         availability_ctx.pi_probe_result,
+        availability_ctx.cursor_probe_result,
         availability_ctx.routing_settings,
     );
 
@@ -773,6 +795,7 @@ fn model_entry_for_pinned(
             availability_ctx.installed,
             availability_ctx.opencode_probe_result,
             availability_ctx.pi_probe_result,
+            availability_ctx.cursor_probe_result,
             availability_ctx.is_offline,
         )),
     }
@@ -799,6 +822,7 @@ fn resolve_harness_with_routing(
     installed: &HashSet<String>,
     opencode_probe_result: Option<&OpenCodeProbeResult>,
     pi_probe_result: Option<&PiProbeResult>,
+    cursor_probe_result: Option<&CursorProbeResult>,
     routing_settings: &ResolvedRoutingSettings,
 ) -> (Option<String>, HarnessSource) {
     let provider_order = routing_settings.provider_order_names();
@@ -816,6 +840,7 @@ fn resolve_harness_with_routing(
         linked_harnesses: (!linked_harnesses.is_empty()).then_some(linked_harnesses.as_slice()),
         opencode_probe_result,
         pi_probe_result,
+        cursor_probe_result,
     });
 
     match crate::routing::acceptance::accept_route(
@@ -857,6 +882,7 @@ fn route_trace_for_resolved_model(input: &RouteTraceInput<'_>) -> crate::routing
         linked_harnesses: (!linked_harnesses.is_empty()).then_some(linked_harnesses.as_slice()),
         opencode_probe_result: input.opencode_probe_result,
         pi_probe_result: input.pi_probe_result,
+        cursor_probe_result: input.cursor_probe_result,
     })
 }
 
@@ -884,6 +910,7 @@ fn route_trace_for_fixed_harness(
         linked_harnesses: (!linked_harnesses.is_empty()).then_some(linked_harnesses.as_slice()),
         opencode_probe_result: input.opencode_probe_result,
         pi_probe_result: input.pi_probe_result,
+        cursor_probe_result: input.cursor_probe_result,
     };
     let assessment = crate::routing::evaluate_fixed_harness(&fixed_input, fixed_harness);
     crate::routing::trace_for_fixed_harness(source, fixed_harness, assessment, Vec::new())
@@ -908,6 +935,7 @@ fn apply_routing_settings_to_resolved_aliases(
     installed: &HashSet<String>,
     opencode_probe_result: Option<&OpenCodeProbeResult>,
     pi_probe_result: Option<&PiProbeResult>,
+    cursor_probe_result: Option<&CursorProbeResult>,
     routing_settings: &ResolvedRoutingSettings,
 ) {
     for alias in resolved.values_mut() {
@@ -922,6 +950,7 @@ fn apply_routing_settings_to_resolved_aliases(
             installed,
             opencode_probe_result,
             pi_probe_result,
+            cursor_probe_result,
             routing_settings,
         );
     }
@@ -932,6 +961,7 @@ fn apply_routing_settings_to_resolved_alias(
     installed: &HashSet<String>,
     opencode_probe_result: Option<&OpenCodeProbeResult>,
     pi_probe_result: Option<&PiProbeResult>,
+    cursor_probe_result: Option<&CursorProbeResult>,
     routing_settings: &ResolvedRoutingSettings,
 ) {
     let (harness, harness_source) = resolve_harness_with_routing(
@@ -940,6 +970,7 @@ fn apply_routing_settings_to_resolved_alias(
         installed,
         opencode_probe_result,
         pi_probe_result,
+        cursor_probe_result,
         routing_settings,
     );
     alias.harness = harness;
@@ -951,6 +982,7 @@ fn annotate_resolved_availability(
     installed: &HashSet<String>,
     opencode_probe_result: Option<&OpenCodeProbeResult>,
     pi_probe_result: Option<&PiProbeResult>,
+    cursor_probe_result: Option<&CursorProbeResult>,
     is_offline: bool,
 ) {
     for alias in resolved.values_mut() {
@@ -960,6 +992,7 @@ fn annotate_resolved_availability(
             installed,
             opencode_probe_result,
             pi_probe_result,
+            cursor_probe_result,
             is_offline,
         ));
     }
@@ -1029,6 +1062,7 @@ fn add_probe_results_json(
     out: &mut serde_json::Value,
     probe_result: Option<&OpenCodeProbeResult>,
     pi_probe_result: Option<&PiProbeResult>,
+    cursor_probe_result: Option<&CursorProbeResult>,
 ) {
     if let Some(probe) = probe_result {
         out["probe_results"] = serde_json::json!({
@@ -1048,6 +1082,15 @@ fn add_probe_results_json(
             "missing_surface_tokens": probe.help_surface_tokens_missing,
         });
     }
+    if let Some(probe) = cursor_probe_result {
+        if out.get("probe_results").is_none() {
+            out["probe_results"] = serde_json::json!({});
+        }
+        out["probe_results"]["cursor"] = serde_json::json!({
+            "success": probe.model_probe_success,
+            "models_found": probe.slugs.len(),
+        });
+    }
 }
 
 fn availability_status_label(availability: Option<&ModelAvailability>) -> &'static str {
@@ -1065,6 +1108,7 @@ fn annotate_one_availability(
     installed: &HashSet<String>,
     opencode_probe_result: Option<&OpenCodeProbeResult>,
     pi_probe_result: Option<&PiProbeResult>,
+    cursor_probe_result: Option<&CursorProbeResult>,
 ) {
     let is_offline = models::is_mars_offline() || args.no_refresh_models;
     resolved.availability = Some(models::availability::classify_model(
@@ -1073,6 +1117,7 @@ fn annotate_one_availability(
         installed,
         opencode_probe_result,
         pi_probe_result,
+        cursor_probe_result,
         is_offline,
     ));
 }
@@ -1145,6 +1190,7 @@ fn run_resolve(args: &ResolveAliasArgs, ctx: &MarsContext, json: bool) -> Result
     let cache_outcome = capability_snapshot.opencode.clone();
     let probe_result = cache_outcome.result().cloned();
     let pi_probe_result = capability_snapshot.pi.result().cloned();
+    let cursor_probe_result = capability_snapshot.cursor.result().cloned();
 
     // Step 1: exact alias lookup
     if let Some(alias) = merged.get(&args.name) {
@@ -1177,6 +1223,7 @@ fn run_resolve(args: &ResolveAliasArgs, ctx: &MarsContext, json: bool) -> Result
             installed: &installed,
             probe_outcome: cache_outcome.clone(),
             pi_probe_result: pi_probe_result.as_ref(),
+            cursor_probe_result: cursor_probe_result.as_ref(),
             routing_settings: &routing_settings,
         };
         return run_resolve_exact_alias(
@@ -1198,6 +1245,7 @@ fn run_resolve(args: &ResolveAliasArgs, ctx: &MarsContext, json: bool) -> Result
             cache,
             probe_result.as_ref(),
             pi_probe_result.as_ref(),
+            cursor_probe_result.as_ref(),
         )
     {
         apply_routing_settings_to_resolved_alias(
@@ -1205,6 +1253,7 @@ fn run_resolve(args: &ResolveAliasArgs, ctx: &MarsContext, json: bool) -> Result
             &installed,
             probe_result.as_ref(),
             pi_probe_result.as_ref(),
+            cursor_probe_result.as_ref(),
             &routing_settings,
         );
         annotate_one_availability(
@@ -1213,6 +1262,7 @@ fn run_resolve(args: &ResolveAliasArgs, ctx: &MarsContext, json: bool) -> Result
             &installed,
             probe_result.as_ref(),
             pi_probe_result.as_ref(),
+            cursor_probe_result.as_ref(),
         );
         let route_input = RouteTraceInput {
             model_id: &resolved.model_id,
@@ -1221,6 +1271,7 @@ fn run_resolve(args: &ResolveAliasArgs, ctx: &MarsContext, json: bool) -> Result
             installed: &installed,
             opencode_probe_result: probe_result.as_ref(),
             pi_probe_result: pi_probe_result.as_ref(),
+            cursor_probe_result: cursor_probe_result.as_ref(),
             routing_settings: &routing_settings,
         };
         let route_trace = route_trace_for_resolved_model(&route_input);
@@ -1258,6 +1309,7 @@ fn run_refresh_probe(args: &RefreshProbeArgs) -> Result<i32, MarsError> {
     match args.target.as_str() {
         "opencode" => opencode_cache::run_refresh_probe_command(),
         "pi" => pi_cache::run_refresh_probe_command(),
+        "cursor" => cursor_cache::run_refresh_probe_command(),
         _ => Ok(1),
     }
 }
@@ -1357,6 +1409,7 @@ fn run_resolve_exact_alias(
         &mut diag,
         runtime.probe_outcome.result(),
         runtime.pi_probe_result,
+        runtime.cursor_probe_result,
     );
     let mut route_trace = None;
     let mut fixed_harness_route_rejection = None;
@@ -1367,6 +1420,7 @@ fn run_resolve_exact_alias(
                 runtime.installed,
                 runtime.probe_outcome.result(),
                 runtime.pi_probe_result,
+                runtime.cursor_probe_result,
                 runtime.routing_settings,
             );
         }
@@ -1378,6 +1432,7 @@ fn run_resolve_exact_alias(
             installed: runtime.installed,
             opencode_probe_result: runtime.probe_outcome.result(),
             pi_probe_result: runtime.pi_probe_result,
+            cursor_probe_result: runtime.cursor_probe_result,
             routing_settings: runtime.routing_settings,
         };
         route_trace = Some(if let Some(fixed_harness) = alias.harness.as_deref() {
@@ -1410,6 +1465,7 @@ fn run_resolve_exact_alias(
             runtime.installed,
             runtime.probe_outcome.result(),
             runtime.pi_probe_result,
+            runtime.cursor_probe_result,
         );
     }
     let diagnostics = diag.drain();
@@ -1784,6 +1840,9 @@ fn run_output_passthrough(input: OutputPassthroughInput<'_>) -> Result<i32, Mars
     let pi_probe_result = pi_cache::probe_cached(installed, is_offline)
         .result()
         .cloned();
+    let cursor_probe_result = cursor_cache::probe_cached(installed, is_offline)
+        .result()
+        .cloned();
     let provider_order = routing_settings.provider_order_names();
     let harness_order = routing_settings.harness_order_names();
     let default_harness = routing_settings.default_harness_name();
@@ -1799,6 +1858,7 @@ fn run_output_passthrough(input: OutputPassthroughInput<'_>) -> Result<i32, Mars
         linked_harnesses: (!linked_harnesses.is_empty()).then_some(linked_harnesses.as_slice()),
         opencode_probe_result: probe_result.as_ref(),
         pi_probe_result: pi_probe_result.as_ref(),
+        cursor_probe_result: cursor_probe_result.as_ref(),
     });
     if let Err(rejection_reason) = crate::routing::acceptance::accept_route(
         &trace,
@@ -1846,6 +1906,7 @@ fn run_output_passthrough(input: OutputPassthroughInput<'_>) -> Result<i32, Mars
         installed,
         probe_result.as_ref(),
         pi_probe_result.as_ref(),
+        cursor_probe_result.as_ref(),
         is_offline,
     );
 
@@ -2419,6 +2480,7 @@ description = "Old alias"
         installed: &HashSet<String>,
         opencode_probe_result: Option<&OpenCodeProbeResult>,
         pi_probe_result: Option<&PiProbeResult>,
+        cursor_probe_result: Option<&CursorProbeResult>,
         is_offline: bool,
         routing_settings: &ResolvedRoutingSettings,
     ) -> Vec<ListModelEntry> {
@@ -2429,6 +2491,7 @@ description = "Old alias"
                 installed,
                 opencode_probe_result,
                 pi_probe_result,
+                cursor_probe_result,
                 is_offline,
                 routing_settings,
             },
@@ -2440,6 +2503,7 @@ description = "Old alias"
         installed: &HashSet<String>,
         opencode_probe_result: Option<&OpenCodeProbeResult>,
         pi_probe_result: Option<&PiProbeResult>,
+        cursor_probe_result: Option<&CursorProbeResult>,
         is_offline: bool,
         routing_settings: &ResolvedRoutingSettings,
     ) -> Vec<ListModelEntry> {
@@ -2449,6 +2513,7 @@ description = "Old alias"
                 installed,
                 opencode_probe_result,
                 pi_probe_result,
+                cursor_probe_result,
                 is_offline,
                 routing_settings,
             },
@@ -2473,6 +2538,7 @@ description = "Old alias"
             &merged,
             &models_cache,
             &installed,
+            None,
             None,
             None,
             false,
@@ -2508,6 +2574,7 @@ description = "Old alias"
             &installed,
             None,
             None,
+            None,
             false,
             &default_routing_settings(),
         );
@@ -2533,6 +2600,7 @@ description = "Old alias"
             &installed,
             None,
             None,
+            None,
             false,
             &default_routing_settings(),
         );
@@ -2552,6 +2620,7 @@ description = "Old alias"
             &merged,
             &models_cache,
             &installed,
+            None,
             None,
             None,
             false,
@@ -2580,6 +2649,7 @@ description = "Old alias"
             &installed,
             None,
             None,
+            None,
             false,
             &default_routing_settings(),
         );
@@ -2603,6 +2673,7 @@ description = "Old alias"
             &installed,
             None,
             None,
+            None,
             false,
             &default_routing_settings(),
         );
@@ -2624,6 +2695,7 @@ description = "Old alias"
         let rows = collect_catalog_model_entries(
             &models_cache,
             &installed,
+            None,
             None,
             None,
             false,
@@ -2652,6 +2724,7 @@ description = "Old alias"
             &merged,
             &models_cache,
             &installed,
+            None,
             None,
             None,
             false,

--- a/src/cli/models.rs
+++ b/src/cli/models.rs
@@ -2474,6 +2474,7 @@ description = "Old alias"
         crate::config::routing_settings::resolve(&crate::config::Settings::default())
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn collect_all_model_entries(
         merged: &IndexMap<String, ModelAlias>,
         cache: &models::ModelsCache,

--- a/src/harness/host.rs
+++ b/src/harness/host.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use wait_timeout::ChildExt;
 
 use crate::harness::registry::{self, HarnessId};
+use crate::models::probes::cursor_cache::{self, CachedCursorProbeOutcome};
 use crate::models::probes::opencode_cache::{self, CachedProbeOutcome};
 use crate::models::probes::pi_cache::{self, CachedPiProbeOutcome};
 
@@ -30,6 +31,7 @@ pub struct CapabilitySnapshot {
     pub auth: BTreeMap<HarnessId, AuthState>,
     pub opencode: CachedProbeOutcome,
     pub pi: CachedPiProbeOutcome,
+    pub cursor: CachedCursorProbeOutcome,
     pub offline: bool,
 }
 
@@ -113,12 +115,14 @@ pub fn collect_capability_snapshot_with_resolver(
 
     let opencode_offline = options.offline || !options.allow_probe_refresh;
     let pi_offline = options.offline || !options.allow_probe_refresh;
+    let cursor_offline = options.offline || !options.allow_probe_refresh;
 
     CapabilitySnapshot {
         executable,
         auth,
         opencode: opencode_cache::probe_cached(&installed, opencode_offline),
         pi: pi_cache::probe_cached(&installed, pi_offline),
+        cursor: cursor_cache::probe_cached(&installed, cursor_offline),
         offline: options.offline,
     }
 }

--- a/src/harness/registry.rs
+++ b/src/harness/registry.rs
@@ -89,7 +89,7 @@ const DESCRIPTORS: &[HarnessDescriptor] = &[
         binary: "cursor",
         default_target: ".cursor",
         experimental: true,
-        class: HarnessClass::UniversalPassthrough,
+        class: HarnessClass::ProbeBacked,
     },
 ];
 

--- a/src/models/availability.rs
+++ b/src/models/availability.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 
 use crate::routing::slug;
 
-use super::probes::{OpenCodeProbeResult, PiProbeResult};
+use super::probes::{CursorProbeResult, OpenCodeProbeResult, PiProbeResult};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -29,6 +29,12 @@ pub enum AvailabilitySource {
     OpenCodeProbeNegative,
     #[serde(rename = "opencode_probe_unknown")]
     OpenCodeProbeUnknown,
+    #[serde(rename = "cursor_probe")]
+    CursorProbe,
+    #[serde(rename = "cursor_probe_negative")]
+    CursorProbeNegative,
+    #[serde(rename = "cursor_probe_unknown")]
+    CursorProbeUnknown,
     NoHarness,
     Offline,
 }
@@ -157,6 +163,7 @@ pub fn classify_for_harness(
     model_id: &str,
     installed: &HashSet<String>,
     probe_result: Option<&OpenCodeProbeResult>,
+    cursor_probe_result: Option<&CursorProbeResult>,
 ) -> Option<(AvailabilityStatus, AvailabilitySource, Option<RunnablePath>)> {
     let harness = harness.to_ascii_lowercase();
     if !installed.contains(&harness) {
@@ -171,7 +178,8 @@ pub fn classify_for_harness(
         "claude" => slug::providers_match(provider, "anthropic"),
         "codex" => slug::providers_match(provider, "openai"),
         "opencode" => return classify_opencode(provider, model_id, probe_result),
-        "pi" | "cursor" => return classify_universal_harness(),
+        "pi" => return classify_universal_harness(),
+        "cursor" => return classify_cursor(model_id, cursor_probe_result),
         _ => false,
     };
 
@@ -256,6 +264,53 @@ fn classify_opencode(
     ))
 }
 
+fn classify_cursor(
+    model_id: &str,
+    probe_result: Option<&CursorProbeResult>,
+) -> Option<(AvailabilityStatus, AvailabilitySource, Option<RunnablePath>)> {
+    let Some(probe) = probe_result else {
+        return Some((
+            AvailabilityStatus::Unknown,
+            AvailabilitySource::CursorProbeUnknown,
+            None,
+        ));
+    };
+
+    if !probe.model_probe_success {
+        return Some((
+            AvailabilityStatus::Unknown,
+            AvailabilitySource::CursorProbeUnknown,
+            None,
+        ));
+    }
+    if probe.slugs.is_empty() {
+        return Some((
+            AvailabilityStatus::Unknown,
+            AvailabilitySource::CursorProbeUnknown,
+            None,
+        ));
+    }
+
+    let matches = crate::models::probes::cursor::find_cursor_prefix_matches(model_id, &probe.slugs);
+    if matches.is_empty() {
+        return Some((
+            AvailabilityStatus::Unavailable,
+            AvailabilitySource::CursorProbeNegative,
+            None,
+        ));
+    }
+
+    Some((
+        AvailabilityStatus::Runnable,
+        AvailabilitySource::CursorProbe,
+        Some(RunnablePath {
+            harness: "cursor".to_string(),
+            mars_provider: "cursor".to_string(),
+            harness_model_id: model_id.to_string(),
+        }),
+    ))
+}
+
 fn is_unknown_provider(provider: &str) -> bool {
     let provider = provider.trim();
     provider.is_empty() || provider.eq_ignore_ascii_case("unknown")
@@ -271,14 +326,15 @@ pub fn classify_model(
     installed: &HashSet<String>,
     opencode_probe_result: Option<&OpenCodeProbeResult>,
     pi_probe_result: Option<&PiProbeResult>,
+    cursor_probe_result: Option<&CursorProbeResult>,
     offline: bool,
 ) -> ModelAvailability {
     let mut statuses = Vec::new();
     let mut runnable_paths = Vec::new();
 
-    for harness in ["claude", "codex", "cursor"] {
+    for harness in ["claude", "codex"] {
         let Some((status, source, path)) =
-            classify_for_harness(harness, provider, model_id, installed, None)
+            classify_for_harness(harness, provider, model_id, installed, None, None)
         else {
             continue;
         };
@@ -301,9 +357,14 @@ pub fn classify_model(
         if offline {
             statuses.push((AvailabilityStatus::Unknown, AvailabilitySource::Offline));
         } else if let Some(result) = opencode_probe_result {
-            if let Some((status, source, path)) =
-                classify_for_harness("opencode", provider, model_id, installed, Some(result))
-            {
+            if let Some((status, source, path)) = classify_for_harness(
+                "opencode",
+                provider,
+                model_id,
+                installed,
+                Some(result),
+                None,
+            ) {
                 if let Some(path) = path {
                     runnable_paths.push(path);
                 }
@@ -314,6 +375,18 @@ pub fn classify_model(
                 AvailabilityStatus::Unknown,
                 AvailabilitySource::OpenCodeProbeUnknown,
             ));
+        }
+    }
+
+    if installed.contains("cursor") {
+        if offline {
+            statuses.push((AvailabilityStatus::Unknown, AvailabilitySource::Offline));
+        } else if let Some((status, source, path)) = classify_cursor(model_id, cursor_probe_result)
+        {
+            if let Some(path) = path {
+                runnable_paths.push(path);
+            }
+            statuses.push((status, source));
         }
     }
 
@@ -441,6 +514,7 @@ mod tests {
             "claude-opus-4-7",
             &installed(&["claude"]),
             None,
+            None,
         )
         .unwrap();
         assert_eq!(result.0, AvailabilityStatus::Runnable);
@@ -453,9 +527,15 @@ mod tests {
 
     #[test]
     fn test_classify_codex_openai() {
-        let result =
-            classify_for_harness("codex", "OpenAI", "gpt-5.4", &installed(&["codex"]), None)
-                .unwrap();
+        let result = classify_for_harness(
+            "codex",
+            "OpenAI",
+            "gpt-5.4",
+            &installed(&["codex"]),
+            None,
+            None,
+        )
+        .unwrap();
         assert_eq!(result.0, AvailabilityStatus::Runnable);
         assert_eq!(result.1, AvailabilitySource::HarnessInstalled);
     }
@@ -467,6 +547,7 @@ mod tests {
             "openai-codex",
             "gpt-5.4-mini",
             &installed(&["codex"]),
+            None,
             None,
         )
         .unwrap();
@@ -483,9 +564,15 @@ mod tests {
 
     #[test]
     fn test_classify_pi_is_universal_unknown_when_installed() {
-        let result =
-            classify_for_harness("pi", "OpenAI", "gpt-5.4-mini", &installed(&["pi"]), None)
-                .unwrap();
+        let result = classify_for_harness(
+            "pi",
+            "OpenAI",
+            "gpt-5.4-mini",
+            &installed(&["pi"]),
+            None,
+            None,
+        )
+        .unwrap();
         assert_eq!(result.0, AvailabilityStatus::Unknown);
         assert_eq!(result.1, AvailabilitySource::UniversalHarness);
         assert!(result.2.is_none());
@@ -499,11 +586,80 @@ mod tests {
             "claude-opus-4-7",
             &installed(&["cursor"]),
             None,
+            None,
         )
         .unwrap();
         assert_eq!(result.0, AvailabilityStatus::Unknown);
-        assert_eq!(result.1, AvailabilitySource::UniversalHarness);
+        assert_eq!(result.1, AvailabilitySource::CursorProbeUnknown);
         assert!(result.2.is_none());
+    }
+
+    #[test]
+    fn test_classify_cursor_probe_prefix_match_is_runnable() {
+        let cursor_probe = CursorProbeResult {
+            slugs: vec!["gpt-5.5-high".to_string(), "gpt-5.5-low".to_string()],
+            model_probe_success: true,
+            error: None,
+        };
+        let result = classify_model(
+            "gpt-5.5",
+            "OpenAI",
+            &installed(&["cursor"]),
+            None,
+            None,
+            Some(&cursor_probe),
+            false,
+        );
+
+        assert_eq!(result.status, AvailabilityStatus::Runnable);
+        assert_eq!(result.source, AvailabilitySource::CursorProbe);
+        assert_eq!(result.runnable_paths.len(), 1);
+        assert_eq!(result.runnable_paths[0].harness, "cursor");
+        assert_eq!(result.runnable_paths[0].harness_model_id, "gpt-5.5");
+    }
+
+    #[test]
+    fn test_classify_cursor_probe_no_match_is_unavailable() {
+        let cursor_probe = CursorProbeResult {
+            slugs: vec!["claude-opus-4-7-high".to_string()],
+            model_probe_success: true,
+            error: None,
+        };
+        let result = classify_model(
+            "gpt-5.5",
+            "OpenAI",
+            &installed(&["cursor"]),
+            None,
+            None,
+            Some(&cursor_probe),
+            false,
+        );
+
+        assert_eq!(result.status, AvailabilityStatus::Unavailable);
+        assert_eq!(result.source, AvailabilitySource::CursorProbeNegative);
+        assert!(result.runnable_paths.is_empty());
+    }
+
+    #[test]
+    fn test_classify_cursor_probe_empty_catalog_is_unknown() {
+        let cursor_probe = CursorProbeResult {
+            slugs: Vec::new(),
+            model_probe_success: true,
+            error: None,
+        };
+        let result = classify_model(
+            "gpt-5.5",
+            "OpenAI",
+            &installed(&["cursor"]),
+            None,
+            None,
+            Some(&cursor_probe),
+            false,
+        );
+
+        assert_eq!(result.status, AvailabilityStatus::Unknown);
+        assert_eq!(result.source, AvailabilitySource::CursorProbeUnknown);
+        assert!(result.runnable_paths.is_empty());
     }
 
     #[test]
@@ -513,6 +669,7 @@ mod tests {
             "Anthropic",
             "claude-opus-4-7",
             &installed(&[]),
+            None,
             None,
         )
         .unwrap();
@@ -527,6 +684,7 @@ mod tests {
             "claude-opus-4-7",
             "Anthropic",
             &installed(&["claude", "codex"]),
+            None,
             None,
             None,
             false,
@@ -545,6 +703,7 @@ mod tests {
             &installed(&[]),
             None,
             None,
+            None,
             false,
         );
         assert_eq!(result.status, AvailabilityStatus::Unavailable);
@@ -558,6 +717,7 @@ mod tests {
             "gemini-2.5-pro",
             "Google",
             &installed(&["pi"]),
+            None,
             None,
             None,
             false,
@@ -581,6 +741,7 @@ mod tests {
             &installed(&["pi"]),
             None,
             Some(&pi_probe),
+            None,
             false,
         );
 
@@ -607,6 +768,7 @@ mod tests {
             &installed(&["pi"]),
             None,
             Some(&pi_probe),
+            None,
             false,
         );
 
@@ -628,6 +790,7 @@ mod tests {
             &installed(&["pi", "codex"]),
             None,
             Some(&pi_probe),
+            None,
             false,
         );
 
@@ -651,6 +814,7 @@ mod tests {
             &installed(&["pi"]),
             None,
             Some(&pi_probe),
+            None,
             false,
         );
 
@@ -667,6 +831,7 @@ mod tests {
             &installed(&["codex"]),
             None,
             None,
+            None,
             true,
         );
         assert_eq!(result.status, AvailabilityStatus::Runnable);
@@ -678,6 +843,7 @@ mod tests {
             "gpt-5.4",
             "OpenAI",
             &installed(&["opencode"]),
+            None,
             None,
             None,
             true,
@@ -700,6 +866,7 @@ mod tests {
             "OpenAI",
             &installed(&["opencode"]),
             Some(&probe),
+            None,
             None,
             false,
         );
@@ -725,6 +892,7 @@ mod tests {
             &installed(&["opencode"]),
             Some(&probe),
             None,
+            None,
             false,
         );
 
@@ -746,6 +914,7 @@ mod tests {
             "OpenAI",
             &installed(&["opencode"]),
             Some(&probe),
+            None,
             None,
             false,
         );
@@ -769,6 +938,7 @@ mod tests {
             &installed(&["opencode"]),
             Some(&probe),
             None,
+            None,
             false,
         );
 
@@ -791,6 +961,7 @@ mod tests {
             &installed(&["opencode"]),
             Some(&probe),
             None,
+            None,
             false,
         );
 
@@ -812,6 +983,7 @@ mod tests {
             "Anthropic",
             &installed(&["opencode"]),
             Some(&probe),
+            None,
             None,
             false,
         );
@@ -863,6 +1035,7 @@ mod tests {
             &installed(&["opencode"]),
             Some(&probe),
             None,
+            None,
             false,
         );
 
@@ -884,6 +1057,7 @@ mod tests {
             "unknown",
             &installed(&["opencode"]),
             Some(&probe),
+            None,
             None,
             false,
         );

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -853,7 +853,15 @@ pub fn resolve_with_alias_prefix(
     cache: &ModelsCache,
 ) -> Option<ResolvedAlias> {
     let opencode_probe = probes::opencode_cache::read_cached_probe_result_usable();
-    resolve_with_alias_prefix_with_probe(input, aliases, cache, opencode_probe.as_ref(), None)
+    let cursor_probe = probes::cursor_cache::read_cached_probe_result_usable();
+    resolve_with_alias_prefix_with_probe(
+        input,
+        aliases,
+        cache,
+        opencode_probe.as_ref(),
+        None,
+        cursor_probe.as_ref(),
+    )
 }
 
 pub fn resolve_with_alias_prefix_with_probe(
@@ -862,6 +870,7 @@ pub fn resolve_with_alias_prefix_with_probe(
     cache: &ModelsCache,
     opencode_probe: Option<&probes::OpenCodeProbeResult>,
     pi_probe: Option<&probes::PiProbeResult>,
+    cursor_probe: Option<&probes::CursorProbeResult>,
 ) -> Option<ResolvedAlias> {
     let pattern = if input.contains('*') {
         input.to_string()
@@ -975,6 +984,7 @@ pub fn resolve_with_alias_prefix_with_probe(
         linked_harnesses: None,
         opencode_probe_result: opencode_probe,
         pi_probe_result: pi_probe,
+        cursor_probe_result: cursor_probe,
     });
     let (harness, harness_source) = match crate::routing::acceptance::accept_route(
         &trace,
@@ -1296,7 +1306,15 @@ pub fn resolve_all(
     diag: &mut DiagnosticCollector,
 ) -> IndexMap<String, ResolvedAlias> {
     let opencode_probe = probes::opencode_cache::read_cached_probe_result_usable();
-    resolve_all_with_probe(aliases, cache, diag, opencode_probe.as_ref(), None)
+    let cursor_probe = probes::cursor_cache::read_cached_probe_result_usable();
+    resolve_all_with_probe(
+        aliases,
+        cache,
+        diag,
+        opencode_probe.as_ref(),
+        None,
+        cursor_probe.as_ref(),
+    )
 }
 
 pub fn resolve_all_with_probe(
@@ -1305,6 +1323,7 @@ pub fn resolve_all_with_probe(
     diag: &mut DiagnosticCollector,
     opencode_probe: Option<&probes::OpenCodeProbeResult>,
     pi_probe: Option<&probes::PiProbeResult>,
+    cursor_probe: Option<&probes::CursorProbeResult>,
 ) -> IndexMap<String, ResolvedAlias> {
     let _ = diag;
     let installed = harness::detect_installed_harnesses();
@@ -1323,6 +1342,7 @@ pub fn resolve_all_with_probe(
             &installed,
             opencode_probe,
             pi_probe,
+            cursor_probe,
         );
 
         resolved.insert(
@@ -1354,7 +1374,16 @@ pub fn resolve_one(
     diag: &mut DiagnosticCollector,
 ) -> Option<ResolvedAlias> {
     let opencode_probe = probes::opencode_cache::read_cached_probe_result_usable();
-    resolve_one_with_probe(name, aliases, cache, diag, opencode_probe.as_ref(), None)
+    let cursor_probe = probes::cursor_cache::read_cached_probe_result_usable();
+    resolve_one_with_probe(
+        name,
+        aliases,
+        cache,
+        diag,
+        opencode_probe.as_ref(),
+        None,
+        cursor_probe.as_ref(),
+    )
 }
 
 pub fn resolve_one_with_probe(
@@ -1364,6 +1393,7 @@ pub fn resolve_one_with_probe(
     diag: &mut DiagnosticCollector,
     opencode_probe: Option<&probes::OpenCodeProbeResult>,
     pi_probe: Option<&probes::PiProbeResult>,
+    cursor_probe: Option<&probes::CursorProbeResult>,
 ) -> Option<ResolvedAlias> {
     let alias = aliases.get(name)?;
     let installed = harness::detect_installed_harnesses();
@@ -1376,6 +1406,7 @@ pub fn resolve_one_with_probe(
         &installed,
         opencode_probe,
         pi_probe,
+        cursor_probe,
     );
     let _ = diag;
     Some(ResolvedAlias {
@@ -1549,6 +1580,7 @@ fn resolve_harness(
     installed: &HashSet<String>,
     opencode_probe_result: Option<&probes::OpenCodeProbeResult>,
     pi_probe_result: Option<&probes::PiProbeResult>,
+    cursor_probe_result: Option<&probes::CursorProbeResult>,
 ) -> (Option<String>, HarnessSource) {
     if let Some(h) = &alias.harness {
         if installed.contains(h) {
@@ -1569,6 +1601,7 @@ fn resolve_harness(
             linked_harnesses: None,
             opencode_probe_result,
             pi_probe_result,
+            cursor_probe_result,
         });
         match crate::routing::acceptance::accept_route(
             &trace,
@@ -1996,6 +2029,7 @@ mod tests {
             linked_harnesses: None,
             opencode_probe_result: None,
             pi_probe_result: None,
+            cursor_probe_result: None,
         });
         let (expected_harness, expected_source) = if installed.contains(&trace.harness) {
             (Some(trace.harness), HarnessSource::AutoDetected)
@@ -2572,6 +2606,7 @@ mod tests {
             linked_harnesses: None,
             opencode_probe_result: None,
             pi_probe_result: None,
+            cursor_probe_result: None,
         });
         let (expected_harness, expected_source) = if installed.contains(&trace.harness) {
             (Some(trace.harness), HarnessSource::AutoDetected)
@@ -2987,6 +3022,7 @@ mod tests {
             &installed,
             None,
             None,
+            None,
         );
         assert_eq!(
             resolved,
@@ -3016,6 +3052,7 @@ mod tests {
             &installed,
             None,
             None,
+            None,
         );
         assert_eq!(
             resolved,
@@ -3043,6 +3080,7 @@ mod tests {
             "anthropic",
             "claude-opus-4-6",
             &installed,
+            None,
             None,
             None,
         );
@@ -3077,6 +3115,7 @@ mod tests {
             &installed,
             None,
             None,
+            None,
         );
         assert_eq!(resolved, (None, HarnessSource::Unavailable));
     }
@@ -3096,8 +3135,15 @@ mod tests {
         };
         let installed: HashSet<String> = ["claude", "pi"].iter().map(|s| s.to_string()).collect();
 
-        let resolved =
-            resolve_harness(&alias, "unknown", "my-custom-model", &installed, None, None);
+        let resolved = resolve_harness(
+            &alias,
+            "unknown",
+            "my-custom-model",
+            &installed,
+            None,
+            None,
+            None,
+        );
         assert_eq!(
             resolved,
             (Some("pi".to_string()), HarnessSource::AutoDetected)

--- a/src/models/probes/cursor.rs
+++ b/src/models/probes/cursor.rs
@@ -1,0 +1,237 @@
+use std::io::Read;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use wait_timeout::ChildExt;
+
+/// Result of probing cursor's runtime model catalog.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CursorProbeResult {
+    /// Raw slug strings from `cursor agent --list-models` (fast variants excluded).
+    pub slugs: Vec<String>,
+    /// Whether the model list probe succeeded.
+    pub model_probe_success: bool,
+    /// Redacted error message if probing failed.
+    pub error: Option<String>,
+}
+
+const DEFAULT_PROBE_TIMEOUT_SECS: u64 = 5;
+
+/// Probe cursor with the configured timeout.
+pub fn probe() -> CursorProbeResult {
+    probe_with_timeout(probe_timeout())
+}
+
+/// Probe cursor with a specific timeout.
+pub fn probe_with_timeout(timeout: Duration) -> CursorProbeResult {
+    let mut result = CursorProbeResult::default();
+
+    match run_command("cursor", &["agent", "--list-models"], timeout) {
+        Ok(stdout) => {
+            result.slugs = parse_cursor_models_output(&stdout);
+            result.model_probe_success = true;
+        }
+        Err(error) => {
+            result.model_probe_success = false;
+            result.error = Some(format!("model probe failed: {error}"));
+        }
+    }
+
+    result
+}
+
+fn probe_timeout() -> Duration {
+    std::env::var("MARS_PROBE_TIMEOUT_SECS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or(Duration::from_secs(DEFAULT_PROBE_TIMEOUT_SECS))
+}
+
+fn run_command(cmd: &str, args: &[&str], timeout: Duration) -> Result<String, String> {
+    let program = resolve_command(cmd);
+    let mut child = Command::new(&program)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|error| format!("spawn failed: {error}"))?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "stdout capture unavailable".to_string())?;
+    let stdout_reader = thread::spawn(move || {
+        let mut stdout = stdout;
+        let mut output = Vec::new();
+        stdout
+            .read_to_end(&mut output)
+            .map(|_| output)
+            .map_err(|error| format!("stdout read failed: {error}"))
+    });
+
+    match child
+        .wait_timeout(timeout)
+        .map_err(|error| format!("wait failed: {error}"))?
+    {
+        Some(status) if status.success() => {
+            let stdout = stdout_reader
+                .join()
+                .map_err(|_| "stdout reader panicked".to_string())??;
+            String::from_utf8(stdout).map_err(|error| format!("invalid utf8: {error}"))
+        }
+        Some(status) => {
+            let _ = stdout_reader.join();
+            Err(format!("exit code {}", status.code().unwrap_or(-1)))
+        }
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = stdout_reader.join();
+            Err("timeout".to_string())
+        }
+    }
+}
+
+fn resolve_command(cmd: &str) -> PathBuf {
+    let resolver = crate::harness::host::PathExecutableResolver;
+    crate::harness::host::resolve_binary_path(cmd, &resolver).unwrap_or_else(|| cmd.into())
+}
+
+fn strip_ansi(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '\x1b' {
+            while let Some(&next) = chars.peek() {
+                chars.next();
+                if next.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+        } else {
+            result.push(ch);
+        }
+    }
+
+    result
+}
+
+/// Parse `cursor agent --list-models` output into raw slug strings.
+fn parse_cursor_models_output(stdout: &str) -> Vec<String> {
+    stdout
+        .lines()
+        .filter_map(|line| {
+            let clean = strip_ansi(line.trim());
+            if clean.is_empty()
+                || clean.eq_ignore_ascii_case("available models")
+                || clean.starts_with("Tip:")
+            {
+                return None;
+            }
+
+            let (slug, _) = clean.split_once(" - ")?;
+            let slug = slug.trim();
+            if slug.is_empty() || slug.ends_with("-fast") {
+                return None;
+            }
+
+            Some(slug.to_string())
+        })
+        .collect()
+}
+
+pub fn normalize_slug(s: &str) -> String {
+    s.to_ascii_lowercase().replace('.', "-")
+}
+
+pub fn find_cursor_prefix_matches<'a>(model_id: &str, slugs: &'a [String]) -> Vec<&'a str> {
+    let normalized_model = normalize_slug(model_id);
+    slugs
+        .iter()
+        .filter(|slug| normalize_slug(slug).starts_with(&normalized_model))
+        .map(String::as_str)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_models_basic() {
+        let output = r#"gpt-5.5-high - GPT 5.5 (High)
+gpt-5.5-low - GPT 5.5 (Low)
+claude-opus-4-7-thinking-high - Claude Opus 4.7"#;
+
+        let slugs = parse_cursor_models_output(output);
+
+        assert_eq!(
+            slugs,
+            vec![
+                "gpt-5.5-high".to_string(),
+                "gpt-5.5-low".to_string(),
+                "claude-opus-4-7-thinking-high".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_models_filters_fast() {
+        let output = r#"gpt-5.5-high - GPT 5.5 (High)
+gpt-5.5-fast - GPT 5.5 (Fast)"#;
+        let slugs = parse_cursor_models_output(output);
+        assert_eq!(slugs, vec!["gpt-5.5-high".to_string()]);
+    }
+
+    #[test]
+    fn test_parse_models_skips_header_and_tip() {
+        let output = r#"Available models
+
+gpt-5.5-high - GPT 5.5 (High)
+
+Tip: use --model <id> to select"#;
+        let slugs = parse_cursor_models_output(output);
+        assert_eq!(slugs, vec!["gpt-5.5-high".to_string()]);
+    }
+
+    #[test]
+    fn test_parse_models_strips_ansi() {
+        let slugs = parse_cursor_models_output("\x1b[32mgpt-5.5-high - GPT 5.5\x1b[0m");
+        assert_eq!(slugs, vec!["gpt-5.5-high".to_string()]);
+    }
+
+    #[test]
+    fn test_find_prefix_matches() {
+        let slugs = vec![
+            "gpt-5.5-high".to_string(),
+            "gpt-5.5-low".to_string(),
+            "claude-opus-4-7".to_string(),
+        ];
+        let matches = find_cursor_prefix_matches("gpt-5.5", &slugs);
+        assert_eq!(matches, vec!["gpt-5.5-high", "gpt-5.5-low"]);
+    }
+
+    #[test]
+    fn test_normalize_slug() {
+        assert_eq!(normalize_slug("GPT.5.5-High"), "gpt-5-5-high");
+    }
+
+    #[test]
+    fn test_probe_result_round_trip() {
+        let result = CursorProbeResult {
+            slugs: vec!["gpt-5.5-high".to_string()],
+            model_probe_success: true,
+            error: None,
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        let back: CursorProbeResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.slugs, result.slugs);
+        assert!(back.model_probe_success);
+        assert_eq!(back.error, None);
+    }
+}

--- a/src/models/probes/cursor_cache.rs
+++ b/src/models/probes/cursor_cache.rs
@@ -1,0 +1,550 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+
+use serde::{Deserialize, Serialize};
+
+use super::cursor::CursorProbeResult;
+use crate::error::MarsError;
+
+const SCHEMA_VERSION: u32 = 1;
+const DEFAULT_TTL_SECS: u64 = 60;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProbeCacheEntry {
+    pub schema_version: u32,
+    pub fetched_at: u64,
+    pub last_attempt_at: u64,
+    pub last_error: Option<String>,
+    pub result: Option<CursorProbeResult>,
+}
+
+#[derive(Debug, Clone)]
+pub enum CachedCursorProbeOutcome {
+    Hit(CursorProbeResult),
+    Stale(CursorProbeResult),
+    Miss(CursorProbeResult),
+    Unavailable,
+}
+
+impl CachedCursorProbeOutcome {
+    pub fn result(&self) -> Option<&CursorProbeResult> {
+        match self {
+            Self::Hit(r) | Self::Stale(r) | Self::Miss(r) => Some(r),
+            Self::Unavailable => None,
+        }
+    }
+
+    pub fn cache_status(&self) -> &'static str {
+        match self {
+            Self::Hit(_) => "hit",
+            Self::Stale(_) => "stale",
+            Self::Miss(_) => "miss",
+            Self::Unavailable => "skipped",
+        }
+    }
+}
+
+/// Return the cached cursor probe result, if one exists, is usable, and is fresh.
+///
+/// This helper is read-only and never triggers a probe refresh.
+pub fn read_cached_probe_result() -> Option<CursorProbeResult> {
+    let entry = read_cache_tolerant()?;
+    if !is_fresh(&entry) || !is_usable(&entry) {
+        return None;
+    }
+    entry.result
+}
+
+/// Return the cached cursor probe result if usable, even when stale.
+///
+/// This helper is read-only and never triggers a probe refresh.
+pub fn read_cached_probe_result_usable() -> Option<CursorProbeResult> {
+    let entry = read_cache_tolerant()?;
+    if !is_usable(&entry) {
+        return None;
+    }
+    entry.result
+}
+
+fn cache_dir() -> Result<PathBuf, MarsError> {
+    let root = crate::platform::cache::global_cache_root()?;
+    Ok(root.join("availability"))
+}
+
+fn cache_path() -> Result<PathBuf, MarsError> {
+    Ok(cache_dir()?.join("cursor-probe.json"))
+}
+
+fn lock_path() -> Result<PathBuf, MarsError> {
+    Ok(cache_dir()?.join(".cursor-probe.lock"))
+}
+
+fn ttl_secs() -> u64 {
+    std::env::var("MARS_PROBE_CACHE_TTL_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_TTL_SECS)
+}
+
+fn now_unix_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn is_fresh(entry: &ProbeCacheEntry) -> bool {
+    let ttl = ttl_secs();
+    let now = now_unix_secs();
+    if entry.fetched_at > now {
+        return false;
+    }
+    (now - entry.fetched_at) < ttl
+}
+
+fn is_usable(entry: &ProbeCacheEntry) -> bool {
+    entry.result.as_ref().is_some_and(|r| r.model_probe_success)
+}
+
+fn read_cache_tolerant() -> Option<ProbeCacheEntry> {
+    read_cache_tolerant_at(&cache_path().ok()?)
+}
+
+fn read_cache_tolerant_at(path: &Path) -> Option<ProbeCacheEntry> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let entry: ProbeCacheEntry = serde_json::from_str(&content).ok()?;
+    if entry.schema_version != SCHEMA_VERSION {
+        return None;
+    }
+    Some(entry)
+}
+
+fn write_cache(entry: &ProbeCacheEntry) -> Result<(), MarsError> {
+    write_cache_at(&cache_path()?, entry)
+}
+
+fn write_cache_at(path: &Path, entry: &ProbeCacheEntry) -> Result<(), MarsError> {
+    let json = serde_json::to_string_pretty(entry)
+        .map_err(|e| MarsError::Internal(format!("probe cache serialize: {e}")))?;
+    crate::fs::atomic_write(path, json.as_bytes())
+}
+
+struct FileLock {
+    _file: std::fs::File,
+}
+
+fn try_lock() -> Option<FileLock> {
+    lock_at(&lock_path().ok()?, true)
+}
+
+fn blocking_lock() -> Option<FileLock> {
+    lock_at(&lock_path().ok()?, false)
+}
+
+fn lock_at(path: &Path, nonblocking: bool) -> Option<FileLock> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).ok()?;
+    }
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(path)
+        .ok()?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::io::AsRawFd;
+        let flags = if nonblocking {
+            libc::LOCK_EX | libc::LOCK_NB
+        } else {
+            libc::LOCK_EX
+        };
+        let ret = unsafe { libc::flock(file.as_raw_fd(), flags) };
+        if ret != 0 {
+            return None;
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::io::AsRawHandle;
+        use windows_sys::Win32::Foundation::HANDLE;
+        use windows_sys::Win32::Storage::FileSystem::{
+            LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY, LockFileEx,
+        };
+        let handle = file.as_raw_handle() as HANDLE;
+        let mut overlapped = unsafe { std::mem::zeroed() };
+        let flags = if nonblocking {
+            LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY
+        } else {
+            LOCKFILE_EXCLUSIVE_LOCK
+        };
+        let ret = unsafe { LockFileEx(handle, flags, 0, 1, 0, &mut overlapped) };
+        if ret == 0 {
+            return None;
+        }
+    }
+
+    Some(FileLock { _file: file })
+}
+
+pub fn probe_cached(installed: &HashSet<String>, is_offline: bool) -> CachedCursorProbeOutcome {
+    if !super::should_probe_cursor(installed, is_offline) {
+        return CachedCursorProbeOutcome::Unavailable;
+    }
+
+    probe_cached_impl(is_offline, &cache_path().ok(), super::cursor::probe, || {
+        spawn_detached_refresh().map_err(|_| ())
+    })
+}
+
+fn probe_cached_impl<F, S>(
+    is_offline: bool,
+    path: &Option<PathBuf>,
+    probe: F,
+    spawn_refresh: S,
+) -> CachedCursorProbeOutcome
+where
+    F: Fn() -> CursorProbeResult,
+    S: Fn() -> Result<(), ()>,
+{
+    let cached = path.as_deref().and_then(read_cache_tolerant_at);
+
+    match cached {
+        Some(entry) if is_fresh(&entry) && is_usable(&entry) => {
+            CachedCursorProbeOutcome::Hit(entry.result.unwrap())
+        }
+        Some(entry) if is_usable(&entry) => {
+            let result = entry.result.clone().unwrap();
+            if !is_offline {
+                trigger_background_refresh_with(spawn_refresh);
+            }
+            CachedCursorProbeOutcome::Stale(result)
+        }
+        _ if is_offline => CachedCursorProbeOutcome::Unavailable,
+        _ => synchronous_probe_with(path, probe),
+    }
+}
+
+fn trigger_background_refresh_with<S>(spawn_refresh: S)
+where
+    S: Fn() -> Result<(), ()>,
+{
+    let Some(lock) = try_lock() else { return };
+    if let Some(entry) = read_cache_tolerant()
+        && is_fresh(&entry)
+        && is_usable(&entry)
+    {
+        drop(lock);
+        return;
+    }
+    let _ = spawn_refresh();
+    drop(lock);
+}
+
+fn synchronous_probe_with<F>(path: &Option<PathBuf>, probe: F) -> CachedCursorProbeOutcome
+where
+    F: Fn() -> CursorProbeResult,
+{
+    let lock = blocking_lock();
+
+    if lock.is_some()
+        && let Some(path) = path
+        && let Some(entry) = read_cache_tolerant_at(path)
+        && is_usable(&entry)
+    {
+        if is_fresh(&entry) {
+            return CachedCursorProbeOutcome::Hit(entry.result.unwrap());
+        }
+        let probe_result = probe();
+        if probe_result.model_probe_success {
+            write_probe_attempt(path, probe_result.clone());
+            return CachedCursorProbeOutcome::Miss(probe_result);
+        } else {
+            write_failed_attempt(path, &entry, &probe_result);
+            return CachedCursorProbeOutcome::Stale(entry.result.unwrap());
+        }
+    }
+
+    let probe_result = probe();
+    if let Some(path) = path {
+        write_probe_attempt(path, probe_result.clone());
+    }
+    drop(lock);
+
+    if probe_result.model_probe_success {
+        CachedCursorProbeOutcome::Miss(probe_result)
+    } else {
+        CachedCursorProbeOutcome::Unavailable
+    }
+}
+
+fn write_probe_attempt(path: &Path, probe_result: CursorProbeResult) {
+    let now = now_unix_secs();
+    let entry = ProbeCacheEntry {
+        schema_version: SCHEMA_VERSION,
+        fetched_at: now,
+        last_attempt_at: now,
+        last_error: if probe_result.model_probe_success {
+            None
+        } else {
+            probe_result.error.clone()
+        },
+        result: Some(probe_result),
+    };
+
+    if let Err(e) = write_cache_at(path, &entry) {
+        eprintln!("debug: probe cache write failed: {e}");
+    }
+}
+
+fn write_failed_attempt(path: &Path, existing: &ProbeCacheEntry, failed_probe: &CursorProbeResult) {
+    let now = now_unix_secs();
+    let entry = ProbeCacheEntry {
+        schema_version: SCHEMA_VERSION,
+        fetched_at: existing.fetched_at,
+        last_attempt_at: now,
+        last_error: failed_probe.error.clone(),
+        result: existing.result.clone(),
+    };
+
+    if let Err(e) = write_cache_at(path, &entry) {
+        eprintln!("debug: probe cache write failed: {e}");
+    }
+}
+
+fn spawn_detached_refresh() -> std::io::Result<()> {
+    let mars_bin = std::env::current_exe()?;
+    let mut cmd = std::process::Command::new(mars_bin);
+    cmd.args(["models", "__refresh-probe", "--target", "cursor"]);
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::null());
+    cmd.stderr(Stdio::null());
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        unsafe {
+            cmd.pre_exec(|| {
+                libc::setsid();
+                Ok(())
+            });
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x00000008);
+    }
+
+    cmd.spawn()?;
+    Ok(())
+}
+
+pub fn run_refresh_probe_command() -> Result<i32, MarsError> {
+    let Some(_lock) = blocking_lock() else {
+        return Ok(0);
+    };
+
+    if let Some(entry) = read_cache_tolerant()
+        && is_fresh(&entry)
+        && is_usable(&entry)
+    {
+        return Ok(0);
+    }
+
+    let probe_result = super::cursor::probe();
+    let now = now_unix_secs();
+    let existing = read_cache_tolerant();
+
+    let entry = if probe_result.model_probe_success {
+        ProbeCacheEntry {
+            schema_version: SCHEMA_VERSION,
+            fetched_at: now,
+            last_attempt_at: now,
+            last_error: None,
+            result: Some(probe_result),
+        }
+    } else {
+        ProbeCacheEntry {
+            schema_version: SCHEMA_VERSION,
+            fetched_at: existing.as_ref().map(|e| e.fetched_at).unwrap_or(0),
+            last_attempt_at: now,
+            last_error: probe_result.error.clone(),
+            result: existing.and_then(|e| e.result),
+        }
+    };
+    let _ = write_cache(&entry);
+
+    Ok(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+    use tempfile::TempDir;
+
+    fn ok_result() -> CursorProbeResult {
+        CursorProbeResult {
+            slugs: vec!["gpt-5.5-high".to_string()],
+            model_probe_success: true,
+            error: None,
+        }
+    }
+
+    fn fail_result() -> CursorProbeResult {
+        CursorProbeResult {
+            model_probe_success: false,
+            error: Some("boom".to_string()),
+            ..CursorProbeResult::default()
+        }
+    }
+
+    fn entry(fetched_at: u64, result: Option<CursorProbeResult>) -> ProbeCacheEntry {
+        ProbeCacheEntry {
+            schema_version: SCHEMA_VERSION,
+            fetched_at,
+            last_attempt_at: fetched_at,
+            last_error: None,
+            result,
+        }
+    }
+
+    fn cache_file(temp: &TempDir) -> PathBuf {
+        temp.path().join("availability").join("cursor-probe.json")
+    }
+
+    fn write_entry(path: &Path, entry: &ProbeCacheEntry) {
+        write_cache_at(path, entry).unwrap();
+    }
+
+    #[test]
+    fn fresh_hit_returns_cached_result() {
+        let temp = TempDir::new().unwrap();
+        let path = cache_file(&temp);
+        write_entry(&path, &entry(now_unix_secs(), Some(ok_result())));
+
+        let outcome = probe_cached_impl(false, &Some(path), fail_result, || Ok(()));
+        assert!(matches!(outcome, CachedCursorProbeOutcome::Hit(_)));
+        assert_eq!(outcome.result().unwrap().slugs[0], "gpt-5.5-high");
+    }
+
+    #[test]
+    fn stale_entry_returns_stale_outcome() {
+        let temp = TempDir::new().unwrap();
+        let path = cache_file(&temp);
+        write_entry(&path, &entry(1, Some(ok_result())));
+
+        let outcome = probe_cached_impl(false, &Some(path), fail_result, || Ok(()));
+        assert!(matches!(outcome, CachedCursorProbeOutcome::Stale(_)));
+    }
+
+    #[test]
+    fn stale_cache_preserved_on_failed_probe() {
+        let temp = TempDir::new().unwrap();
+        let path = cache_file(&temp);
+        write_entry(&path, &entry(1, Some(ok_result())));
+
+        let outcome = probe_cached_impl(false, &Some(path.clone()), fail_result, || Ok(()));
+
+        assert!(matches!(outcome, CachedCursorProbeOutcome::Stale(_)));
+
+        let on_disk = read_cache_tolerant_at(&path).unwrap();
+        assert!(on_disk.result.as_ref().unwrap().model_probe_success);
+        assert_eq!(on_disk.fetched_at, 1);
+    }
+
+    #[test]
+    fn missing_cache_runs_synchronous_probe() {
+        let temp = TempDir::new().unwrap();
+        let path = cache_file(&temp);
+        let called = Cell::new(false);
+        let outcome = probe_cached_impl(
+            false,
+            &Some(path.clone()),
+            || {
+                called.set(true);
+                ok_result()
+            },
+            || Ok(()),
+        );
+
+        assert!(called.get());
+        assert!(matches!(outcome, CachedCursorProbeOutcome::Miss(_)));
+        assert!(read_cache_tolerant_at(&path).is_some());
+    }
+
+    #[test]
+    fn invalid_json_is_cache_miss() {
+        let temp = TempDir::new().unwrap();
+        let path = cache_file(&temp);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "not json").unwrap();
+
+        let outcome = probe_cached_impl(false, &Some(path), ok_result, || Ok(()));
+        assert!(matches!(outcome, CachedCursorProbeOutcome::Miss(_)));
+    }
+
+    #[test]
+    fn incompatible_schema_is_cache_miss() {
+        let temp = TempDir::new().unwrap();
+        let path = cache_file(&temp);
+        let mut old = entry(now_unix_secs(), Some(ok_result()));
+        old.schema_version = 999;
+        write_entry(&path, &old);
+
+        let outcome = probe_cached_impl(false, &Some(path), ok_result, || Ok(()));
+        assert!(matches!(outcome, CachedCursorProbeOutcome::Miss(_)));
+    }
+
+    #[test]
+    fn future_fetched_at_is_stale() {
+        let future = entry(now_unix_secs() + 3600, Some(ok_result()));
+        assert!(!is_fresh(&future));
+    }
+
+    #[test]
+    fn ttl_override_controls_freshness() {
+        let _guard = EnvGuard::set("MARS_PROBE_CACHE_TTL_SECS", "9999");
+        let recent = entry(now_unix_secs().saturating_sub(10), Some(ok_result()));
+        assert!(is_fresh(&recent));
+    }
+
+    #[test]
+    fn write_failure_degrades_gracefully() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("availability");
+        std::fs::write(&path, "file blocks directory").unwrap();
+        let blocked = path.join("cursor-probe.json");
+
+        let outcome = probe_cached_impl(false, &Some(blocked), ok_result, || Ok(()));
+        assert!(matches!(outcome, CachedCursorProbeOutcome::Miss(_)));
+    }
+
+    struct EnvGuard {
+        key: &'static str,
+        prev: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let prev = std::env::var_os(key);
+            unsafe { std::env::set_var(key, value) };
+            Self { key, prev }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            if let Some(prev) = &self.prev {
+                unsafe { std::env::set_var(self.key, prev) };
+            } else {
+                unsafe { std::env::remove_var(self.key) };
+            }
+        }
+    }
+}

--- a/src/models/probes/mod.rs
+++ b/src/models/probes/mod.rs
@@ -1,10 +1,15 @@
 use std::collections::HashSet;
 
+pub mod cursor;
+pub mod cursor_cache;
 pub mod opencode;
 pub mod opencode_cache;
 pub mod pi;
 pub mod pi_cache;
 
+pub use cursor::{
+    CursorProbeResult, probe as probe_cursor, probe_with_timeout as probe_cursor_with_timeout,
+};
 pub use opencode::{OpenCodeProbeResult, probe, probe_with_timeout};
 pub use pi::{PiProbeResult, probe as probe_pi, probe_with_timeout as probe_pi_with_timeout};
 
@@ -12,4 +17,10 @@ pub use pi::{PiProbeResult, probe as probe_pi, probe_with_timeout as probe_pi_wi
 /// Returns false if offline or opencode is not installed.
 pub fn should_probe_opencode(installed: &HashSet<String>, is_offline: bool) -> bool {
     !is_offline && installed.contains("opencode")
+}
+
+/// Determine whether a cursor probe should be attempted.
+/// Returns false if offline or cursor is not installed.
+pub fn should_probe_cursor(installed: &HashSet<String>, is_offline: bool) -> bool {
+    !is_offline && installed.contains("cursor")
 }

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -6,6 +6,7 @@ pub mod slug;
 
 use crate::models;
 use crate::models::harness::HarnessOrderFailure;
+use crate::models::probes::CursorProbeResult;
 use crate::models::probes::OpenCodeProbeResult;
 use crate::models::probes::PiProbeResult;
 
@@ -162,6 +163,7 @@ pub struct RoutingInput<'a> {
     pub linked_harnesses: Option<&'a [String]>,
     pub opencode_probe_result: Option<&'a OpenCodeProbeResult>,
     pub pi_probe_result: Option<&'a PiProbeResult>,
+    pub cursor_probe_result: Option<&'a CursorProbeResult>,
 }
 
 /// Evaluate all candidates and return a routing trace.
@@ -684,6 +686,53 @@ where
     }
 
     if harness == "cursor" {
+        let Some(cursor_probe) = input.cursor_probe_result else {
+            return passthrough_assessment(harness);
+        };
+        if !cursor_probe.model_probe_success {
+            return passthrough_assessment(harness);
+        }
+        if cursor_probe.slugs.is_empty() {
+            return passthrough_assessment(harness);
+        }
+
+        let normalized_model = crate::models::probes::cursor::normalize_slug(input.model_id);
+        if cursor_probe
+            .slugs
+            .iter()
+            .any(|slug| crate::models::probes::cursor::normalize_slug(slug) == normalized_model)
+        {
+            return CandidateAssessment {
+                harness: harness.to_string(),
+                installed: true,
+                candidate_slugs: vec![input.model_id.to_string()],
+                filtered_slugs: vec![input.model_id.to_string()],
+                chosen_slug: Some(input.model_id.to_string()),
+                chosen_model: Some(input.model_id.to_string()),
+                match_evidence: Some(MatchEvidence::Confirmed),
+                skip_reason: None,
+            };
+        }
+
+        let matches = crate::models::probes::cursor::find_cursor_prefix_matches(
+            input.model_id,
+            &cursor_probe.slugs,
+        );
+        if !matches.is_empty() {
+            let candidate_slugs: Vec<String> =
+                matches.iter().map(|slug| (*slug).to_string()).collect();
+            return CandidateAssessment {
+                harness: harness.to_string(),
+                installed: true,
+                candidate_slugs: candidate_slugs.clone(),
+                filtered_slugs: candidate_slugs,
+                chosen_slug: Some(input.model_id.to_string()),
+                chosen_model: Some(input.model_id.to_string()),
+                match_evidence: Some(MatchEvidence::Confirmed),
+                skip_reason: None,
+            };
+        }
+
         return CandidateAssessment {
             harness: harness.to_string(),
             installed: true,
@@ -691,8 +740,8 @@ where
             filtered_slugs: Vec::new(),
             chosen_slug: None,
             chosen_model: None,
-            match_evidence: Some(MatchEvidence::Passthrough),
-            skip_reason: None,
+            match_evidence: None,
+            skip_reason: Some("no_model_match"),
         };
     }
 
@@ -705,6 +754,19 @@ where
         chosen_model: None,
         match_evidence: None,
         skip_reason: Some("unsupported_candidate"),
+    }
+}
+
+fn passthrough_assessment(harness: &str) -> CandidateAssessment {
+    CandidateAssessment {
+        harness: harness.to_string(),
+        installed: true,
+        candidate_slugs: Vec::new(),
+        filtered_slugs: Vec::new(),
+        chosen_slug: None,
+        chosen_model: None,
+        match_evidence: Some(MatchEvidence::Passthrough),
+        skip_reason: None,
     }
 }
 
@@ -954,7 +1016,11 @@ mod tests {
         false
     }
 
-    type ProbeInputs<'a> = (Option<&'a OpenCodeProbeResult>, Option<&'a PiProbeResult>);
+    type ProbeInputs<'a> = (
+        Option<&'a OpenCodeProbeResult>,
+        Option<&'a PiProbeResult>,
+        Option<&'a CursorProbeResult>,
+    );
 
     fn routing_input<'a>(
         model_id: &'a str,
@@ -965,7 +1031,7 @@ mod tests {
         linked_harnesses: Option<&'a [String]>,
         probe_inputs: ProbeInputs<'a>,
     ) -> RoutingInput<'a> {
-        let (opencode_probe_result, pi_probe_result) = probe_inputs;
+        let (opencode_probe_result, pi_probe_result, cursor_probe_result) = probe_inputs;
         RoutingInput {
             model_id,
             provider_for_order,
@@ -977,6 +1043,7 @@ mod tests {
             linked_harnesses,
             opencode_probe_result,
             pi_probe_result,
+            cursor_probe_result,
         }
     }
 
@@ -990,7 +1057,7 @@ mod tests {
             None,
             &installed,
             None,
-            (None, None),
+            (None, None, None),
         );
 
         let trace = evaluate_candidates_with_auth(&input, always_authed);
@@ -1012,7 +1079,7 @@ mod tests {
             None,
             &installed,
             None,
-            (None, None),
+            (None, None, None),
         );
 
         let trace = evaluate_candidates_with_auth(&input, never_authed);
@@ -1040,13 +1107,128 @@ mod tests {
             None,
             &installed,
             None,
-            (None, None),
+            (None, None, None),
         );
 
         let trace = evaluate_candidates_with_auth(&input, never_authed);
 
         assert_eq!(trace.harness, "cursor");
         assert_eq!(trace.match_evidence, MatchEvidence::Passthrough);
+    }
+
+    #[test]
+    fn cursor_with_no_probe_falls_back_to_passthrough() {
+        let installed = installed(&["cursor"]);
+        let input = routing_input(
+            "gpt-5.5",
+            Some("openai"),
+            None,
+            None,
+            &installed,
+            None,
+            (None, None, None),
+        );
+
+        let trace = evaluate_candidates_with_auth(&input, never_authed);
+        assert_eq!(trace.harness, "cursor");
+        assert_eq!(trace.match_evidence, MatchEvidence::Passthrough);
+    }
+
+    #[test]
+    fn cursor_prefix_match_returns_confirmed_with_candidate_slugs() {
+        let installed = installed(&["cursor"]);
+        let cursor_probe = CursorProbeResult {
+            slugs: vec!["gpt-5.5-high".to_string(), "gpt-5.5-low".to_string()],
+            model_probe_success: true,
+            error: None,
+        };
+        let input = routing_input(
+            "gpt-5.5",
+            Some("openai"),
+            None,
+            None,
+            &installed,
+            None,
+            (None, None, Some(&cursor_probe)),
+        );
+
+        let trace = evaluate_candidates_with_auth(&input, never_authed);
+        assert_eq!(trace.harness, "cursor");
+        assert_eq!(trace.match_evidence, MatchEvidence::Confirmed);
+        let cursor_assessment = trace
+            .assessments
+            .iter()
+            .find(|assessment| assessment.harness == "cursor")
+            .expect("cursor assessment should exist");
+        assert_eq!(
+            cursor_assessment.candidate_slugs,
+            vec!["gpt-5.5-high".to_string(), "gpt-5.5-low".to_string()]
+        );
+        assert_eq!(cursor_assessment.chosen_slug.as_deref(), Some("gpt-5.5"));
+    }
+
+    #[test]
+    fn cursor_exact_match_returns_confirmed() {
+        let installed = installed(&["cursor"]);
+        let cursor_probe = CursorProbeResult {
+            slugs: vec!["gpt-5.5".to_string(), "gpt-5.5-high".to_string()],
+            model_probe_success: true,
+            error: None,
+        };
+        let input = routing_input(
+            "gpt-5.5",
+            Some("openai"),
+            None,
+            None,
+            &installed,
+            None,
+            (None, None, Some(&cursor_probe)),
+        );
+
+        let trace = evaluate_candidates_with_auth(&input, never_authed);
+        assert_eq!(trace.harness, "cursor");
+        assert_eq!(trace.match_evidence, MatchEvidence::Confirmed);
+        let cursor_assessment = trace
+            .assessments
+            .iter()
+            .find(|assessment| assessment.harness == "cursor")
+            .expect("cursor assessment should exist");
+        assert_eq!(
+            cursor_assessment.candidate_slugs,
+            vec!["gpt-5.5".to_string()]
+        );
+        assert_eq!(cursor_assessment.chosen_slug.as_deref(), Some("gpt-5.5"));
+    }
+
+    #[test]
+    fn cursor_no_match_falls_through() {
+        let installed = installed(&["cursor"]);
+        let cursor_probe = CursorProbeResult {
+            slugs: vec!["claude-opus-4-7-high".to_string()],
+            model_probe_success: true,
+            error: None,
+        };
+        let input = routing_input(
+            "gpt-5.5",
+            Some("openai"),
+            None,
+            None,
+            &installed,
+            None,
+            (None, None, Some(&cursor_probe)),
+        );
+
+        let trace = evaluate_candidates_with_auth(&input, never_authed);
+        assert_eq!(trace.harness, "pi");
+        assert_eq!(trace.selection_kind, SelectionKind::HardcodedDefault);
+        assert_eq!(
+            trace
+                .assessments
+                .iter()
+                .find(|assessment| assessment.harness == "cursor")
+                .and_then(|assessment| assessment.skip_reason),
+            Some("no_model_match")
+        );
     }
 
     #[test]
@@ -1064,7 +1246,7 @@ mod tests {
             None,
             &installed,
             None,
-            (None, Some(&pi_probe)),
+            (None, Some(&pi_probe), None),
         );
 
         let trace = evaluate_candidates_with_auth(&input, never_authed);
@@ -1097,6 +1279,7 @@ mod tests {
             linked_harnesses: None,
             opencode_probe_result: Some(&opencode_probe),
             pi_probe_result: Some(&pi_probe),
+            cursor_probe_result: None,
         };
 
         let trace = evaluate_candidates_with_auth(&input, never_authed);
@@ -1132,6 +1315,7 @@ mod tests {
             linked_harnesses: None,
             opencode_probe_result: None,
             pi_probe_result: Some(&pi_probe),
+            cursor_probe_result: None,
         };
 
         let trace = evaluate_candidates_with_auth(&input, always_authed);
@@ -1180,6 +1364,7 @@ mod tests {
             linked_harnesses: None,
             opencode_probe_result: Some(&probe),
             pi_probe_result: None,
+            cursor_probe_result: None,
         };
 
         let trace = evaluate_candidates_with_auth(&input, never_authed);
@@ -1206,7 +1391,7 @@ mod tests {
             None,
             &installed,
             None,
-            (None, Some(&pi_probe)),
+            (None, Some(&pi_probe), None),
         );
 
         let trace = evaluate_candidates_with_auth(&input, never_authed);
@@ -1237,7 +1422,7 @@ mod tests {
             None,
             &installed,
             None,
-            (Some(&probe), None),
+            (Some(&probe), None, None),
         );
 
         let trace = evaluate_candidates_with_auth(&input, never_authed);
@@ -1261,7 +1446,7 @@ mod tests {
             None,
             &installed,
             None,
-            (Some(&probe), None),
+            (Some(&probe), None, None),
         );
 
         let trace = evaluate_candidates_with_auth(&input, never_authed);
@@ -1289,7 +1474,7 @@ mod tests {
             None,
             &installed,
             Some(&linked_harnesses),
-            (None, None),
+            (None, None, None),
         );
 
         let trace = evaluate_candidates_with_auth(&input, always_authed);
@@ -1309,7 +1494,7 @@ mod tests {
             None,
             &installed,
             None,
-            (None, None),
+            (None, None, None),
         );
 
         let trace = evaluate_candidates_with_auth(&input, always_authed);
@@ -1330,7 +1515,7 @@ mod tests {
             None,
             &installed,
             None,
-            (None, None),
+            (None, None, None),
         );
 
         let trace = evaluate_candidates_with_auth(&input, always_authed);
@@ -1355,7 +1540,7 @@ mod tests {
             Some("Pi"),
             &installed,
             None,
-            (None, None),
+            (None, None, None),
         );
 
         let trace = evaluate_candidates_with_auth(&input, never_authed);
@@ -1369,7 +1554,15 @@ mod tests {
     #[test]
     fn uses_hardcoded_pi_fallback_with_warning() {
         let installed = installed(&[]);
-        let input = routing_input("model", None, None, None, &installed, None, (None, None));
+        let input = routing_input(
+            "model",
+            None,
+            None,
+            None,
+            &installed,
+            None,
+            (None, None, None),
+        );
 
         let trace = evaluate_candidates_with_auth(&input, never_authed);
 
@@ -1396,7 +1589,7 @@ mod tests {
             Some("pi"),
             &installed,
             Some(&linked_harnesses),
-            (None, None),
+            (None, None, None),
         );
         let with_default_trace = evaluate_candidates_with_auth(&with_config_default, never_authed);
         assert_eq!(with_default_trace.source, RouteSource::Provider);
@@ -1419,7 +1612,7 @@ mod tests {
             None,
             &installed,
             Some(&linked_harnesses),
-            (None, None),
+            (None, None, None),
         );
         let hardcoded_trace = evaluate_candidates_with_auth(&without_config_default, never_authed);
         assert_eq!(hardcoded_trace.source, RouteSource::Provider);
@@ -1448,7 +1641,7 @@ mod tests {
                 Some("pi"),
                 &installed,
                 Some(&linked_harnesses),
-                (None, None),
+                (None, None, None),
             ),
             never_authed,
         );
@@ -1467,7 +1660,7 @@ mod tests {
             Some("pi"),
             &installed,
             None,
-            (None, None),
+            (None, None, None),
         );
         let assessment = evaluate_fixed_harness_with_auth(&input, "codex", never_authed);
 
@@ -1491,6 +1684,7 @@ mod tests {
             linked_harnesses: None,
             opencode_probe_result: None,
             pi_probe_result: None,
+            cursor_probe_result: None,
         };
 
         let assessment = evaluate_fixed_harness_with_auth(&input, "codex", always_authed);
@@ -1518,6 +1712,7 @@ mod tests {
             linked_harnesses: None,
             opencode_probe_result: None,
             pi_probe_result: None,
+            cursor_probe_result: None,
         };
 
         let assessment = evaluate_fixed_harness_with_auth(&input, "codex", always_authed);
@@ -1542,6 +1737,7 @@ mod tests {
             linked_harnesses: None,
             opencode_probe_result: None,
             pi_probe_result: None,
+            cursor_probe_result: None,
         };
 
         let assessment = evaluate_fixed_harness_with_auth(&input, "claude", always_authed);
@@ -1619,6 +1815,7 @@ mod tests {
             linked_harnesses: None,
             opencode_probe_result: None,
             pi_probe_result: Some(&pi_probe),
+            cursor_probe_result: None,
         };
 
         let trace = evaluate_candidates_with_auth(&input, always_authed);
@@ -1654,6 +1851,7 @@ mod tests {
             linked_harnesses: None,
             opencode_probe_result: None,
             pi_probe_result: Some(&pi_probe),
+            cursor_probe_result: None,
         };
 
         let trace = evaluate_candidates_with_auth(&input, always_authed);


### PR DESCRIPTION
## Why

Cursor was registered as `UniversalPassthrough` in mars-agents, which meant:
- All cursor models reported `availability: unknown`
- `meridian spawn -m gpt-5.5` couldn't route to cursor by slug evidence
- Users needed explicit aliases with `harness = "cursor"` per model

Cursor exposes `cursor agent --list-models`, which provides a live model catalog. This PR enables probe-backed routing.

## Goal

After merge:
- `mars models list` shows cursor models with `availability: runnable` (when cursor is installed)
- Launch bundles include `candidate_slugs` for all prefix-matching catalog entries
- Python-side effort resolution (`--effort high`) can map to `gpt-5.5-high` via the catalog
- No probe result / probe failure / empty catalog → graceful degradation (passthrough, same as before)

## Summary

Implements a full probe-backed cursor model path in mars-agents:
- `cursor.rs`: Probe runs `cursor agent --list-models`, strips ANSI, filters `-fast` slugs, normalizes, and does prefix matching
- `cursor_cache.rs`: TTL cache (same pattern as opencode/pi) with hit/stale/miss/unavailable outcomes and detached background refresh
- Registry: cursor changes from `HarnessClass::UniversalPassthrough` to `HarnessClass::ProbeBacked`
- Routing: prefix matching returns `candidate_slugs` (all matching catalog entries) in the launch bundle; exact match returns confirmed with single slug
- Availability: `classify_cursor` + `CursorProbe`/`CursorProbeNegative`/`CursorProbeUnknown` sources
- Build policy: `cursor_probe_result` threaded through harness/runnable/mod policy layers

## Work Item

cursor-model-probe

## Changes

- New files: `src/models/probes/cursor.rs`, `src/models/probes/cursor_cache.rs`
- Key behavior: slug decomposition NOT used (cursor naming is inconsistent) — raw slugs stored, prefix match used
- `-fast` slugs filtered at probe parse time (design note: fast variants deferred to #256)
- `chosen_slug` in bundle = base model ID (e.g. `gpt-5.5`) — intentional; Python effort resolution uses `candidate_slugs` to produce the final model arg
- Graceful degradation: offline/no-probe/failed-probe/empty-catalog all fall through to passthrough

**Known structural debt (issues filed):**
- #67: Cursor/opencode/pi cache modules share ~90% identical code — refactor to shared `ProbeCache<R>` engine deferred
- #68: `models::probes::cursor` imports from `harness::host` — inverted dependency boundary, fix deferred

## Verification

- `cargo build` ✅
- `cargo test` (1196 unit tests) ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo fmt --check` ✅

## Knowledge Updates

No durable KB updates needed — design documents in `work/cursor-model-probe/` cover the architecture.

## Spawn Trace

- p2261 coder — implemented cursor probe, cache, routing, availability, bundle threading

## Release Label Guide

Set one `release:*` label on this PR:

- `release:patch` or `release:stable` — create the next stable patch release after merge
- `release:rc` — create the next RC release after merge
- `release:skip` — no release for this merge

No `release:*` label means no auto-release.
Unknown `release:*` labels default to RC.

## Post-Merge Automation

After merge to `main`, CI (`.github/workflows/release-on-main.yml`) will:

1. Read the PR release label
2. Skip when no `release:*` label is present or when `release:skip` is present
3. Compute the next stable or RC version from existing `v*` tags
4. Update Cargo/PyPI/npm package versions + promote `CHANGELOG.md` `[Unreleased]`
5. Commit `release: vX.Y.Z` or `release: vX.Y.Z-rc.N`, create/push the matching tag
6. Run `.github/workflows/release.yml` from the tag

## Cleanup

After merge, clean merged worktrees with:

```bash
scripts/prune-worktrees.sh
```