### PR TITLE
fix(harness_model): stop provider_constraint blind prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-### Added
-- bump
+### Fixed
+- `resolve_harness_model` no longer prepends `{provider}/{model_id}` from alias `provider` before harness logic; native Codex/Claude receive bare model ids, Pi/OpenCode use probe slugs (fixes `gptmini` → `openai/…` on Codex and Pi).
 
 ## [0.7.1] - 2026-05-24
 

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -590,6 +590,12 @@ mars build launch-bundle [--agent NAME] [--model TOKEN] [flags]
 
 **Warning semantics:** `warnings[]` contains only unexpected, user-actionable conditions. Routing path facts are NOT warnings — `harness_model_source: "passthrough"` and `harness_model_confidence: "unknown"` (e.g., Pi or explicit harness) appear in routing/provenance fields and do not produce warnings. Real warnings include: linked harness constraints exhausting auto-routing candidates, or Cursor experimental target.
 
+**`harness_model` resolution:** Alias `provider` does not always become `provider/model` in
+`routing.harness_model`. Native Codex/Claude use bare canonical ids when the provider matches;
+Pi/OpenCode select probe slugs. Example: `-m gptmini` on a project with that alias → Codex +
+`harness_model: "gpt-5.4-mini"` (`provider-match`), not `openai/gpt-5.4-mini`. See
+[`src/models/.context/CONTEXT.md`](../../src/models/.context/CONTEXT.md).
+
 ```bash
 # Ad-hoc: route gpt-5.4-mini from any directory
 mars build launch-bundle --model gpt-5.4-mini --json

--- a/src/build/.context/CONTEXT.md
+++ b/src/build/.context/CONTEXT.md
@@ -99,6 +99,18 @@ Catalog slugs feed `RoutingInput.catalog_model_slugs` so native harness matching
 probe/catalog candidates for debugging only — bundle doc comment: consumers run `harness_model`
 verbatim. `routing.candidate_slugs` on the trace/report is diagnostic; do not use it for launch.
 
+### Alias `provider` → `harness_model`
+
+Resolved in `models::resolve_harness_model` ([`src/models/.context/CONTEXT.md`](../../models/.context/CONTEXT.md)):
+
+- **Codex / Claude:** when alias or routing `provider` matches the native harness, emit the
+  **bare** canonical model id (`gpt-5.4-mini`, not `openai/gpt-5.4-mini`).
+- **Pi / OpenCode:** pick a probe-listed slug (`openai-codex/gpt-5.4-mini`, etc.); use
+  `provider_constraint` only to order/filter slugs, not to prefix before the probe runs.
+
+`harness_model_source` / `harness_model_confidence` record how the id was chosen (`provider-match`,
+`cached-probe`, `passthrough`) — still not user-facing warnings.
+
 ### Cursor effort → `harness_model`
 
 When harness is `cursor` and effort is set, `resolve_routing` calls

--- a/src/build/AGENTS.md
+++ b/src/build/AGENTS.md
@@ -73,6 +73,8 @@ effort from `routing.effort`.
 `routing.candidate_slugs` is **diagnostic only** (probe/catalog candidates for the selected
 harness). Consumers ignore it unless debugging.
 
+Alias `provider` → `harness_model` (bare native ids vs probe slugs): [`src/models/.context/CONTEXT.md`](../models/.context/CONTEXT.md).
+
 ## Anti-Patterns
 
 - Do NOT add warnings for harness-model path facts (`passthrough`, `synthesized`, `unknown` confidence)

--- a/src/models/.context/CONTEXT.md
+++ b/src/models/.context/CONTEXT.md
@@ -1,0 +1,40 @@
+# `resolve_harness_model` — launch argv model id
+
+Maps resolved canonical `model_id` + selected `harness` to `routing.harness_model` (the
+token harness CLIs receive on `--model`). Alias `provider` feeds **routing and probe
+selection**, not an unconditional `provider/model` prefix.
+
+## Resolution order
+
+1. **Empty `model_id`** → empty `harness_model`, `passthrough`, `unknown` confidence.
+2. **Pi / OpenCode** → probe slug selection (`select_probe_slug`) when probe cache is
+   compatible; `provider_constraint` biases slug choice only (see `probe_constraint_for_selection`).
+   Without a usable probe → `constraint_qualified_passthrough` when the constraint is already
+   qualified (`openai-codex/foo`), else bare passthrough.
+3. **Native harnesses (`codex`, `claude`)** → when `provider_constraint` or `provider_for_order`
+   matches the harness (`slug::provider_matches_native_harness`, including variants like
+   `openai-codex` on Codex), return **bare** `model_id` with `provider-match` / `likely`.
+4. **Default** → bare `model_id`, `passthrough`, `unknown`.
+
+## Anti-patterns (removed)
+
+Do **not** prepend `{provider_constraint}/{model_id}` before harness branches. That produced
+`openai/gpt-5.4-mini` for aliases such as `gptmini` (`provider = "openai"`, `harness = "codex"`),
+which breaks ChatGPT-auth Codex (expects bare `gpt-5.4-mini`) and Pi (expects probe slugs like
+`openai-codex/gpt-5.4-mini`).
+
+## Examples
+
+| Input | Harness | Typical `harness_model` | Source |
+|-------|---------|-------------------------|--------|
+| alias `gptmini` | codex (alias-fixed) | `gpt-5.4-mini` | `provider-match` |
+| alias `gptmini` | pi (CLI) | `openai-codex/gpt-5.4-mini` | `cached-probe` |
+| CLI `gpt-5.4-mini` | codex (auto, native match) | `gpt-5.4-mini` | `provider-match` |
+
+Manual evidence: `tests/smoke/manual/results-launch-bundle-resolver.md` (gptmini section).
+
+## Related
+
+- [`harness_model.rs`](../harness_model.rs) — implementation + unit tests
+- [`src/build/.context/CONTEXT.md`](../../build/.context/CONTEXT.md) — bundle consumer contract
+- [`src/routing/.context/CONTEXT.md`](../../routing/.context/CONTEXT.md) — harness selection vs argv model

--- a/src/models/AGENTS.md
+++ b/src/models/AGENTS.md
@@ -91,6 +91,13 @@ Do not conflate env offline with flag-driven skip when debugging missing probe d
 
 Resolved aliases include auto-detected harness based on installed binaries and probe results. Encapsulated in `resolve_harness()` — callers don't pass installed harnesses.
 
+## Launch `harness_model` (argv model id)
+
+After harness selection, `resolve_harness_model()` in `harness_model.rs` produces
+`routing.harness_model`. Alias `provider` is **not** a blind `provider/model` prefix:
+native Codex/Claude get bare ids when the provider matches; Pi/OpenCode use probe slugs.
+Details and examples: [.context/CONTEXT.md](.context/CONTEXT.md).
+
 ## Patterns
 
 **Test without real API:**

--- a/src/models/harness_model.rs
+++ b/src/models/harness_model.rs
@@ -24,17 +24,6 @@ pub fn resolve_harness_model(input: HarnessModelInput<'_>) -> ResolvedRunnablePa
         };
     }
 
-    if let Some(constraint) = input
-        .provider_constraint
-        .filter(|provider| !provider.trim().is_empty())
-    {
-        return ResolvedRunnablePath {
-            harness_model_id: format!("{}/{}", constraint.trim(), model_id),
-            source: RunnablePathSource::Passthrough,
-            confidence: RunnableConfidence::Confirmed,
-        };
-    }
-
     let harness = input.harness;
     if harness.eq_ignore_ascii_case("pi") {
         return resolve_pi_harness_model(input);
@@ -43,8 +32,7 @@ pub fn resolve_harness_model(input: HarnessModelInput<'_>) -> ResolvedRunnablePa
         return resolve_opencode_harness_model(input);
     }
 
-    let provider = input.provider_for_order.unwrap_or("").trim();
-    if !provider.is_empty() && slug::provider_matches_native_harness(provider, harness) {
+    if native_provider_matches_harness(input, harness) {
         return ResolvedRunnablePath {
             harness_model_id: model_id.to_string(),
             source: RunnablePathSource::ProviderMatch,
@@ -59,13 +47,21 @@ pub fn resolve_harness_model(input: HarnessModelInput<'_>) -> ResolvedRunnablePa
     }
 }
 
+fn native_provider_matches_harness(input: HarnessModelInput<'_>, harness: &str) -> bool {
+    let provider_matches = |provider: &str| {
+        !provider.trim().is_empty() && slug::provider_matches_native_harness(provider, harness)
+    };
+    input.provider_constraint.is_some_and(provider_matches)
+        || input.provider_for_order.is_some_and(provider_matches)
+}
+
 fn resolve_pi_harness_model(input: HarnessModelInput<'_>) -> ResolvedRunnablePath {
     let model_id = input.model_id.trim();
     let Some(pi_probe) = input.pi_probe else {
-        return passthrough_bare(model_id);
+        return constraint_qualified_passthrough(model_id, input.provider_constraint);
     };
     if !pi_probe.compatible {
-        return passthrough_bare(model_id);
+        return constraint_qualified_passthrough(model_id, input.provider_constraint);
     }
 
     probe_slug_or_passthrough(
@@ -80,10 +76,10 @@ fn resolve_pi_harness_model(input: HarnessModelInput<'_>) -> ResolvedRunnablePat
 fn resolve_opencode_harness_model(input: HarnessModelInput<'_>) -> ResolvedRunnablePath {
     let model_id = input.model_id.trim();
     let Some(opencode_probe) = input.opencode_probe else {
-        return passthrough_bare(model_id);
+        return constraint_qualified_passthrough(model_id, input.provider_constraint);
     };
     if !opencode_probe.model_probe_success {
-        return passthrough_bare(model_id);
+        return constraint_qualified_passthrough(model_id, input.provider_constraint);
     }
 
     probe_slug_or_passthrough(
@@ -104,7 +100,7 @@ fn probe_slug_or_passthrough<'a>(
 ) -> ResolvedRunnablePath {
     let selection = select_probe_slug(
         model_id,
-        provider_constraint,
+        probe_constraint_for_selection(provider_constraint, provider_for_order),
         provider_for_order,
         settings_provider_order,
         slugs,
@@ -117,6 +113,37 @@ fn probe_slug_or_passthrough<'a>(
         };
     }
 
+    constraint_qualified_passthrough(model_id, provider_constraint)
+}
+
+/// Broad alias constraints (e.g. `openai`) must not force an exact-tier probe pick
+/// before variant preference; keep the constraint for qualified passthrough fallback.
+fn probe_constraint_for_selection<'a>(
+    provider_constraint: Option<&'a str>,
+    provider_for_order: Option<&'a str>,
+) -> Option<&'a str> {
+    let constraint = provider_constraint.filter(|provider| !provider.trim().is_empty())?;
+    let order = provider_for_order.filter(|provider| !provider.trim().is_empty());
+    if order.is_some_and(|order| slug::providers_exact_match(constraint, order)) {
+        return None;
+    }
+    Some(constraint)
+}
+
+fn constraint_qualified_passthrough(
+    model_id: &str,
+    provider_constraint: Option<&str>,
+) -> ResolvedRunnablePath {
+    if model_id.contains('/') {
+        return passthrough_bare(model_id);
+    }
+    if let Some(constraint) = provider_constraint.filter(|provider| !provider.trim().is_empty()) {
+        return ResolvedRunnablePath {
+            harness_model_id: format!("{}/{}", constraint.trim(), model_id),
+            source: RunnablePathSource::Passthrough,
+            confidence: RunnableConfidence::Confirmed,
+        };
+    }
     passthrough_bare(model_id)
 }
 
@@ -255,6 +282,50 @@ mod tests {
         assert_eq!(resolved.harness_model_id, "gpt-5.4-mini");
         assert_eq!(resolved.source, RunnablePathSource::ProviderMatch);
         assert_eq!(resolved.confidence, RunnableConfidence::Likely);
+    }
+
+    #[test]
+    fn codex_provider_constraint_native_match_returns_bare_model() {
+        let resolved = resolve_harness_model(HarnessModelInput {
+            harness: "codex",
+            model_id: "gpt-5.4-mini",
+            provider_constraint: Some("openai"),
+            provider_for_order: Some("openai"),
+            settings_provider_order: None,
+            opencode_probe: None,
+            pi_probe: None,
+        });
+
+        assert_eq!(resolved.harness_model_id, "gpt-5.4-mini");
+        assert_eq!(resolved.source, RunnablePathSource::ProviderMatch);
+        assert_eq!(resolved.confidence, RunnableConfidence::Likely);
+    }
+
+    #[test]
+    fn pi_provider_constraint_uses_probe_slug_not_blind_prefix() {
+        let mut model_slugs = HashSet::new();
+        model_slugs.insert("openai-codex/gpt-5.4-mini".to_string());
+        model_slugs.insert("openai/gpt-5.4-mini".to_string());
+        let pi_probe = PiProbeResult {
+            compatible: true,
+            model_slugs,
+            ..PiProbeResult::default()
+        };
+
+        let resolved = resolve_harness_model(HarnessModelInput {
+            harness: "pi",
+            model_id: "gpt-5.4-mini",
+            provider_constraint: Some("openai"),
+            provider_for_order: Some("openai"),
+            settings_provider_order: None,
+            opencode_probe: None,
+            pi_probe: Some(&pi_probe),
+        });
+
+        assert_eq!(resolved.harness_model_id, "openai-codex/gpt-5.4-mini");
+        assert_ne!(resolved.harness_model_id, "openai/gpt-5.4-mini");
+        assert_eq!(resolved.source, RunnablePathSource::CachedProbe);
+        assert_eq!(resolved.confidence, RunnableConfidence::Confirmed);
     }
 
     #[test]

--- a/src/routing/.context/CONTEXT.md
+++ b/src/routing/.context/CONTEXT.md
@@ -25,7 +25,7 @@ Acceptance decisions belong to callers via `accept_route()` / `accept_assessment
 |---|---|
 | `model_id` | Resolved model identifier (used for OpenCode/Pi slug matching) |
 | `provider_for_order` | Optional provider name (determines native affinity and candidate order) |
