### PR TITLE
Fix target-scoped lock output lookups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,6 +219,14 @@ cargo clippy
 
 Integration tests under `tests/`. Prefer keeping changes localized to one module.
 
+## Pull Requests
+
+When creating or updating a GitHub PR, follow `.github/PULL_REQUEST_TEMPLATE.md`.
+Fill every section with the current branch state: why, goal, summary, work item,
+changes, verification, knowledge updates, spawn trace, release label guidance,
+post-merge automation, and cleanup. Keep the PR body current as the branch
+evolves; update it when verification, knowledge capture, risks, or scope changes.
+
 ## Releasing
 
 Mars releases are CI-owned. Never manually `git tag` or edit version numbers for stable releases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Canonical sync diff uses `.mars` lock outputs, avoiding false local-modified warnings when linked targets store different compiled checksums for the same item path.
+
 ## [0.6.6-rc.1] - 2026-05-23
 
 ### Changed

--- a/docs/internals/lock-file.md
+++ b/docs/internals/lock-file.md
@@ -7,7 +7,7 @@
 TOML format with deterministically sorted keys for clean git diffs.
 
 ```toml
-version = 1
+version = 2
 
 [dependencies.base]
 url = "https://github.com/meridian-flow/meridian-base"
@@ -17,21 +17,32 @@ commit = "abc123def456"
 [dependencies.local]
 path = "/home/dev/my-agents"
 
-[items."agents/coder.md"]
+[items."agent/coder"]
 source = "base"
 kind = "agent"
 version = "v1.2.0"
 source_checksum = "sha256:aaa111..."
-installed_checksum = "sha256:bbb222..."
-dest_path = "agents/coder.md"
 
-[items."skills/review"]
+[[items."agent/coder".outputs]]
+target_root = ".mars"
+dest_path = "agents/coder.md"
+installed_checksum = "sha256:bbb222..."
+
+[[items."agent/coder".outputs]]
+target_root = ".codex"
+dest_path = "agents/coder.md"
+installed_checksum = "sha256:ccc333..."
+
+[items."skill/review"]
 source = "base"
 kind = "skill"
 version = "v1.2.0"
-source_checksum = "sha256:ccc333..."
-installed_checksum = "sha256:ddd444..."
+source_checksum = "sha256:ddd444..."
+
+[[items."skill/review".outputs]]
+target_root = ".mars"
 dest_path = "skills/review"
+installed_checksum = "sha256:eee555..."
 ```
 
 ## Schema
@@ -42,7 +53,7 @@ dest_path = "skills/review"
 |---|---|---|
 | `version` | integer | Schema version (`2` is current; `1` is legacy) |
 | `dependencies` | table | Resolved source entries |
-| `items` | table | Installed items with checksums |
+| `items` | table | Logical items with source checksums and per-target output records |
 
 ### `[dependencies.<name>]`
 
@@ -56,9 +67,9 @@ Resolved provenance for each source. Built from the resolved dependency graph, n
 | `commit` | string | Git source | Resolved commit hash |
 | `tree_hash` | string | *(reserved)* | Future: deterministic tree hash for verification |
 
-### `[items."<dest_path>"]`
+### `[items."<kind/name>"]`
 
-Each item key is the destination path relative to the managed root (e.g., `agents/coder.md`, `skills/review`).
+Each item key is the logical item identity (e.g., `agent/coder`, `skill/review`).
 
 | Field | Type | Description |
 |---|---|---|
@@ -66,8 +77,17 @@ Each item key is the destination path relative to the managed root (e.g., `agent
 | `kind` | string | `"agent"` or `"skill"` |
 | `version` | string? | Version from the source's resolved graph node |
 | `source_checksum` | string | SHA-256 of the original source content |
-| `installed_checksum` | string | SHA-256 of what Mars wrote to disk |
-| `dest_path` | string | Destination path (same as the key) |
+| `outputs` | array | Per-target materialized outputs |
+
+### `[[items."<kind/name>".outputs]]`
+
+Each output is one path Mars materialized under one target root.
+
+| Field | Type | Description |
+|---|---|---|
+| `target_root` | string | Target directory, such as `.mars`, `.codex`, `.pi`, or `.agents` |
+| `dest_path` | string | Destination path relative to `target_root` |
+| `installed_checksum` | string | SHA-256 of what Mars wrote to that output |
 
 ## Dual Checksums
 
@@ -75,11 +95,11 @@ Each item tracks two checksums:
 
 - **`source_checksum`**: Hash of the content as it exists in the source tree, before any transformations. Used to detect when the source has changed (new version, upstream edit).
 
-- **`installed_checksum`**: Hash of what Mars actually wrote to disk. May differ from `source_checksum` when frontmatter rewriting occurred (`frontmatter` is the YAML metadata block at the top of Markdown agent/skill files; Mars may rewrite skill references there). Used to detect when the user has modified the file locally.
+- **`installed_checksum`**: Hash of what Mars actually wrote to one output. May differ from `source_checksum` when frontmatter rewriting or native-target lowering occurred. Used to detect whether that exact output changed locally.
 
 This dual-checksum design enables the [conflict diff](conflicts.md#diff-matrix):
 - Source changed? → compare new source hash against `source_checksum`
-- Local changed? → compare current disk hash against `installed_checksum`
+- Local changed? → compare current disk hash against the `installed_checksum` for the same `(target_root, dest_path)`
 
 ## Checksums
 
@@ -95,12 +115,15 @@ Project-local agents and skills — those in `.mars-src/` or, for source package
 [dependencies._self]
 path = "."
 
-[items."skills/local-skill"]
+[items."skill/local-skill"]
 source = "_self"
 kind = "skill"
 source_checksum = "sha256:..."
-installed_checksum = "sha256:..."
+
+[[items."skill/local-skill".outputs]]
+target_root = ".mars"
 dest_path = "skills/local-skill"
+installed_checksum = "sha256:..."
 ```
 
 ## Lock v2 and per-target outputs
@@ -113,7 +136,9 @@ Current locks use `version = 2`. Items are keyed by stable id (e.g. `agent/coder
 | `dest_path` | Path relative to that target root |
 | `installed_checksum` | SHA-256 of content at that target path |
 
-Mars may delete or overwrite a path in a linked target only when the previous lock contains a matching `(target_root, dest_path)`. The same `dest_path` under `.mars` does not imply ownership under `.cursor`. See `src/target_sync/.context/CONTEXT.md`.
+Mars may delete or overwrite a path in a linked target only when the previous lock contains a matching `(target_root, dest_path)`. The same `dest_path` under `.mars` does not imply ownership under `.cursor`.
+
+The same rule applies to divergence checks. Canonical sync diff compares `.mars/` disk content only with `.mars` output records. Linked/native targets may have different compiled bytes and different `installed_checksum` values for the same relative `dest_path`. See `src/lock/.context/CONTEXT.md` and `src/target_sync/.context/CONTEXT.md`.
 
 ## Building the Lock
 

--- a/src/cli/adopt.rs
+++ b/src/cli/adopt.rs
@@ -67,7 +67,7 @@ pub fn run(args: &AdoptArgs, ctx: &MarsContext, json: bool) -> Result<i32, MarsE
             ),
         }
     })?;
-    if lock.contains_dest_path(&target_dest) {
+    if lock.contains_output(&target_name, target_dest.as_str()) {
         return Err(MarsError::InvalidRequest {
             message: format!(
                 "{source_display} is already managed by Mars (target `{target_name}` item `{}`)",

--- a/src/lock/.context/CONTEXT.md
+++ b/src/lock/.context/CONTEXT.md
@@ -1,0 +1,114 @@
+# src/lock/ — Target-Scoped Lock Outputs
+
+`mars.lock` is the ownership registry for managed content. Lock v2 stores one
+logical item with one or more output records. Every output record is scoped by
+the target root that received it.
+
+## Contracts
+
+### Output identity is `(target_root, dest_path)`
+
+`OutputRecord` has three fields that must be interpreted together:
+
+| Field | Meaning |
+|---|---|
+| `target_root` | Directory Mars materialized into, such as `.mars`, `.codex`, `.pi`, `.agents` |
+| `dest_path` | Path relative to that target root, such as `skills/planning` |
+| `installed_checksum` | Hash of the bytes installed at that exact output |
+
+The pair `(target_root, dest_path)` is the stable identity of an installed
+output. `dest_path` alone is not unique once a project has multiple targets.
+
+Native targets can lower the same source skill differently. A single skill can
+therefore have multiple valid installed checksums:
+
+```toml
+[[items."skill/planning".outputs]]
+target_root = ".mars"
+dest_path = "skills/planning"
+installed_checksum = "sha256:canonical..."
+
+[[items."skill/planning".outputs]]
+target_root = ".pi"
+dest_path = "skills/planning"
+installed_checksum = "sha256:pi-projected..."
+```
+
+### `LockIndex` is the read seam
+
+`LockFile` preserves the persisted schema. `LockIndex` provides hot lookup
+views over that schema:
+
+| Method | Use |
+|---|---|
+| `find_output(target_root, dest_path)` | Diff, mutation, collision, and carry-forward checks for one concrete target |
+| `contains_output(target_root, dest_path)` | Ownership checks for one concrete target |
+| `find_by_dest_path(dest_path)` | Broad/legacy lookup where target root is intentionally irrelevant |
+| `contains_dest_path(dest_path)` | Broad/legacy existence check |
+
+New code that reasons about disk content under a target root should start with
+the target-scoped methods. Unscoped methods are safe only when the caller is not
+deciding ownership, modification status, or mutation permission for a concrete
+target path.
+
+### Canonical sync diff reads canonical outputs
+
+Phase 4 sync diff compares the `.mars/` canonical store against the old lock.
+It must use `.mars` output records:
+
+```text
+disk: .mars/skills/planning
+lock: target_root = ".mars", dest_path = "skills/planning"
+```
+
+Comparing `.mars/skills/planning` to a `.pi` or `.codex` output checksum is
+incorrect because those outputs may be valid target-specific projections. The
+symptom is a false `disk-lock-divergent` / local-modified warning immediately
+after a clean sync.
+
+### Linked-target mutation uses the same identity
+
+Linked-target deletion, overwrite, and orphan cleanup use the same
+`(target_root, dest_path)` ownership contract. See
+`../../target_sync/.context/CONTEXT.md` for the mutation-side rules.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    LockFile["LockFile v2 schema"]
+    Item["LockedItemV2 logical item"]
+    Outputs["OutputRecord[]"]
+    Index["LockIndex"]
+    Canonical["sync::diff .mars check"]
+    TargetSync["target_sync ownership checks"]
+    CLI["CLI ownership checks"]
+
+    LockFile --> Item --> Outputs --> Index
+    Index -->|find_output .mars + dest| Canonical
+    Index -->|contains_output target + dest| TargetSync
+    Index -->|contains_output target + dest| CLI
+```
+
+The lock module should not know how each target lowers content. It only records
+the outputs and provides target-scoped lookup semantics. Compiler and target
+sync code decide what bytes to produce; lock lookup decides which recorded
+checksum applies to the target being inspected.
+
+## Rationale
+
+The v2 schema already models per-target outputs. The bug class comes from
+flattening those outputs into a `dest_path -> output` map and letting duplicate
+paths overwrite each other. Sorting can make a later target win, so canonical
+diff may read a linked/native target checksum even when `.mars` is clean.
+
+Keeping the schema unchanged and fixing the ephemeral index preserves lock-file
+compatibility while making the read model match the schema model.
+
+## Patterns
+
+- Use `CANONICAL_TARGET_ROOT` when the caller is checking `.mars/`.
+- Use the configured target name when checking a linked/native target.
+- Use `canonical_flat_items()` for `.mars`-only orphan scans.
+- Use `flat_items_for_target(target_root)` for target-scoped listing.
+- Use `flat_items()` only when the caller deliberately wants every output.

--- a/src/lock/AGENTS.md
+++ b/src/lock/AGENTS.md
@@ -1,0 +1,52 @@
+# src/lock/ — Lock Ownership Registry
+
+`src/lock/` owns the `mars.lock` schema, migration, persistence, and lookup
+views. Treat the lock as Mars's ownership registry: it records which logical
+items Mars manages, which outputs were materialized, and which target root owns
+each output path.
+
+## Mental Model
+
+Lock v2 separates a logical item from its materialized outputs:
+
+```text
+items."skill/planning"
+  source_checksum          # source-tree content
+  outputs[]
+    target_root = ".mars"  # canonical store output
+    dest_path = "skills/planning"
+    installed_checksum     # bytes at that target output
+```
+
+The same `dest_path` may appear under multiple `target_root`s. Native targets
+can compile the same skill into different bytes, so `.mars/skills/foo` and
+`.pi/skills/foo` are different ownership records even though their relative
+paths match.
+
+## Key Rules
+
+- **Target root is part of output identity.** Mutation, diff, collision, and
+  carry-forward paths must use `(target_root, dest_path)` lookups.
+- **Canonical sync diff is `.mars`-scoped.** Comparing `.mars/` disk content to
+  a `.pi`, `.codex`, or `.opencode` checksum creates false local-modified
+  warnings.
+- **Unscoped `dest_path` views are broad views only.** Use them for listing,
+  diagnostics, or legacy compatibility, not for deciding whether a concrete
+  target path is owned or unchanged.
+- **Do not change the lock schema for lookup fixes.** `LockIndex` is the
+  ephemeral seam for efficient read shapes over the persisted v2 schema.
+- **Keep path comparisons separator-tolerant.** `DestPath` uses forward-slash
+  canonical form; lookup normalization preserves Windows compatibility.
+
+## Anti-Patterns
+
+- Keying lock outputs only by `dest_path` when target-specific checksums matter.
+- Treating a `.mars` output as authorization to mutate a linked/native target.
+- Scanning target directories and deleting unknown paths.
+- Routing library warnings directly to stderr instead of diagnostics.
+
+## Entry Points
+
+- `mod.rs` — schema types, load/write, v1 promotion, lock build, `LockIndex`.
+- `.context/CONTEXT.md` — target-scoped lookup contracts and rationale.
+- `../target_sync/.context/CONTEXT.md` — linked-target mutation ownership rules.

--- a/src/lock/mod.rs
+++ b/src/lock/mod.rs
@@ -180,25 +180,33 @@ impl LockFile {
 /// at hot call sites that need repeated output-path lookups.
 pub struct LockIndex<'a> {
     lock: &'a LockFile,
+    by_output: HashMap<(String, String), (&'a str, usize)>,
     by_dest_path: HashMap<String, (&'a str, usize)>,
 }
 
 impl<'a> LockIndex<'a> {
     pub fn new(lock: &'a LockFile) -> Self {
-        let by_dest_path = lock
-            .items
-            .iter()
-            .flat_map(|(key, item)| {
-                item.outputs.iter().enumerate().map(move |(idx, output)| {
-                    (
-                        normalize_dest_path(output.dest_path.as_str()),
-                        (key.as_str(), idx),
-                    )
-                })
-            })
-            .collect();
+        let mut by_output = HashMap::new();
+        let mut by_dest_path = HashMap::new();
 
-        Self { lock, by_dest_path }
+        for (key, item) in &lock.items {
+            for (idx, output) in item.outputs.iter().enumerate() {
+                let normalized_dest = normalize_dest_path(output.dest_path.as_str());
+                by_dest_path
+                    .entry(normalized_dest.clone())
+                    .or_insert((key.as_str(), idx));
+                by_output.insert(
+                    (output.target_root.clone(), normalized_dest),
+                    (key.as_str(), idx),
+                );
+            }
+        }
+
+        Self {
+            lock,
+            by_output,
+            by_dest_path,
+        }
     }
 
     /// Look up a locked item by output dest_path, returning a flat [`LockedItem`] view.
@@ -206,6 +214,27 @@ impl<'a> LockIndex<'a> {
         let (item_key, output_idx) = *self
             .by_dest_path
             .get(&normalize_dest_path(dest_path.as_str()))?;
+        self.locked_item_for(item_key, output_idx)
+    }
+
+    /// Look up a locked output by target root + dest_path, returning a flat [`LockedItem`] view.
+    pub fn find_output(&self, target_root: &str, dest_path: &DestPath) -> Option<LockedItem> {
+        let (item_key, output_idx) = *self.by_output.get(&(
+            target_root.to_string(),
+            normalize_dest_path(dest_path.as_str()),
+        ))?;
+        self.locked_item_for(item_key, output_idx)
+    }
+
+    /// Whether any output is recorded for `target_root + dest_path`.
+    pub fn contains_output(&self, target_root: &str, dest_path: &DestPath) -> bool {
+        self.by_output.contains_key(&(
+            target_root.to_string(),
+            normalize_dest_path(dest_path.as_str()),
+        ))
+    }
+
+    fn locked_item_for(&self, item_key: &str, output_idx: usize) -> Option<LockedItem> {
         let item_v2 = self.lock.items.get(item_key)?;
         let output = item_v2.outputs.get(output_idx)?;
         Some(LockedItem {
@@ -547,7 +576,9 @@ pub fn build(
                     } else {
                         // Fall back: search old lock by dest_path (handles v1→v2 migrations
                         // where item_key may not match yet)
-                        if let Some(flat) = old_lock_index.find_by_dest_path(&outcome.dest_path) {
+                        if let Some(flat) =
+                            old_lock_index.find_output(CANONICAL_TARGET_ROOT, &outcome.dest_path)
+                        {
                             let key =
                                 format!("{}/{}", flat.kind, outcome.dest_path.item_name(flat.kind));
                             items.entry(key).or_insert_with(|| LockedItemV2 {
@@ -571,7 +602,9 @@ pub fn build(
                 let item_key = item_key(&outcome.item_id);
                 if let Some(old_item) = old_lock.items.get(&item_key) {
                     items.insert(item_key, old_item.clone());
-                } else if let Some(flat) = old_lock_index.find_by_dest_path(&outcome.dest_path) {
+                } else if let Some(flat) =
+                    old_lock_index.find_output(CANONICAL_TARGET_ROOT, &outcome.dest_path)
+                {
                     let key = format!("{}/{}", flat.kind, outcome.dest_path.item_name(flat.kind));
                     items.entry(key).or_insert_with(|| LockedItemV2 {
                         source: flat.source,
@@ -1140,6 +1173,36 @@ installed_checksum = "sha256:222"
 
         assert!(index.contains_dest_path(&DestPath::from("agents/coder.md")));
         assert!(!index.contains_dest_path(&DestPath::from("agents/nobody.md")));
+    }
+
+    #[test]
+    fn lock_index_target_scoped_lookup_distinguishes_same_dest_path() {
+        let mut lock = sample_lock();
+        lock.items
+            .get_mut("agent/coder")
+            .unwrap()
+            .outputs
+            .push(OutputRecord {
+                target_root: ".pi".to_string(),
+                dest_path: "agents/coder.md".into(),
+                installed_checksum: "sha256:pi".into(),
+            });
+
+        let index = LockIndex::new(&lock);
+        let dest = DestPath::from("agents/coder.md");
+
+        let mars = index
+            .find_output(".mars", &dest)
+            .expect("expected canonical .mars output");
+        let pi = index
+            .find_output(".pi", &dest)
+            .expect("expected .pi output");
+
+        assert_eq!(mars.installed_checksum, "sha256:bbb");
+        assert_eq!(pi.installed_checksum, "sha256:pi");
+        assert!(index.contains_output(".mars", &dest));
+        assert!(index.contains_output(".pi", &dest));
+        assert!(!index.contains_output(".cursor", &dest));
     }
 
     #[test]

--- a/src/sync/diff.rs
+++ b/src/sync/diff.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use crate::error::MarsError;
 use crate::hash;
-use crate::lock::{LockFile, LockIndex, LockedItem};
+use crate::lock::{CANONICAL_TARGET_ROOT, LockFile, LockIndex, LockedItem};
 use crate::sync::target::{TargetItem, TargetState};
 use crate::types::ContentHash;
 
@@ -61,7 +61,9 @@ pub fn compute(
 
     // Process each target item
     for (_dest_key, target_item) in &target.items {
-        if let Some(locked_item) = lock_index.find_by_dest_path(&target_item.dest_path) {
+        if let Some(locked_item) =
+            lock_index.find_output(CANONICAL_TARGET_ROOT, &target_item.dest_path)
+        {
             // Item exists in lock — compare checksums
             let source_changed = target_item.source_hash != locked_item.source_checksum
                 || rewritten_installed_checksum(target_item)
@@ -140,7 +142,7 @@ pub fn compute(
     }
 
     // Find orphans: items in lock but not in target
-    for (dest_path, locked_item) in lock.flat_items() {
+    for (dest_path, locked_item) in lock.canonical_flat_items() {
         if !target.items.contains_key(&dest_path) {
             items.push(DiffEntry::Orphan {
                 locked: locked_item,
@@ -628,6 +630,69 @@ mod tests {
 
         let forced = compute(root.path(), &lock, &target, true).unwrap();
         assert!(matches!(&forced.items[0], DiffEntry::LocalModified { .. }));
+    }
+
+    #[test]
+    fn canonical_diff_ignores_non_canonical_output_checksum() {
+        let root = TempDir::new().unwrap();
+        let canonical_content = b"# canonical";
+        let canonical_hash = hash::hash_bytes(canonical_content);
+        let pi_hash = hash::hash_bytes(b"# pi rewrite");
+
+        let agents_dir = root.path().join("agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+        fs::write(agents_dir.join("coder.md"), canonical_content).unwrap();
+
+        let mut target_items = IndexMap::new();
+        target_items.insert(
+            "agents/coder.md".into(),
+            make_target_item(
+                "coder",
+                ItemKind::Agent,
+                &canonical_hash,
+                PathBuf::from("/tmp/source/agents/coder.md"),
+            ),
+        );
+        let target = TargetState {
+            items: target_items,
+        };
+
+        let mut lock_items = IndexMap::new();
+        lock_items.insert(
+            "agent/coder".to_string(),
+            LockedItemV2 {
+                source: SourceName::from("test-source"),
+                kind: ItemKind::Agent,
+                version: None,
+                source_checksum: canonical_hash.clone().into(),
+                outputs: vec![
+                    OutputRecord {
+                        target_root: ".mars".to_string(),
+                        dest_path: "agents/coder.md".into(),
+                        installed_checksum: canonical_hash.clone().into(),
+                    },
+                    OutputRecord {
+                        target_root: ".pi".to_string(),
+                        dest_path: "agents/coder.md".into(),
+                        installed_checksum: pi_hash.into(),
+                    },
+                ],
+            },
+        );
+        let lock = LockFile {
+            version: 2,
+            dependencies: IndexMap::new(),
+            items: lock_items,
+            config_entries: std::collections::BTreeMap::new(),
+        };
+
+        let diff = compute(root.path(), &lock, &target, false).unwrap();
+        assert_eq!(diff.items.len(), 1);
+        assert!(
+            matches!(&diff.items[0], DiffEntry::Unchanged { .. }),
+            "expected Unchanged, got {:?}",
+            diff.items[0]
+        );
     }
 
     #[test]

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -18,7 +18,7 @@ use crate::diagnostic::{Diagnostic, DiagnosticCollector};
 use crate::error::MarsError;
 use crate::fs::FileLock;
 use crate::hash;
-use crate::lock::{ItemId, ItemKind};
+use crate::lock::{CANONICAL_TARGET_ROOT, ItemId, ItemKind};
 use crate::lock::{LockFile, LockIndex};
 use crate::resolve::{ResolveOptions, ResolvedGraph};
 use crate::source::GlobalCache;
@@ -312,7 +312,9 @@ pub(crate) fn build_target(
         }
 
         let disk_path = dest_path.resolve(managed_root);
-        if !old_lock_index.contains_dest_path(&dest_path) && disk_path.symlink_metadata().is_ok() {
+        if !old_lock_index.contains_output(CANONICAL_TARGET_ROOT, &dest_path)
+            && disk_path.symlink_metadata().is_ok()
+        {
             diag.warn(
                 "unmanaged-collision",
                 format!(

--- a/src/sync/target.rs
+++ b/src/sync/target.rs
@@ -8,7 +8,7 @@ use crate::diagnostic::{DiagnosticCategory, DiagnosticCollector};
 use crate::discover;
 use crate::error::MarsError;
 use crate::hash;
-use crate::lock::{ItemId, ItemKind, LockFile, LockIndex};
+use crate::lock::{CANONICAL_TARGET_ROOT, ItemId, ItemKind, LockFile, LockIndex};
 use crate::resolve::ResolvedGraph;
 use crate::sync::filter::apply_filter;
 use crate::types::{
@@ -218,7 +218,7 @@ pub fn check_unmanaged_collisions(
     let lock_index = LockIndex::new(lock);
 
     for (dest_key, target_item) in &target.items {
-        if lock_index.contains_dest_path(dest_key) {
+        if lock_index.contains_output(CANONICAL_TARGET_ROOT, dest_key) {
             continue;
         }
 


### PR DESCRIPTION
## Why

Projects with multiple targets (`.mars`, `.codex`, `.opencode`, `.pi`, etc.) could report cleanly synced skills as locally modified immediately after `mars sync`. The lock stored distinct per-target checksums, but the sync diff could read the wrong target's checksum for the same relative path.

Fixes #73.

## Goal

Canonical `.mars` sync diff should compare `.mars/` disk content only against `.mars` lock outputs. Linked/native targets may keep different compiled bytes and checksums for the same `dest_path` without causing false `disk-lock-divergent` warnings.

## Summary

- Added target-scoped `LockIndex` lookups keyed by `(target_root, dest_path)`.
- Updated canonical sync diff, orphan scan, collision checks, and lock carry-forward fallbacks to use `.mars` outputs.
- Updated `mars adopt` ownership check to use the actual target root.
- Added regression coverage for same-path multi-target checksum collisions.
- Captured the target-scoped lock-output contract in QI/docs.

## Work Item

None — direct issue fix for `haowjy/mars-agents#73`.

## Changes

- `mars.lock` schema unchanged; the fix is in ephemeral lookup/index behavior and call sites.
- Canonical sync now ignores linked-target compiled checksums when checking `.mars/` local divergence.
- New inline docs clarify that output identity is `(target_root, dest_path)` and unscoped destination views are broad/diagnostic only.
- Follow-up risk: reviewer suggested dedicated `mars adopt` coverage for target-scoped ownership; current change updates behavior but does not add a separate adopt-specific test.

## Verification

- `cargo test lock_index_target_scoped_lookup_distinguishes_same_dest_path --lib`
- `cargo test canonical_diff_ignores_non_canonical_output_checksum --lib`
- `cargo test --lib`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `scripts/smoke-target-scoped.sh` — 9 passed, 0 failed
- Manual issue #73 repro via `cargo run --quiet -- sync --root <tmp-project> --no-upgrade-hint`:
  - targets: `.codex`, `.opencode`, `.pi`
  - lock had distinct output checksums for `.mars`, `.codex`, `.opencode`, `.pi`
  - second sync printed `already up to date`; stderr empty
- Pre-push hook after rebase:
  - `cargo fmt --check`
  - `cargo clippy --all-targets -- -D warnings`
  - `cargo test -- --skip cli::version::tests::run`
  - `cargo build --release`

## Knowledge Updates

- Added `src/lock/AGENTS.md`.
- Added `src/lock/.context/CONTEXT.md`.
- Updated `docs/internals/lock-file.md` to describe current lock v2 item/output shape and target-scoped checksum semantics.

## Spawn Trace

- p2365 coder — implemented target-scoped lock lookup fix and regression tests.
- p2368 reviewer — Codex-path read-only review; no blocking findings, one low adopt-test coverage suggestion.
- p2370 kb-lead — attempted post-implementation capture, got stuck on tool permissions; cancelled. Knowledge updates completed directly afterward.

## Release Label Guide

Recommended label: `release:patch` / `release:stable`.

This is a user-visible bug fix for sync false-positive local modification warnings.

## Post-Merge Automation

After merge to `main`, CI will promote the changelog and create the release/tag according to the selected `release:*` label.

## Cleanup

After merge, clean merged worktrees with:

```bash
scripts/prune-worktrees.sh
```