-| `provider_constraint` | Optional provider constraint (filters slug selection, excludes mismatched native harnesses) |
+| `provider_constraint` | Alias/provider pin from model config — filters probe slug selection and native harness acceptance; shapes `harness_model` via [`resolve_harness_model`](../../models/harness_model.rs) (no blind `provider/model` prefix) |
 | `settings_provider_order` | Raw `provider_order` from config, if set |
 | `settings_harness_order` | Raw `harness_order` from config, if set |
 | `config_default_harness` | Raw `default_harness` from config, if set |

--- a/tests/launch_bundle/routing.rs
+++ b/tests/launch_bundle/routing.rs
@@ -2384,7 +2384,7 @@ Review code changes."#;
     );
     assert_eq!(
         bundle["routing"]["harness_model_source"].as_str(),
-        Some("passthrough")
+        Some("cached-probe")
     );
 }
 
@@ -2475,17 +2475,14 @@ harness = "codex""#;
         bundle["routing"]["match_evidence"].as_str(),
         Some("constrained")
     );
-    assert_eq!(
-        bundle["routing"]["harness_model"].as_str(),
-        Some("openai-codex/gpt-5")
-    );
+    assert_eq!(bundle["routing"]["harness_model"].as_str(), Some("gpt-5"));
     assert_eq!(
         bundle["routing"]["harness_model_source"].as_str(),
-        Some("passthrough")
+        Some("provider-match")
     );
     assert_eq!(
         bundle["routing"]["harness_model_confidence"].as_str(),
-        Some("confirmed")
+        Some("likely")
     );
 }
 

--- a/tests/smoke/manual/results-launch-bundle-resolver.md
+++ b/tests/smoke/manual/results-launch-bundle-resolver.md
@@ -1,5 +1,30 @@
 # Launch Bundle / Resolver Smoke Results
 
+## Alias `gptmini` — native Codex bare id, Pi probe slug (2026-05-24)
+
+Date run: 2026-05-24  
+Repo: `/home/jimyao/gitrepos/mars-agents.worktrees/native-harness-model`  
+Project root: `meridian-cli` worktree (synced `mars.toml` / catalog; `gptmini` from base package)
+
+```bash
+MARS=./target/release/mars
+ROOT=~/gitrepos/meridian-cli.worktrees/pi-generic-background-tasks
+```
+
+| Command | `harness_model` | `harness_model_source` |
+|---------|-----------------|------------------------|
+| `--root "$ROOT" --model gptmini` | `gpt-5.4-mini` | `provider-match` |
+| `--root "$ROOT" --model gptmini --harness pi` | `openai-codex/gpt-5.4-mini` | `cached-probe` |
+
+Before this change (main): both cases produced `openai/gpt-5.4-mini` from blind
+`provider_constraint` prefixing.
+
+Why: alias `provider = "openai"` must not become argv `openai/…` on Codex (ChatGPT auth
+expects bare ids) or on Pi (probe lists `openai-codex/…`). See
+[`src/models/.context/CONTEXT.md`](../../../src/models/.context/CONTEXT.md).
+
+---
+
 Date run: 2026-05-20
 Repo: `/home/jimyao/gitrepos/mars-agents.worktrees/capability-cache-resolver`
 


### PR DESCRIPTION
## Why

Alias `provider` on models (e.g. `gptmini` with `provider = "openai"`) was unconditionally prefixed to `openai/gpt-5.4-mini` before harness-specific routing. That breaks Codex with ChatGPT auth (expects bare `gpt-5.4-mini`) and Pi/OpenCode (should pick probe slugs like `openai-codex/…`, not forced `openai/…`).

## Goal

`harness_model` reflects harness-native argv shape: bare ids for native Codex/Claude when the alias provider matches, and probe-selected qualified slugs for Pi/OpenCode.

## Summary

- Remove unconditional early `{provider_constraint}/{model_id}` return in `resolve_harness_model`.
- Route Pi/OpenCode first through probe slug selection; use `provider_constraint` for probe ordering only.
- Native Codex/Claude: when provider matches harness, emit bare `model_id` with `provider-match` source.
- Qualified passthrough when probes are absent; avoid blind prefix when probe can disambiguate variants.

## Work Item

N/A (mars-agents routing fix; meridian-cli spawn validation is downstream)

## Changes

- `src/models/harness_model.rs`: reorder resolution; add `native_provider_matches_harness`, `probe_constraint_for_selection`, `constraint_qualified_passthrough`.
- `tests/launch_bundle/routing.rs`: expect bare Codex model for `openai-codex` provider variant alias; Pi qualified CLI model may source `cached-probe`.

## Verification

Manual smoke (`mars` built from this branch; project root = meridian-cli worktree with synced `mars.toml` / catalog):

```bash
MARS=./target/release/mars   # mars-agents.worktrees/native-harness-model
ROOT=~/gitrepos/meridian-cli.worktrees/pi-generic-background-tasks

$MARS build launch-bundle --root "$ROOT" --model gptmini --json
# harness=codex, harness_model=gpt-5.4-mini, harness_model_source=provider-match

$MARS build launch-bundle --root "$ROOT" --model gptmini --harness pi --json
# harness=pi, harness_model=openai-codex/gpt-5.4-mini, harness_model_source=cached-probe
# (not openai/gpt-5.4-mini)
```

| Case | Before (main) | After (this PR) |
|------|---------------|-----------------|
| `--model gptmini` | `openai/gpt-5.4-mini` | `gpt-5.4-mini` (bare, Codex) |
| `--model gptmini --harness pi` | `openai/gpt-5.4-mini` | `openai-codex/gpt-5.4-mini` (probe) |

`cargo test` (harness_model / launch_bundle) is CI guardrails only, not the verification record for this change.

## Knowledge Updates

- `src/models/.context/CONTEXT.md` — `resolve_harness_model` order and examples
- `src/models/AGENTS.md`, `src/build/.context/CONTEXT.md`, `src/build/AGENTS.md`, `src/routing/.context/CONTEXT.md`
- `docs/cli/commands.md` — harness_model resolution note
- `tests/smoke/manual/results-launch-bundle-resolver.md` — gptmini manual smoke (2026-05-24)
- `CHANGELOG.md` [Unreleased] Fixed entry

## Spawn Trace

N/A

## Release Label Guide

Suggest `release:patch` — routing fix for launch-bundle consumers (Meridian spawn).

