### PR TITLE
Soft-fail no_model_match when CLI harness outranks profile model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Launch-bundle fixed-harness routing now soft-fails `no_model_match` only when the harness comes from a higher-precedence source than the selected model (for example CLI harness overriding profile model), clears the model to passthrough routing, and emits a warning instead of failing hard.
+
 ## [0.7.4] - 2026-05-27
 
 ### Added

--- a/src/build/.context/CONTEXT.md
+++ b/src/build/.context/CONTEXT.md
@@ -44,6 +44,36 @@ Examples that are NOT warnings (they go to routing/provenance fields):
 - `harness_model_source: "passthrough"` — Pi or explicit harness receives the model token as-is; this is expected behavior
 - `harness_model_confidence: "unknown"` — Pi/passthrough harnesses are provider-routers at runtime; unknown confidence is the correct answer
 
+### Cross-field precedence soft-fail
+
+When a fixed harness conflicts with a model from a lower-precedence source, the harness wins
+and the model is cleared. Precedence ranks (`PolicySource::precedence_rank()`):
+
+| Rank | Sources |
+|------|---------|
+| 5 | CLI |
+| 4 | Overlay, OverlayModelPolicy |
+| 3 | Profile, ProfileModelPolicy, ProfileHarnessOverride |
+| 2 | SettingsModelPolicy, Project, Config |
+| 1 | Alias |
+| 0 | Unset, ConfigOrder, Provider, Default |
+
+**Trigger condition:** fixed harness assessment returns `skip_reason = "no_model_match"` AND
+`harness_source.precedence_rank() > model_source.precedence_rank()`.
+
+**Only `no_model_match` triggers soft-fail.** Other rejection reasons (`provider_constraint_unsatisfied`,
+`pi_incompatible`) stay hard errors regardless of precedence rank — the model field being cleared
+cannot resolve a provider constraint or compatibility failure.
+
+**Same-precedence conflicts are hard errors.** CLI harness + CLI model both `no_model_match` →
+error; the user explicitly requested an impossible combination.
+
+`HarnessResolution.model_override: Option<()>` signals the outcome. When `Some(())`, `policy/mod.rs`
+substitutes empty strings for `model`, `model_token`, `provider_constraint`, and `provider_for_order`
+before calling `runnable::resolve_routing` — the harness uses its own default model. A warning
+(`"<source> model '<token>' cannot run on <source> harness '<name>'; clearing model"`) flows
+through the normal warnings pipeline to the bundle's `warnings[]` field.
+
 ### `can_run_without_project` guard
 
 ```rust

--- a/src/build/.context/CONTEXT.md
+++ b/src/build/.context/CONTEXT.md
@@ -44,36 +44,6 @@ Examples that are NOT warnings (they go to routing/provenance fields):
 - `harness_model_source: "passthrough"` — Pi or explicit harness receives the model token as-is; this is expected behavior
 - `harness_model_confidence: "unknown"` — Pi/passthrough harnesses are provider-routers at runtime; unknown confidence is the correct answer
 
-### Cross-field precedence soft-fail
-
-When a fixed harness conflicts with a model from a lower-precedence source, the harness wins
-and the model is cleared. Precedence ranks (`PolicySource::precedence_rank()`):
-
-| Rank | Sources |
-|------|---------|
-| 5 | CLI |
-| 4 | Overlay, OverlayModelPolicy |
-| 3 | Profile, ProfileModelPolicy, ProfileHarnessOverride |
-| 2 | SettingsModelPolicy, Project, Config |
-| 1 | Alias |
-| 0 | Unset, ConfigOrder, Provider, Default |
-
-**Trigger condition:** fixed harness assessment returns `skip_reason = "no_model_match"` AND
-`harness_source.precedence_rank() > model_source.precedence_rank()`.
-
-**Only `no_model_match` triggers soft-fail.** Other rejection reasons (`provider_constraint_unsatisfied`,
-`pi_incompatible`) stay hard errors regardless of precedence rank — the model field being cleared
-cannot resolve a provider constraint or compatibility failure.
-
-**Same-precedence conflicts are hard errors.** CLI harness + CLI model both `no_model_match` →
-error; the user explicitly requested an impossible combination.
-
-`HarnessResolution.model_override: Option<()>` signals the outcome. When `Some(())`, `policy/mod.rs`
-substitutes empty strings for `model`, `model_token`, `provider_constraint`, and `provider_for_order`
-before calling `runnable::resolve_routing` — the harness uses its own default model. A warning
-(`"<source> model '<token>' cannot run on <source> harness '<name>'; clearing model"`) flows
-through the normal warnings pipeline to the bundle's `warnings[]` field.
-
 ### `can_run_without_project` guard
 
 ```rust
@@ -208,6 +178,10 @@ to real warnings.
 
 ## Related docs
 
+- [policy/AGENTS.md](../policy/AGENTS.md) — policy resolution pipeline, field independence,
+  cross-field precedence conflict handling
+- [policy/.context/CONTEXT.md](../policy/.context/CONTEXT.md) — precedence ranks, soft-fail
+  contract, model_override mechanism
 - [src/models/AGENTS.md](../../models/AGENTS.md) — catalog `ensure_fresh`, `ModelsRefreshControl`
 - [src/routing/.context/CONTEXT.md](../../routing/.context/CONTEXT.md) — harness candidate
   evaluation, selection-kind vs match-evidence semantics, and `RouteDecisionReport`

--- a/src/build/AGENTS.md
+++ b/src/build/AGENTS.md
@@ -48,18 +48,9 @@ LaunchBundle {routing, execution_policy, prompt_surface, tools, skills_metadata,
 
 ## Policy Resolution Pipeline
 
-```
-build_launch_bundle()                    → load EffectiveProjectConfig once
-                                        (fallback to default only when mars.toml is absent)
-models::merged_runtime_aliases()         → merged alias map (dependency + consumer overlays)
-models::ensure_fresh()                   → models.dev catalog (TTL-aware; not read-only)
-model::resolve_model()                   → alias → model_id + provider, or unset
-harness::resolve_harness()               → route selection, candidate eval (shared evaluator);
-                                           cross-field soft-fail: fixed harness outranks lower-
-                                           precedence model on no_model_match → model cleared
-execution::resolve_execution_policy()    → effort, approval, sandbox, autocompact
-runnable::resolve_routing()              → populate Routing (warnings always empty)
-```
+`resolve_policy()` resolves routing, execution, and provenance. Each field resolves
+independently — see [`policy/AGENTS.md`](policy/AGENTS.md) for the full pipeline,
+field independence, and cross-field precedence conflict handling.
 
 `resolve_policy` always runs `models::ensure_fresh` on `.mars/` (stale fallback may warn).
 CLI passes `ModelsRefreshControl` from `--refresh-models` / `--no-refresh-models` on
@@ -88,5 +79,6 @@ Alias `provider` → `harness_model` (bare native ids vs probe slugs): [`src/mod
 ## See Also
 
 - `.context/CONTEXT.md` — detailed contracts, warning semantics, ad-hoc guard
+- `policy/AGENTS.md` — policy resolution pipeline, field independence, cross-field precedence
 - `src/routing/AGENTS.md` — harness candidate evaluation
 - `src/cli/build.rs` — CLI arg definitions

--- a/src/build/AGENTS.md
+++ b/src/build/AGENTS.md
@@ -54,7 +54,9 @@ build_launch_bundle()                    → load EffectiveProjectConfig once
 models::merged_runtime_aliases()         → merged alias map (dependency + consumer overlays)
 models::ensure_fresh()                   → models.dev catalog (TTL-aware; not read-only)
 model::resolve_model()                   → alias → model_id + provider, or unset
-harness::resolve_harness()               → route selection, candidate eval (shared evaluator)
+harness::resolve_harness()               → route selection, candidate eval (shared evaluator);
+                                           cross-field soft-fail: fixed harness outranks lower-
+                                           precedence model on no_model_match → model cleared
 execution::resolve_execution_policy()    → effort, approval, sandbox, autocompact
 runnable::resolve_routing()              → populate Routing (warnings always empty)
 ```

--- a/src/build/policy/.context/CONTEXT.md
+++ b/src/build/policy/.context/CONTEXT.md
@@ -1,0 +1,69 @@
+# src/build/policy/
+
+## Contracts
+
+### Cross-field precedence soft-fail
+
+When a fixed harness conflicts with a model from a lower-precedence source, the harness
+wins and the model is cleared. Precedence ranks (`PolicySource::precedence_rank()`):
+
+| Rank | Sources |
+|------|---------|
+| 5 | CLI |
+| 4 | Overlay, OverlayModelPolicy |
+| 3 | Profile, ProfileModelPolicy, ProfileHarnessOverride |
+| 2 | SettingsModelPolicy, Project, Config |
+| 1 | Alias |
+| 0 | Unset, ConfigOrder, Provider, Default |
+
+**Trigger condition:** fixed harness assessment returns `skip_reason = "no_model_match"` AND
+`harness_source.precedence_rank() > model_source.precedence_rank()`.
+
+**Only `no_model_match` triggers soft-fail.** Other rejection reasons (`provider_constraint_unsatisfied`,
+`pi_incompatible`) stay hard errors regardless of precedence rank — clearing the model cannot
+resolve a provider constraint or harness compatibility failure.
+
+**Same-precedence conflicts are hard errors.** CLI harness + CLI model both `no_model_match` →
+error; the user explicitly requested an impossible combination.
+
+### model_override mechanism
+
+`HarnessResolution.model_override: Option<()>` signals the outcome. When `Some(())`, `mod.rs`
+substitutes empty strings for `model`, `model_token`, `provider_constraint`, and `provider_for_order`
+before calling `runnable::resolve_routing` — the harness uses its own default model. A warning
+(`"<source> model '<token>' cannot run on <source> harness '<name>'; clearing model"`) flows
+through the normal warnings pipeline to the bundle's `warnings[]` field.
+
+### Resolution flow in harness.rs
+
+```
+resolve_harness()
+  ├─ resolve_fixed_harness_selection()   → Option<ResolvedField> (CLI > overlay > profile > alias)
+  ├─ [fixed] evaluate_fixed_harness      → assessment
+  │   ├─ [profile + not installed]       → pivot to candidate evaluation
+  │   ├─ [assessment rejected]           → resolve_fixed_harness_rejection()
+  │   │   ├─ not installed               → hard error
+  │   │   ├─ no_model_match + outranks   → soft_fail (clear model, retry with empty model_id)
+  │   │   └─ other / same rank           → hard error
+  │   └─ [assessment ok]                 → use fixed trace
+  └─ [auto] evaluate_candidates          → candidate ordering with probe matching
+```
+
+## Rationale
+
+Cross-field precedence conflict arises from harness shortcuts (`meridian opencode`) that
+set CLI-level harness while the agent profile provides a model. Before this mechanism,
+this was a hard error requiring the user to also override the model. The soft-fail lets
+the higher-precedence field win naturally — the harness proceeds with its own default
+model selection, and the warning tells the user what happened.
+
+Only `no_model_match` is soft-failed because it means "the harness can't find this model
+in its probe results" — clearing the model is a valid recovery (let the harness pick).
+Provider constraints and harness incompatibility are structural — clearing the model
+doesn't help.
+
+## Related docs
+
+- `../AGENTS.md` — policy resolution mental model and field independence
+- `../../.context/CONTEXT.md` — bundle-level contracts, warning semantics
+- `../../../routing/.context/CONTEXT.md` — candidate evaluation, assessment mechanics

--- a/src/build/policy/AGENTS.md
+++ b/src/build/policy/AGENTS.md
@@ -1,0 +1,51 @@
+# src/build/policy/ — Policy Resolution
+
+Resolves routing and execution policy for a launch bundle. 5 files, ~2700 lines.
+
+## Mental Model
+
+Each field resolves independently through its own module, then results combine
+in `mod.rs`:
+
+```
+resolve_policy()
+  ├─ model::resolve_model()             → model_id, provider, model_token
+  ├─ harness::resolve_harness()         → harness, route trace, model_override
+  ├─ execution::resolve_execution_policy() → effort, approval, sandbox, autocompact
+  └─ runnable::resolve_routing()        → final Routing struct (warnings always empty)
+```
+
+## Field Independence and Cross-Field Conflict
+
+Fields resolve independently — CLI model does not force CLI harness or vice versa.
+But independently-resolved fields can **conflict**: a profile model may not run on
+a CLI harness. When this happens, precedence rank decides the outcome:
+
+- **Harness outranks model** → model cleared with warning, harness proceeds
+  (soft-fail, `no_model_match` only)
+- **Same or model outranks** → hard error (user asked for an impossible combination)
+- **Non-model rejections** (provider constraint, incompatibility) → always hard error
+
+See `.context/CONTEXT.md` for precedence ranks and the soft-fail contract.
+
+## Key Rules
+
+- `resolve_routing()` returns `warnings: Vec::new()` always — route facts go to
+  `routing.harness_model_source` / `routing.harness_model_confidence`, not warnings
+- Harness resolution may clear the model (`model_override: Some(())`); downstream
+  routing must check this before using resolved model fields
+- Catalog refresh (`ensure_fresh`) runs before harness evaluation, not read-only
+
+## Anti-Patterns
+
+- Do NOT add route-path facts to the warnings vector
+- Do NOT assume model and harness come from the same precedence source
+- Do NOT bypass `model_override` — if harness resolution cleared the model, routing
+  must use empty model fields
+
+## See Also
+
+- `.context/CONTEXT.md` — precedence ranks, soft-fail contract, model_override mechanism
+- `../AGENTS.md` — bundle construction pipeline (parent context)
+- `../../routing/AGENTS.md` — harness candidate evaluation and probe matching
+- `../../models/AGENTS.md` — catalog refresh, model alias resolution

--- a/src/build/policy/harness.rs
+++ b/src/build/policy/harness.rs
@@ -17,12 +17,17 @@ pub(super) struct HarnessResolution {
     pub(super) harness_order_position: Option<usize>,
     pub(super) candidates_tried: Vec<String>,
     pub(super) route_trace: routing::RoutingTrace,
+    pub(super) model_cleared: bool,
     pub(super) is_experimental: bool,
     pub(super) resolved_harness: HarnessKind,
     pub(super) warnings: Vec<String>,
 }
 
-pub(super) type HarnessEvidence<'a> = routing::RoutingEvidence<'a>;
+pub(super) struct HarnessEvidence<'a> {
+    pub(super) routing: routing::RoutingEvidence<'a>,
+    pub(super) model_token: &'a str,
+    pub(super) model_source: PolicySource,
+}
 
 pub(super) fn resolve_harness(
     input: &PolicyInput<'_>,
@@ -33,6 +38,7 @@ pub(super) fn resolve_harness(
     probe_resolver: &mut dyn routing::ProbeResolver,
 ) -> Result<HarnessResolution, MarsError> {
     let mut warnings = Vec::new();
+    let mut model_cleared = false;
 
     let profile_harness = input.profile.harness.as_ref().map(harness_kind_to_str);
     let overlay_harness = overlay
@@ -53,8 +59,10 @@ pub(super) fn resolve_harness(
         .filter(|decision| decision.source == PolicySource::SettingsModelPolicy)
         .cloned();
     let alias_harness = alias.and_then(|entry| entry.harness.as_deref());
-    let normalized_config_default_harness =
-        routing::normalize_config_default_harness(evidence.config_default_harness, &mut warnings);
+    let normalized_config_default_harness = routing::normalize_config_default_harness(
+        evidence.routing.config_default_harness,
+        &mut warnings,
+    );
     let model_from_cli = input.model_override.is_some();
     let mut selected_harness_order_position = None;
     let fixed_harness_selection = resolve_fixed_harness_selection(
@@ -67,94 +75,42 @@ pub(super) fn resolve_harness(
         settings_policy_harness,
         alias_harness,
     );
-    let (harness, candidates_tried, route_trace, unavailable_profile_harness) =
-        if let Some(selection) = fixed_harness_selection.clone() {
-            let fixed_provider_for_order = routing::provider_for_order_for_fixed_harness(
-                evidence.provider_for_order,
-                &selection.value,
-            );
-            let mut fixed_input = routing_input_from_evidence(
-                &evidence,
-                normalized_config_default_harness.as_deref(),
-            );
-            fixed_input.provider_for_order = fixed_provider_for_order;
-            let fixed_assessment = routing::evaluate_fixed_harness_with_auth_and_probes(
-                &fixed_input,
-                &selection.value,
-                probe_resolver,
-                crate::models::harness::native_harness_authenticated,
-            );
-            let fixed_route_trace = routing::trace_for_fixed_harness(
-                route_source_for_policy_source(selection.source),
-                &selection.value,
-                fixed_assessment.clone(),
-                Vec::new(),
-            );
-            if selection.source == PolicySource::Profile
-                && routing::acceptance::accept_route(
-                    &fixed_route_trace,
-                    evidence.installed_harnesses,
-                    routing::acceptance::MatchPolicy::InstalledOnly,
-                )
-                .is_err()
-            {
-                warnings.push(format!(
-                    "profile harness '{}' not installed; pivoting via model-policies",
-                    selection.value
-                ));
-                let trace = evaluate_candidates(
-                    &evidence,
-                    normalized_config_default_harness.as_deref(),
-                    probe_resolver,
-                );
-                selected_harness_order_position = trace.selected_harness_order_position();
-                warnings.extend(trace.selected_diagnostics().to_vec());
-                let unavailable = routing::acceptance::accept_route(
-                    &trace,
-                    evidence.installed_harnesses,
-                    routing::acceptance::MatchPolicy::InstalledOnly,
-                )
-                .err()
-                .map(|_| selection.value.clone());
-                let candidates_tried = trace.candidates_tried.clone();
-                (
-                    ResolvedField {
-                        value: trace.harness.clone(),
-                        source: trace.source.into(),
-                        matched_rule: None,
-                    },
-                    candidates_tried,
-                    trace,
-                    unavailable,
-                )
-            } else {
-                routing::acceptance::accept_assessment(&fixed_assessment).map_err(|rejection| {
-                    if rejection.is_not_installed() {
-                        unavailable_fixed_harness_error(
-                            selection.source.label(),
-                            &selection.value,
-                            evidence.installed_harnesses,
-                        )
-                    } else {
-                        let skip_reason = match rejection {
-                            routing::acceptance::RejectionReason::AssessmentFailed {
-                                ref skip_reason,
-                                ..
-                            } => skip_reason.as_deref(),
-                            _ => None,
-                        };
-                        fixed_harness_constraint_error(
-                            selection.source.label(),
-                            &selection.value,
-                            skip_reason,
-                        )
-                    }
-                })?;
-                let route_trace = fixed_route_trace;
-                let candidates_tried = route_trace.candidates_tried.clone();
-                (selection, candidates_tried, route_trace, None)
-            }
-        } else {
+    let (harness, candidates_tried, route_trace, unavailable_profile_harness) = if let Some(
+        selection,
+    ) =
+        fixed_harness_selection.clone()
+    {
+        let fixed_provider_for_order = routing::provider_for_order_for_fixed_harness(
+            evidence.routing.provider_for_order,
+            &selection.value,
+        );
+        let mut fixed_input =
+            routing_input_from_evidence(&evidence, normalized_config_default_harness.as_deref());
+        fixed_input.provider_for_order = fixed_provider_for_order;
+        let fixed_assessment = routing::evaluate_fixed_harness_with_auth_and_probes(
+            &fixed_input,
+            &selection.value,
+            probe_resolver,
+            crate::models::harness::native_harness_authenticated,
+        );
+        let mut fixed_route_trace = routing::trace_for_fixed_harness(
+            route_source_for_policy_source(selection.source),
+            &selection.value,
+            fixed_assessment.clone(),
+            Vec::new(),
+        );
+        if selection.source == PolicySource::Profile
+            && routing::acceptance::accept_route(
+                &fixed_route_trace,
+                evidence.routing.installed_harnesses,
+                routing::acceptance::MatchPolicy::InstalledOnly,
+            )
+            .is_err()
+        {
+            warnings.push(format!(
+                "profile harness '{}' not installed; pivoting via model-policies",
+                selection.value
+            ));
             let trace = evaluate_candidates(
                 &evidence,
                 normalized_config_default_harness.as_deref(),
@@ -162,6 +118,13 @@ pub(super) fn resolve_harness(
             );
             selected_harness_order_position = trace.selected_harness_order_position();
             warnings.extend(trace.selected_diagnostics().to_vec());
+            let unavailable = routing::acceptance::accept_route(
+                &trace,
+                evidence.routing.installed_harnesses,
+                routing::acceptance::MatchPolicy::InstalledOnly,
+            )
+            .err()
+            .map(|_| selection.value.clone());
             let candidates_tried = trace.candidates_tried.clone();
             (
                 ResolvedField {
@@ -171,15 +134,81 @@ pub(super) fn resolve_harness(
                 },
                 candidates_tried,
                 trace,
-                None,
+                unavailable,
             )
-        };
+        } else {
+            if let Err(rejection) = routing::acceptance::accept_assessment(&fixed_assessment) {
+                if rejection.is_not_installed() {
+                    return Err(unavailable_fixed_harness_error(
+                        selection.source.label(),
+                        &selection.value,
+                        evidence.routing.installed_harnesses,
+                    ));
+                }
+
+                let skip_reason = match rejection {
+                    routing::acceptance::RejectionReason::AssessmentFailed {
+                        ref skip_reason,
+                        ..
+                    } => skip_reason.as_deref(),
+                    _ => None,
+                };
+                if let Some(retry) = soft_fail_fixed_harness_no_model_match(
+                    selection.source,
+                    evidence.model_source,
+                    skip_reason,
+                    fixed_input,
+                    &selection.value,
+                    probe_resolver,
+                ) {
+                    let retry = retry?;
+                    fixed_route_trace = retry;
+                    warnings.push(format!(
+                        "{} model '{}' cannot run on {} harness '{}'; clearing model (harness override takes precedence).",
+                        evidence.model_source.label(),
+                        evidence.model_token,
+                        selection.source.label(),
+                        selection.value
+                    ));
+                    model_cleared = true;
+                } else {
+                    return Err(fixed_harness_constraint_error(
+                        selection.source.label(),
+                        &selection.value,
+                        skip_reason,
+                    ));
+                }
+            }
+            let route_trace = fixed_route_trace;
+            let candidates_tried = route_trace.candidates_tried.clone();
+            (selection, candidates_tried, route_trace, None)
+        }
+    } else {
+        let trace = evaluate_candidates(
+            &evidence,
+            normalized_config_default_harness.as_deref(),
+            probe_resolver,
+        );
+        selected_harness_order_position = trace.selected_harness_order_position();
+        warnings.extend(trace.selected_diagnostics().to_vec());
+        let candidates_tried = trace.candidates_tried.clone();
+        (
+            ResolvedField {
+                value: trace.harness.clone(),
+                source: trace.source.into(),
+                matched_rule: None,
+            },
+            candidates_tried,
+            trace,
+            None,
+        )
+    };
 
     if let Some(profile_harness) = unavailable_profile_harness {
         return Err(unavailable_profile_pivot_error(
             &profile_harness,
             &harness.value,
-            evidence.installed_harnesses,
+            evidence.routing.installed_harnesses,
         ));
     }
 
@@ -199,6 +228,7 @@ pub(super) fn resolve_harness(
         harness_order_position: selected_harness_order_position,
         candidates_tried,
         route_trace,
+        model_cleared,
         warnings,
     })
 }
@@ -269,7 +299,9 @@ fn routing_input_from_evidence<'a>(
     evidence: &'a HarnessEvidence<'_>,
     normalized_config_default_harness: Option<&'a str>,
 ) -> RoutingInput<'a> {
-    evidence.routing_input_with_config_default_harness(normalized_config_default_harness)
+    evidence
+        .routing
+        .routing_input_with_config_default_harness(normalized_config_default_harness)
 }
 
 fn evaluate_candidates(
@@ -295,6 +327,47 @@ fn route_source_for_policy_source(source: PolicySource) -> routing::RouteSource 
         PolicySource::Provider => routing::RouteSource::Provider,
         _ => routing::RouteSource::Provider,
     }
+}
+
+fn soft_fail_fixed_harness_no_model_match(
+    harness_source: PolicySource,
+    model_source: PolicySource,
+    skip_reason: Option<&str>,
+    fixed_input: RoutingInput<'_>,
+    requested_harness: &str,
+    probe_resolver: &mut dyn routing::ProbeResolver,
+) -> Option<Result<routing::RoutingTrace, MarsError>> {
+    let should_retry = skip_reason == Some("no_model_match")
+        && harness_source.precedence_rank() > model_source.precedence_rank();
+    if !should_retry {
+        return None;
+    }
+
+    let mut passthrough_input = fixed_input;
+    passthrough_input.model_id = "";
+    let assessment = routing::evaluate_fixed_harness_with_auth_and_probes(
+        &passthrough_input,
+        requested_harness,
+        probe_resolver,
+        crate::models::harness::native_harness_authenticated,
+    );
+    let route_trace = routing::trace_for_fixed_harness(
+        route_source_for_policy_source(harness_source),
+        requested_harness,
+        assessment.clone(),
+        Vec::new(),
+    );
+    Some(
+        routing::acceptance::accept_assessment(&assessment)
+            .map_err(|_| {
+                fixed_harness_constraint_error(
+                    harness_source.label(),
+                    requested_harness,
+                    skip_reason,
+                )
+            })
+            .map(|_| route_trace),
+    )
 }
 
 fn unavailable_profile_pivot_error(
@@ -382,11 +455,15 @@ mod tests {
     }
 
     fn profile(harness: Option<HarnessKind>) -> AgentProfile {
+        profile_with_model(harness, None)
+    }
+
+    fn profile_with_model(harness: Option<HarnessKind>, model: Option<&str>) -> AgentProfile {
         AgentProfile {
             name: None,
             description: None,
             harness,
-            model: None,
+            model: model.map(str::to_string),
             mode: None,
             model_invocable: false,
             approval: None,
@@ -444,22 +521,34 @@ mod tests {
         installed_harnesses: &'a HashSet<String>,
     ) -> HarnessEvidence<'a> {
         HarnessEvidence {
-            model_id: "gpt-5",
-            provider_for_order: Some("openai"),
-            provider_constraint: None,
-            settings_provider_order: None,
-            config_default_harness,
-            settings_harness_order: harness_order,
-            installed_harnesses,
-            linked_harnesses: None,
-            opencode_probe_result: None,
-            pi_probe_result: None,
-            cursor_probe_result: None,
-            catalog_model_slugs: None,
+            routing: routing::RoutingEvidence {
+                model_id: "gpt-5",
+                provider_for_order: Some("openai"),
+                provider_constraint: None,
+                settings_provider_order: None,
+                config_default_harness,
+                settings_harness_order: harness_order,
+                installed_harnesses,
+                linked_harnesses: None,
+                opencode_probe_result: None,
+                pi_probe_result: None,
+                cursor_probe_result: None,
+                catalog_model_slugs: None,
+            },
+            model_token: "gpt-5",
+            model_source: PolicySource::Alias,
         }
     }
 
     fn positive_opencode_probe() -> OpenCodeProbeResult {
+        OpenCodeProbeResult {
+            model_slugs: vec!["openai/gpt-5".to_string()],
+            model_probe_success: true,
+            error: None,
+        }
+    }
+
+    fn opencode_probe_without_anthropic() -> OpenCodeProbeResult {
         OpenCodeProbeResult {
             model_slugs: vec!["openai/gpt-5".to_string()],
             model_probe_success: true,
@@ -590,18 +679,22 @@ mod tests {
             ..Default::default()
         };
         let evidence = HarnessEvidence {
-            model_id: "gpt-5",
-            provider_for_order: Some("openai"),
-            provider_constraint: None,
-            settings_provider_order: None,
-            config_default_harness: None,
-            settings_harness_order: None,
-            installed_harnesses: &installed,
-            linked_harnesses: None,
-            opencode_probe_result: None,
-            pi_probe_result: None,
-            cursor_probe_result: None,
-            catalog_model_slugs: None,
+            routing: routing::RoutingEvidence {
+                model_id: "gpt-5",
+                provider_for_order: Some("openai"),
+                provider_constraint: None,
+                settings_provider_order: None,
+                config_default_harness: None,
+                settings_harness_order: None,
+                installed_harnesses: &installed,
+                linked_harnesses: None,
+                opencode_probe_result: None,
+                pi_probe_result: None,
+                cursor_probe_result: None,
+                catalog_model_slugs: None,
+            },
+            model_token: "gpt-5",
+            model_source: PolicySource::Alias,
         };
 
         let resolution = resolve_harness(&input, None, None, None, evidence, &mut probe_resolver)
@@ -672,18 +765,22 @@ mod tests {
         let input = policy_input(&profile, None, Some("codex"));
         let mut probe_resolver = TestProbeResolver::default();
         let evidence = HarnessEvidence {
-            model_id: "gpt-5",
-            provider_for_order: Some("openai"),
-            provider_constraint: Some("anthropic"),
-            settings_provider_order: None,
-            config_default_harness: None,
-            settings_harness_order: None,
-            installed_harnesses: &installed,
-            linked_harnesses: None,
-            opencode_probe_result: None,
-            pi_probe_result: None,
-            cursor_probe_result: None,
-            catalog_model_slugs: None,
+            routing: routing::RoutingEvidence {
+                model_id: "gpt-5",
+                provider_for_order: Some("openai"),
+                provider_constraint: Some("anthropic"),
+                settings_provider_order: None,
+                config_default_harness: None,
+                settings_harness_order: None,
+                installed_harnesses: &installed,
+                linked_harnesses: None,
+                opencode_probe_result: None,
+                pi_probe_result: None,
+                cursor_probe_result: None,
+                catalog_model_slugs: None,
+            },
+            model_token: "gpt-5",
+            model_source: PolicySource::Alias,
         };
 
         let error = resolve_harness(&input, None, None, None, evidence, &mut probe_resolver)
@@ -744,5 +841,184 @@ mod tests {
                 .iter()
                 .any(|warning| warning.contains("settings.default_harness `bogus` is invalid"))
         );
+    }
+
+    #[test]
+    fn cli_fixed_harness_clears_lower_precedence_profile_model_on_no_model_match() {
+        let installed = installed(&["opencode"]);
+        let profile = profile_with_model(Some(HarnessKind::Claude), Some("opus"));
+        let input = policy_input(&profile, None, Some("opencode"));
+        let mut probe_resolver = TestProbeResolver {
+            opencode: Some(opencode_probe_without_anthropic()),
+            ..Default::default()
+        };
+        let evidence = HarnessEvidence {
+            routing: routing::RoutingEvidence {
+                model_id: "claude-opus-4-6",
+                provider_for_order: Some("anthropic"),
+                provider_constraint: Some("anthropic"),
+                settings_provider_order: None,
+                config_default_harness: None,
+                settings_harness_order: None,
+                installed_harnesses: &installed,
+                linked_harnesses: None,
+                opencode_probe_result: None,
+                pi_probe_result: None,
+                cursor_probe_result: None,
+                catalog_model_slugs: None,
+            },
+            model_token: "opus",
+            model_source: PolicySource::Profile,
+        };
+
+        let resolution = resolve_harness(&input, None, None, None, evidence, &mut probe_resolver)
+            .expect("cli harness should soft-fail model mismatch and continue");
+
+        assert_eq!(resolution.harness.value, "opencode");
+        assert!(resolution.warnings.iter().any(|warning| warning.contains(
+            "profile model 'opus' cannot run on cli harness 'opencode'; clearing model"
+        )));
+        assert!(resolution.model_cleared);
+    }
+
+    #[test]
+    fn cli_fixed_harness_and_cli_model_no_model_match_is_hard_error() {
+        let installed = installed(&["opencode"]);
+        let profile = profile(None);
+        let input = policy_input(&profile, Some("opus"), Some("opencode"));
+        let mut probe_resolver = TestProbeResolver {
+            opencode: Some(opencode_probe_without_anthropic()),
+            ..Default::default()
+        };
+        let evidence = HarnessEvidence {
+            routing: routing::RoutingEvidence {
+                model_id: "claude-opus-4-6",
+                provider_for_order: Some("anthropic"),
+                provider_constraint: Some("anthropic"),
+                settings_provider_order: None,
+                config_default_harness: None,
+                settings_harness_order: None,
+                installed_harnesses: &installed,
+                linked_harnesses: None,
+                opencode_probe_result: None,
+                pi_probe_result: None,
+                cursor_probe_result: None,
+                catalog_model_slugs: None,
+            },
+            model_token: "opus",
+            model_source: PolicySource::Cli,
+        };
+
+        let err = resolve_harness(&input, None, None, None, evidence, &mut probe_resolver)
+            .expect_err("same-precedence model mismatch must remain hard error");
+        assert!(err.to_string().contains("no_model_match"));
+    }
+
+    #[test]
+    fn alias_fixed_harness_with_higher_precedence_cli_model_no_model_match_is_hard_error() {
+        let installed = installed(&["opencode"]);
+        let profile = profile(None);
+        let input = policy_input(&profile, Some("opus"), None);
+        let mut probe_resolver = TestProbeResolver {
+            opencode: Some(opencode_probe_without_anthropic()),
+            ..Default::default()
+        };
+        let evidence = HarnessEvidence {
+            routing: routing::RoutingEvidence {
+                model_id: "claude-opus-4-6",
+                provider_for_order: Some("anthropic"),
+                provider_constraint: Some("anthropic"),
+                settings_provider_order: None,
+                config_default_harness: None,
+                settings_harness_order: None,
+                installed_harnesses: &installed,
+                linked_harnesses: None,
+                opencode_probe_result: None,
+                pi_probe_result: None,
+                cursor_probe_result: None,
+                catalog_model_slugs: None,
+            },
+            model_token: "opus",
+            model_source: PolicySource::Cli,
+        };
+
+        let err = resolve_harness(
+            &input,
+            Some(&model_alias(Some("opencode"))),
+            None,
+            None,
+            evidence,
+            &mut probe_resolver,
+        )
+        .expect_err("higher-precedence cli model mismatch must not be softened by alias harness");
+        assert!(err.to_string().contains("no_model_match"));
+    }
+
+    #[test]
+    fn fixed_harness_provider_constraint_unsatisfied_stays_hard_with_probe_match() {
+        let installed = installed(&["opencode"]);
+        let profile = profile_with_model(None, Some("gpt-5"));
+        let input = policy_input(&profile, None, Some("opencode"));
+        let mut probe_resolver = TestProbeResolver {
+            opencode: Some(opencode_probe_without_anthropic()),
+            ..Default::default()
+        };
+        let evidence = HarnessEvidence {
+            routing: routing::RoutingEvidence {
+                model_id: "gpt-5",
+                provider_for_order: Some("openai"),
+                provider_constraint: Some("anthropic"),
+                settings_provider_order: None,
+                config_default_harness: None,
+                settings_harness_order: None,
+                installed_harnesses: &installed,
+                linked_harnesses: None,
+                opencode_probe_result: None,
+                pi_probe_result: None,
+                cursor_probe_result: None,
+                catalog_model_slugs: None,
+            },
+            model_token: "gpt-5",
+            model_source: PolicySource::Profile,
+        };
+
+        let err = resolve_harness(&input, None, None, None, evidence, &mut probe_resolver)
+            .expect_err("provider constraint failures must remain hard even when probe matches");
+        let message = err.to_string();
+        assert!(message.contains("provider_constraint_unsatisfied"));
+        assert!(!message.contains("no_model_match"));
+    }
+
+    #[test]
+    fn profile_fixed_harness_and_profile_model_no_model_match_is_hard_error() {
+        let installed = installed(&["opencode"]);
+        let profile = profile_with_model(Some(HarnessKind::OpenCode), Some("opus"));
+        let input = policy_input(&profile, None, None);
+        let mut probe_resolver = TestProbeResolver {
+            opencode: Some(opencode_probe_without_anthropic()),
+            ..Default::default()
+        };
+        let evidence = HarnessEvidence {
+            routing: routing::RoutingEvidence {
+                model_id: "claude-opus-4-6",
+                provider_for_order: Some("anthropic"),
+                provider_constraint: Some("anthropic"),
+                settings_provider_order: None,
+                config_default_harness: None,
+                settings_harness_order: None,
+                installed_harnesses: &installed,
+                linked_harnesses: None,
+                opencode_probe_result: None,
+                pi_probe_result: None,
+                cursor_probe_result: None,
+                catalog_model_slugs: None,
+            },
+            model_token: "opus",
+            model_source: PolicySource::Profile,
+        };
+
+        let err = resolve_harness(&input, None, None, None, evidence, &mut probe_resolver)
+            .expect_err("equal precedence mismatch must remain hard error");
+        assert!(err.to_string().contains("no_model_match"));
     }
 }

--- a/src/build/policy/harness.rs
+++ b/src/build/policy/harness.rs
@@ -138,45 +138,23 @@ pub(super) fn resolve_harness(
             )
         } else {
             if let Err(rejection) = routing::acceptance::accept_assessment(&fixed_assessment) {
-                if rejection.is_not_installed() {
-                    return Err(unavailable_fixed_harness_error(
-                        selection.source.label(),
-                        &selection.value,
-                        evidence.routing.installed_harnesses,
-                    ));
-                }
-
-                let skip_reason = match rejection {
-                    routing::acceptance::RejectionReason::AssessmentFailed {
-                        ref skip_reason,
-                        ..
-                    } => skip_reason.as_deref(),
-                    _ => None,
-                };
-                if let Some(trace) = soft_fail_fixed_harness_no_model_match(
+                fixed_route_trace = resolve_fixed_harness_rejection(
+                    rejection,
                     selection.source,
                     evidence.model_source,
-                    skip_reason,
                     fixed_input,
                     &selection.value,
+                    evidence.routing.installed_harnesses,
                     probe_resolver,
-                ) {
-                    fixed_route_trace = trace;
-                    warnings.push(format!(
-                        "{} model '{}' cannot run on {} harness '{}'; clearing model (harness override takes precedence).",
-                        evidence.model_source.label(),
-                        evidence.model_token,
-                        selection.source.label(),
-                        selection.value
-                    ));
-                    model_cleared = true;
-                } else {
-                    return Err(fixed_harness_constraint_error(
-                        selection.source.label(),
-                        &selection.value,
-                        skip_reason,
-                    ));
-                }
+                )?;
+                warnings.push(format!(
+                    "{} model '{}' cannot run on {} harness '{}'; clearing model (harness override takes precedence).",
+                    evidence.model_source.label(),
+                    evidence.model_token,
+                    selection.source.label(),
+                    selection.value
+                ));
+                model_cleared = true;
             }
             let route_trace = fixed_route_trace;
             let candidates_tried = route_trace.candidates_tried.clone();
@@ -326,6 +304,44 @@ fn route_source_for_policy_source(source: PolicySource) -> routing::RouteSource 
         PolicySource::Provider => routing::RouteSource::Provider,
         _ => routing::RouteSource::Provider,
     }
+}
+
+/// Classifies a fixed-harness assessment rejection into the appropriate outcome:
+/// soft-fail (returns the retry trace when harness outranks model), or a hard error
+/// (not-installed or constraint cannot be resolved).
+fn resolve_fixed_harness_rejection(
+    rejection: routing::acceptance::RejectionReason,
+    selection_source: PolicySource,
+    model_source: PolicySource,
+    fixed_input: RoutingInput<'_>,
+    requested_harness: &str,
+    installed_harnesses: &HashSet<String>,
+    probe_resolver: &mut dyn routing::ProbeResolver,
+) -> Result<routing::RoutingTrace, MarsError> {
+    if rejection.is_not_installed() {
+        return Err(unavailable_fixed_harness_error(
+            selection_source.label(),
+            requested_harness,
+            installed_harnesses,
+        ));
+    }
+    let skip_reason = match &rejection {
+        routing::acceptance::RejectionReason::AssessmentFailed { skip_reason, .. } => {
+            skip_reason.as_deref()
+        }
+        _ => None,
+    };
+    soft_fail_fixed_harness_no_model_match(
+        selection_source,
+        model_source,
+        skip_reason,
+        fixed_input,
+        requested_harness,
+        probe_resolver,
+    )
+    .ok_or_else(|| {
+        fixed_harness_constraint_error(selection_source.label(), requested_harness, skip_reason)
+    })
 }
 
 fn soft_fail_fixed_harness_no_model_match(

--- a/src/build/policy/harness.rs
+++ b/src/build/policy/harness.rs
@@ -701,8 +701,16 @@ mod tests {
             opencode: Some(positive_opencode_probe()),
             ..Default::default()
         };
-        let evidence =
-            evidence_for_model("gpt-5", "gpt-5", PolicySource::Alias, Some("openai"), None, &installed, None, None);
+        let evidence = evidence_for_model(
+            "gpt-5",
+            "gpt-5",
+            PolicySource::Alias,
+            Some("openai"),
+            None,
+            &installed,
+            None,
+            None,
+        );
 
         let resolution = resolve_harness(&input, None, None, None, evidence, &mut probe_resolver)
             .expect("harness should pivot to opencode");
@@ -772,7 +780,14 @@ mod tests {
         let input = policy_input(&profile, None, Some("codex"));
         let mut probe_resolver = TestProbeResolver::default();
         let evidence = evidence_for_model(
-            "gpt-5", "gpt-5", PolicySource::Alias, Some("openai"), Some("anthropic"), &installed, None, None,
+            "gpt-5",
+            "gpt-5",
+            PolicySource::Alias,
+            Some("openai"),
+            Some("anthropic"),
+            &installed,
+            None,
+            None,
         );
 
         let error = resolve_harness(&input, None, None, None, evidence, &mut probe_resolver)
@@ -845,8 +860,14 @@ mod tests {
             ..Default::default()
         };
         let evidence = evidence_for_model(
-            "claude-opus-4-6", "opus", PolicySource::Profile,
-            Some("anthropic"), Some("anthropic"), &installed, None, None,
+            "claude-opus-4-6",
+            "opus",
+            PolicySource::Profile,
+            Some("anthropic"),
+            Some("anthropic"),
+            &installed,
+            None,
+            None,
         );
 
         let resolution = resolve_harness(&input, None, None, None, evidence, &mut probe_resolver)
@@ -869,8 +890,14 @@ mod tests {
             ..Default::default()
         };
         let evidence = evidence_for_model(
-            "claude-opus-4-6", "opus", PolicySource::Cli,
-            Some("anthropic"), Some("anthropic"), &installed, None, None,
+            "claude-opus-4-6",
+            "opus",
+            PolicySource::Cli,
+            Some("anthropic"),
+            Some("anthropic"),
+            &installed,
+            None,
+            None,
         );
 
         let err = resolve_harness(&input, None, None, None, evidence, &mut probe_resolver)
@@ -888,8 +915,14 @@ mod tests {
             ..Default::default()
         };
         let evidence = evidence_for_model(
-            "gpt-5", "gpt-5", PolicySource::Profile,
-            Some("openai"), Some("anthropic"), &installed, None, None,
+            "gpt-5",
+            "gpt-5",
+            PolicySource::Profile,
+            Some("openai"),
+            Some("anthropic"),
+            &installed,
+            None,
+            None,
         );
 
         let err = resolve_harness(&input, None, None, None, evidence, &mut probe_resolver)
@@ -898,5 +931,4 @@ mod tests {
         assert!(message.contains("provider_constraint_unsatisfied"));
         assert!(!message.contains("no_model_match"));
     }
-
 }

--- a/src/build/policy/harness.rs
+++ b/src/build/policy/harness.rs
@@ -520,11 +520,34 @@ mod tests {
         harness_order: Option<&'a [String]>,
         installed_harnesses: &'a HashSet<String>,
     ) -> HarnessEvidence<'a> {
+        evidence_for_model(
+            "gpt-5",
+            "gpt-5",
+            PolicySource::Alias,
+            Some("openai"),
+            None,
+            installed_harnesses,
+            config_default_harness,
+            harness_order,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn evidence_for_model<'a>(
+        model_id: &'a str,
+        model_token: &'a str,
+        model_source: PolicySource,
+        provider_for_order: Option<&'a str>,
+        provider_constraint: Option<&'a str>,
+        installed_harnesses: &'a HashSet<String>,
+        config_default_harness: Option<&'a str>,
+        harness_order: Option<&'a [String]>,
+    ) -> HarnessEvidence<'a> {
         HarnessEvidence {
             routing: routing::RoutingEvidence {
-                model_id: "gpt-5",
-                provider_for_order: Some("openai"),
-                provider_constraint: None,
+                model_id,
+                provider_for_order,
+                provider_constraint,
                 settings_provider_order: None,
                 config_default_harness,
                 settings_harness_order: harness_order,
@@ -535,8 +558,8 @@ mod tests {
                 cursor_probe_result: None,
                 catalog_model_slugs: None,
             },
-            model_token: "gpt-5",
-            model_source: PolicySource::Alias,
+            model_token,
+            model_source,
         }
     }
 
@@ -665,29 +688,12 @@ mod tests {
         let installed = installed(&["opencode"]);
         let profile = profile(Some(HarnessKind::Claude));
         let input = policy_input(&profile, None, None);
-        let opencode_probe = positive_opencode_probe();
         let mut probe_resolver = TestProbeResolver {
-            opencode: Some(opencode_probe.clone()),
+            opencode: Some(positive_opencode_probe()),
             ..Default::default()
         };
-        let evidence = HarnessEvidence {
-            routing: routing::RoutingEvidence {
-                model_id: "gpt-5",
-                provider_for_order: Some("openai"),
-                provider_constraint: None,
-                settings_provider_order: None,
-                config_default_harness: None,
-                settings_harness_order: None,
-                installed_harnesses: &installed,
-                linked_harnesses: None,
-                opencode_probe_result: None,
-                pi_probe_result: None,
-                cursor_probe_result: None,
-                catalog_model_slugs: None,
-            },
-            model_token: "gpt-5",
-            model_source: PolicySource::Alias,
-        };
+        let evidence =
+            evidence_for_model("gpt-5", "gpt-5", PolicySource::Alias, Some("openai"), None, &installed, None, None);
 
         let resolution = resolve_harness(&input, None, None, None, evidence, &mut probe_resolver)
             .expect("harness should pivot to opencode");
@@ -756,24 +762,9 @@ mod tests {
         let profile = profile(None);
         let input = policy_input(&profile, None, Some("codex"));
         let mut probe_resolver = TestProbeResolver::default();
-        let evidence = HarnessEvidence {
-            routing: routing::RoutingEvidence {
-                model_id: "gpt-5",
-                provider_for_order: Some("openai"),
-                provider_constraint: Some("anthropic"),
-                settings_provider_order: None,
-                config_default_harness: None,
-                settings_harness_order: None,
-                installed_harnesses: &installed,
-                linked_harnesses: None,
-                opencode_probe_result: None,
-                pi_probe_result: None,
-                cursor_probe_result: None,
-                catalog_model_slugs: None,
-            },
-            model_token: "gpt-5",
-            model_source: PolicySource::Alias,
-        };
+        let evidence = evidence_for_model(
+            "gpt-5", "gpt-5", PolicySource::Alias, Some("openai"), Some("anthropic"), &installed, None, None,
+        );
 
         let error = resolve_harness(&input, None, None, None, evidence, &mut probe_resolver)
             .expect_err("incompatible provider constraint should fail");
@@ -844,24 +835,10 @@ mod tests {
             opencode: Some(positive_opencode_probe()),
             ..Default::default()
         };
-        let evidence = HarnessEvidence {
-            routing: routing::RoutingEvidence {
-                model_id: "claude-opus-4-6",
-                provider_for_order: Some("anthropic"),
-                provider_constraint: Some("anthropic"),
-                settings_provider_order: None,
-                config_default_harness: None,
-                settings_harness_order: None,
-                installed_harnesses: &installed,
-                linked_harnesses: None,
-                opencode_probe_result: None,
-                pi_probe_result: None,
-                cursor_probe_result: None,
-                catalog_model_slugs: None,
-            },
-            model_token: "opus",
-            model_source: PolicySource::Profile,
-        };
+        let evidence = evidence_for_model(
+            "claude-opus-4-6", "opus", PolicySource::Profile,
+            Some("anthropic"), Some("anthropic"), &installed, None, None,
+        );
 
         let resolution = resolve_harness(&input, None, None, None, evidence, &mut probe_resolver)
             .expect("cli harness should soft-fail model mismatch and continue");
@@ -882,24 +859,10 @@ mod tests {
             opencode: Some(positive_opencode_probe()),
             ..Default::default()
         };
-        let evidence = HarnessEvidence {
-            routing: routing::RoutingEvidence {
-                model_id: "claude-opus-4-6",
-                provider_for_order: Some("anthropic"),
-                provider_constraint: Some("anthropic"),
-                settings_provider_order: None,
-                config_default_harness: None,
-                settings_harness_order: None,
-                installed_harnesses: &installed,
-                linked_harnesses: None,
-                opencode_probe_result: None,
-                pi_probe_result: None,
-                cursor_probe_result: None,
-                catalog_model_slugs: None,
-            },
-            model_token: "opus",
-            model_source: PolicySource::Cli,
-        };
+        let evidence = evidence_for_model(
+            "claude-opus-4-6", "opus", PolicySource::Cli,
+            Some("anthropic"), Some("anthropic"), &installed, None, None,
+        );
 
         let err = resolve_harness(&input, None, None, None, evidence, &mut probe_resolver)
             .expect_err("same-precedence model mismatch must remain hard error");
@@ -915,24 +878,10 @@ mod tests {
             opencode: Some(positive_opencode_probe()),
             ..Default::default()
         };
-        let evidence = HarnessEvidence {
-            routing: routing::RoutingEvidence {
-                model_id: "gpt-5",
-                provider_for_order: Some("openai"),
-                provider_constraint: Some("anthropic"),
-                settings_provider_order: None,
-                config_default_harness: None,
-                settings_harness_order: None,
-                installed_harnesses: &installed,
-                linked_harnesses: None,
-                opencode_probe_result: None,
-                pi_probe_result: None,
-                cursor_probe_result: None,
-                catalog_model_slugs: None,
-            },
-            model_token: "gpt-5",
-            model_source: PolicySource::Profile,
-        };
+        let evidence = evidence_for_model(
+            "gpt-5", "gpt-5", PolicySource::Profile,
+            Some("openai"), Some("anthropic"), &installed, None, None,
+        );
 
         let err = resolve_harness(&input, None, None, None, evidence, &mut probe_resolver)
             .expect_err("provider constraint failures must remain hard even when probe matches");

--- a/src/build/policy/harness.rs
+++ b/src/build/policy/harness.rs
@@ -153,7 +153,7 @@ pub(super) fn resolve_harness(
                     } => skip_reason.as_deref(),
                     _ => None,
                 };
-                if let Some(retry) = soft_fail_fixed_harness_no_model_match(
+                if let Some(trace) = soft_fail_fixed_harness_no_model_match(
                     selection.source,
                     evidence.model_source,
                     skip_reason,
@@ -161,8 +161,7 @@ pub(super) fn resolve_harness(
                     &selection.value,
                     probe_resolver,
                 ) {
-                    let retry = retry?;
-                    fixed_route_trace = retry;
+                    fixed_route_trace = trace;
                     warnings.push(format!(
                         "{} model '{}' cannot run on {} harness '{}'; clearing model (harness override takes precedence).",
                         evidence.model_source.label(),
@@ -336,7 +335,7 @@ fn soft_fail_fixed_harness_no_model_match(
     fixed_input: RoutingInput<'_>,
     requested_harness: &str,
     probe_resolver: &mut dyn routing::ProbeResolver,
-) -> Option<Result<routing::RoutingTrace, MarsError>> {
+) -> Option<routing::RoutingTrace> {
     let should_retry = skip_reason == Some("no_model_match")
         && harness_source.precedence_rank() > model_source.precedence_rank();
     if !should_retry {
@@ -357,17 +356,9 @@ fn soft_fail_fixed_harness_no_model_match(
         assessment.clone(),
         Vec::new(),
     );
-    Some(
-        routing::acceptance::accept_assessment(&assessment)
-            .map_err(|_| {
-                fixed_harness_constraint_error(
-                    harness_source.label(),
-                    requested_harness,
-                    skip_reason,
-                )
-            })
-            .map(|_| route_trace),
-    )
+    routing::acceptance::accept_assessment(&assessment)
+        .ok()
+        .map(|_| route_trace)
 }
 
 fn unavailable_profile_pivot_error(

--- a/src/build/policy/harness.rs
+++ b/src/build/policy/harness.rs
@@ -548,14 +548,6 @@ mod tests {
         }
     }
 
-    fn opencode_probe_without_anthropic() -> OpenCodeProbeResult {
-        OpenCodeProbeResult {
-            model_slugs: vec!["openai/gpt-5".to_string()],
-            model_probe_success: true,
-            error: None,
-        }
-    }
-
     #[derive(Default)]
     struct TestProbeResolver {
         opencode: Option<OpenCodeProbeResult>,
@@ -849,7 +841,7 @@ mod tests {
         let profile = profile_with_model(Some(HarnessKind::Claude), Some("opus"));
         let input = policy_input(&profile, None, Some("opencode"));
         let mut probe_resolver = TestProbeResolver {
-            opencode: Some(opencode_probe_without_anthropic()),
+            opencode: Some(positive_opencode_probe()),
             ..Default::default()
         };
         let evidence = HarnessEvidence {
@@ -887,7 +879,7 @@ mod tests {
         let profile = profile(None);
         let input = policy_input(&profile, Some("opus"), Some("opencode"));
         let mut probe_resolver = TestProbeResolver {
-            opencode: Some(opencode_probe_without_anthropic()),
+            opencode: Some(positive_opencode_probe()),
             ..Default::default()
         };
         let evidence = HarnessEvidence {
@@ -915,52 +907,12 @@ mod tests {
     }
 
     #[test]
-    fn alias_fixed_harness_with_higher_precedence_cli_model_no_model_match_is_hard_error() {
-        let installed = installed(&["opencode"]);
-        let profile = profile(None);
-        let input = policy_input(&profile, Some("opus"), None);
-        let mut probe_resolver = TestProbeResolver {
-            opencode: Some(opencode_probe_without_anthropic()),
-            ..Default::default()
-        };
-        let evidence = HarnessEvidence {
-            routing: routing::RoutingEvidence {
-                model_id: "claude-opus-4-6",
-                provider_for_order: Some("anthropic"),
-                provider_constraint: Some("anthropic"),
-                settings_provider_order: None,
-                config_default_harness: None,
-                settings_harness_order: None,
-                installed_harnesses: &installed,
-                linked_harnesses: None,
-                opencode_probe_result: None,
-                pi_probe_result: None,
-                cursor_probe_result: None,
-                catalog_model_slugs: None,
-            },
-            model_token: "opus",
-            model_source: PolicySource::Cli,
-        };
-
-        let err = resolve_harness(
-            &input,
-            Some(&model_alias(Some("opencode"))),
-            None,
-            None,
-            evidence,
-            &mut probe_resolver,
-        )
-        .expect_err("higher-precedence cli model mismatch must not be softened by alias harness");
-        assert!(err.to_string().contains("no_model_match"));
-    }
-
-    #[test]
     fn fixed_harness_provider_constraint_unsatisfied_stays_hard_with_probe_match() {
         let installed = installed(&["opencode"]);
         let profile = profile_with_model(None, Some("gpt-5"));
         let input = policy_input(&profile, None, Some("opencode"));
         let mut probe_resolver = TestProbeResolver {
-            opencode: Some(opencode_probe_without_anthropic()),
+            opencode: Some(positive_opencode_probe()),
             ..Default::default()
         };
         let evidence = HarnessEvidence {
@@ -989,36 +941,4 @@ mod tests {
         assert!(!message.contains("no_model_match"));
     }
 
-    #[test]
-    fn profile_fixed_harness_and_profile_model_no_model_match_is_hard_error() {
-        let installed = installed(&["opencode"]);
-        let profile = profile_with_model(Some(HarnessKind::OpenCode), Some("opus"));
-        let input = policy_input(&profile, None, None);
-        let mut probe_resolver = TestProbeResolver {
-            opencode: Some(opencode_probe_without_anthropic()),
-            ..Default::default()
-        };
-        let evidence = HarnessEvidence {
-            routing: routing::RoutingEvidence {
-                model_id: "claude-opus-4-6",
-                provider_for_order: Some("anthropic"),
-                provider_constraint: Some("anthropic"),
-                settings_provider_order: None,
-                config_default_harness: None,
-                settings_harness_order: None,
-                installed_harnesses: &installed,
-                linked_harnesses: None,
-                opencode_probe_result: None,
-                pi_probe_result: None,
-                cursor_probe_result: None,
-                catalog_model_slugs: None,
-            },
-            model_token: "opus",
-            model_source: PolicySource::Profile,
-        };
-
-        let err = resolve_harness(&input, None, None, None, evidence, &mut probe_resolver)
-            .expect_err("equal precedence mismatch must remain hard error");
-        assert!(err.to_string().contains("no_model_match"));
-    }
 }

--- a/src/build/policy/harness.rs
+++ b/src/build/policy/harness.rs
@@ -17,7 +17,9 @@ pub(super) struct HarnessResolution {
     pub(super) harness_order_position: Option<usize>,
     pub(super) candidates_tried: Vec<String>,
     pub(super) route_trace: routing::RoutingTrace,
-    pub(super) model_cleared: bool,
+    /// Set to Some(()) when a soft-fail cleared the model so harness could proceed.
+    /// Downstream routing should treat model/provider fields as empty when this is Some.
+    pub(super) model_override: Option<()>,
     pub(super) is_experimental: bool,
     pub(super) resolved_harness: HarnessKind,
     pub(super) warnings: Vec<String>,
@@ -38,7 +40,7 @@ pub(super) fn resolve_harness(
     probe_resolver: &mut dyn routing::ProbeResolver,
 ) -> Result<HarnessResolution, MarsError> {
     let mut warnings = Vec::new();
-    let mut model_cleared = false;
+    let mut model_override: Option<()> = None;
 
     let profile_harness = input.profile.harness.as_ref().map(harness_kind_to_str);
     let overlay_harness = overlay
@@ -154,7 +156,7 @@ pub(super) fn resolve_harness(
                     selection.source.label(),
                     selection.value
                 ));
-                model_cleared = true;
+                model_override = Some(());
             }
             let route_trace = fixed_route_trace;
             let candidates_tried = route_trace.candidates_tried.clone();
@@ -205,7 +207,7 @@ pub(super) fn resolve_harness(
         harness_order_position: selected_harness_order_position,
         candidates_tried,
         route_trace,
-        model_cleared,
+        model_override,
         warnings,
     })
 }
@@ -854,7 +856,7 @@ mod tests {
         assert!(resolution.warnings.iter().any(|warning| warning.contains(
             "profile model 'opus' cannot run on cli harness 'opencode'; clearing model"
         )));
-        assert!(resolution.model_cleared);
+        assert!(resolution.model_override.is_some());
     }
 
     #[test]

--- a/src/build/policy/mod.rs
+++ b/src/build/policy/mod.rs
@@ -9,6 +9,7 @@ use crate::config::{AgentOverlay, EffectiveProjectConfig, ModelPolicyMatchType, 
 use crate::error::{ConfigError, MarsError};
 use crate::harness::host::{CapabilityCollectionOptions, CapabilitySession};
 use crate::models::{self, ModelAlias};
+use crate::routing;
 
 mod execution;
 mod harness;
@@ -89,6 +90,17 @@ impl PolicySource {
             Self::Default => "default",
             Self::ProfileHarnessOverride => "profile-harness-override",
             Self::Unset => "unset",
+        }
+    }
+
+    pub(super) fn precedence_rank(self) -> u8 {
+        match self {
+            Self::Cli => 5,
+            Self::Overlay | Self::OverlayModelPolicy => 4,
+            Self::Profile | Self::ProfileModelPolicy | Self::ProfileHarnessOverride => 3,
+            Self::SettingsModelPolicy | Self::Project | Self::Config => 2,
+            Self::Alias => 1,
+            Self::Unset | Self::ConfigOrder | Self::Provider | Self::Default => 0,
         }
     }
 }
@@ -214,7 +226,7 @@ pub fn resolve_policy(
         &cache,
     )?;
 
-    warnings.extend(resolved_model.warnings);
+    warnings.extend(resolved_model.warnings.iter().cloned());
     provenance.insert(
         "model_source".to_string(),
         resolved_model.model_source.label().to_string(),
@@ -244,19 +256,23 @@ pub fn resolve_policy(
             overlay,
             matched_policy.as_ref(),
             harness::HarnessEvidence {
-                model_id: &resolved_model.model,
-                provider_for_order: resolved_model.provider_for_order.as_deref(),
-                provider_constraint: resolved_model.provider_constraint.as_deref(),
-                settings_provider_order: effective_config.settings.provider_order.as_deref(),
-                config_default_harness: effective_config.settings.default_harness.as_deref(),
-                settings_harness_order: Some(harness_order),
-                installed_harnesses: &installed_harnesses,
-                linked_harnesses: (!linked_harnesses.is_empty())
-                    .then_some(linked_harnesses.as_slice()),
-                opencode_probe_result: None,
-                pi_probe_result: None,
-                cursor_probe_result: None,
-                catalog_model_slugs: Some(catalog_slugs.as_slice()),
+                routing: routing::RoutingEvidence {
+                    model_id: &resolved_model.model,
+                    provider_for_order: resolved_model.provider_for_order.as_deref(),
+                    provider_constraint: resolved_model.provider_constraint.as_deref(),
+                    settings_provider_order: effective_config.settings.provider_order.as_deref(),
+                    config_default_harness: effective_config.settings.default_harness.as_deref(),
+                    settings_harness_order: Some(harness_order),
+                    installed_harnesses: &installed_harnesses,
+                    linked_harnesses: (!linked_harnesses.is_empty())
+                        .then_some(linked_harnesses.as_slice()),
+                    opencode_probe_result: None,
+                    pi_probe_result: None,
+                    cursor_probe_result: None,
+                    catalog_model_slugs: Some(catalog_slugs.as_slice()),
+                },
+                model_token: &resolved_model.model_token,
+                model_source: resolved_model.model_source,
             },
             &mut probe_resolver,
         )?
@@ -371,10 +387,14 @@ pub fn resolve_policy(
     let cursor_probe_result = needs_cursor_probe
         .then(|| capability_session.cursor_probe_result())
         .flatten();
+    let effective_routing_model = EffectiveRoutingModel::from_harness_resolution(
+        &resolved_model,
+        harness_resolution.model_cleared,
+    );
 
     let routing_resolution = runnable::resolve_routing(runnable::RoutingInput {
-        model: resolved_model.model.clone(),
-        model_token: resolved_model.model_token.clone(),
+        model: effective_routing_model.model,
+        model_token: effective_routing_model.model_token,
         harness: selected_harness.clone(),
         selection_kind: harness_resolution
             .route_trace
@@ -386,8 +406,8 @@ pub fn resolve_policy(
             .selected_match_evidence()
             .label()
             .to_string(),
-        provider_constraint: resolved_model.provider_constraint.as_deref(),
-        provider_for_order: resolved_model.provider_for_order.as_deref(),
+        provider_constraint: effective_routing_model.provider_constraint.as_deref(),
+        provider_for_order: effective_routing_model.provider_for_order.as_deref(),
         settings_provider_order: effective_config.settings.provider_order.as_deref(),
         effort: execution_resolution.effort.value.clone(),
         opencode_probe_result: opencode_probe_result.as_ref(),
@@ -543,6 +563,34 @@ pub(super) fn matched_policy_u8_override(
         source: policy.layer.field_source(),
         matched_rule: Some(policy.matched_rule_ref()),
     })
+}
+
+#[derive(Debug, Clone)]
+struct EffectiveRoutingModel {
+    model: String,
+    model_token: String,
+    provider_constraint: Option<String>,
+    provider_for_order: Option<String>,
+}
+
+impl EffectiveRoutingModel {
+    fn from_harness_resolution(resolved_model: &model::ResolvedModel, model_cleared: bool) -> Self {
+        if model_cleared {
+            return Self {
+                model: String::new(),
+                model_token: String::new(),
+                provider_constraint: None,
+                provider_for_order: None,
+            };
+        }
+
+        Self {
+            model: resolved_model.model.clone(),
+            model_token: resolved_model.model_token.clone(),
+            provider_constraint: resolved_model.provider_constraint.clone(),
+            provider_for_order: resolved_model.provider_for_order.clone(),
+        }
+    }
 }
 
 fn effective_policies<'a>(

--- a/src/build/policy/mod.rs
+++ b/src/build/policy/mod.rs
@@ -387,17 +387,21 @@ pub fn resolve_policy(
     let cursor_probe_result = needs_cursor_probe
         .then(|| capability_session.cursor_probe_result())
         .flatten();
-    let (effective_model, effective_model_token, effective_provider_constraint, effective_provider_for_order) =
-        if harness_resolution.model_override.is_some() {
-            (String::new(), String::new(), None::<String>, None::<String>)
-        } else {
-            (
-                resolved_model.model.clone(),
-                resolved_model.model_token.clone(),
-                resolved_model.provider_constraint.clone(),
-                resolved_model.provider_for_order.clone(),
-            )
-        };
+    let (
+        effective_model,
+        effective_model_token,
+        effective_provider_constraint,
+        effective_provider_for_order,
+    ) = if harness_resolution.model_override.is_some() {
+        (String::new(), String::new(), None::<String>, None::<String>)
+    } else {
+        (
+            resolved_model.model.clone(),
+            resolved_model.model_token.clone(),
+            resolved_model.provider_constraint.clone(),
+            resolved_model.provider_for_order.clone(),
+        )
+    };
 
     let routing_resolution = runnable::resolve_routing(runnable::RoutingInput {
         model: effective_model,

--- a/src/build/policy/mod.rs
+++ b/src/build/policy/mod.rs
@@ -387,14 +387,21 @@ pub fn resolve_policy(
     let cursor_probe_result = needs_cursor_probe
         .then(|| capability_session.cursor_probe_result())
         .flatten();
-    let effective_routing_model = EffectiveRoutingModel::from_harness_resolution(
-        &resolved_model,
-        harness_resolution.model_cleared,
-    );
+    let (effective_model, effective_model_token, effective_provider_constraint, effective_provider_for_order) =
+        if harness_resolution.model_override.is_some() {
+            (String::new(), String::new(), None::<String>, None::<String>)
+        } else {
+            (
+                resolved_model.model.clone(),
+                resolved_model.model_token.clone(),
+                resolved_model.provider_constraint.clone(),
+                resolved_model.provider_for_order.clone(),
+            )
+        };
 
     let routing_resolution = runnable::resolve_routing(runnable::RoutingInput {
-        model: effective_routing_model.model,
-        model_token: effective_routing_model.model_token,
+        model: effective_model,
+        model_token: effective_model_token,
         harness: selected_harness.clone(),
         selection_kind: harness_resolution
             .route_trace
@@ -406,8 +413,8 @@ pub fn resolve_policy(
             .selected_match_evidence()
             .label()
             .to_string(),
-        provider_constraint: effective_routing_model.provider_constraint.as_deref(),
-        provider_for_order: effective_routing_model.provider_for_order.as_deref(),
+        provider_constraint: effective_provider_constraint.as_deref(),
+        provider_for_order: effective_provider_for_order.as_deref(),
         settings_provider_order: effective_config.settings.provider_order.as_deref(),
         effort: execution_resolution.effort.value.clone(),
         opencode_probe_result: opencode_probe_result.as_ref(),
@@ -563,34 +570,6 @@ pub(super) fn matched_policy_u8_override(
         source: policy.layer.field_source(),
         matched_rule: Some(policy.matched_rule_ref()),
     })
-}
-
-#[derive(Debug, Clone)]
-struct EffectiveRoutingModel {
-    model: String,
-    model_token: String,
-    provider_constraint: Option<String>,
-    provider_for_order: Option<String>,
-}
-
-impl EffectiveRoutingModel {
-    fn from_harness_resolution(resolved_model: &model::ResolvedModel, model_cleared: bool) -> Self {
-        if model_cleared {
-            return Self {
-                model: String::new(),
-                model_token: String::new(),
-                provider_constraint: None,
-                provider_for_order: None,
-            };
-        }
-
-        Self {
-            model: resolved_model.model.clone(),
-            model_token: resolved_model.model_token.clone(),
-            provider_constraint: resolved_model.provider_constraint.clone(),
-            provider_for_order: resolved_model.provider_for_order.clone(),
-        }
-    }
 }
 
 fn effective_policies<'a>(

--- a/tests/launch_bundle.rs
+++ b/tests/launch_bundle.rs
@@ -284,8 +284,8 @@ fn build_launch_bundle_synthesizes_opencode_model_when_cache_missing() {
 }
 
 #[test]
-fn build_launch_bundle_explicit_unknown_harness_model_path_fails_closed() {
-    routing::build_launch_bundle_explicit_unknown_harness_model_path_fails_closed();
+fn build_launch_bundle_explicit_unknown_harness_model_path_clears_and_warns() {
+    routing::build_launch_bundle_explicit_unknown_harness_model_path_clears_and_warns();
 }
 
 #[test]
@@ -423,6 +423,11 @@ fn build_launch_bundle_unavailable_profile_harness_errors_without_installed_fall
 #[test]
 fn build_launch_bundle_unavailable_cli_harness_errors_without_pivoting() {
     routing::build_launch_bundle_unavailable_cli_harness_errors_without_pivoting();
+}
+
+#[test]
+fn build_launch_bundle_cli_harness_soft_fail_clears_profile_model_in_final_routing() {
+    routing::build_launch_bundle_cli_harness_soft_fail_clears_profile_model_in_final_routing();
 }
 
 #[test]

--- a/tests/launch_bundle/routing.rs
+++ b/tests/launch_bundle/routing.rs
@@ -1134,6 +1134,69 @@ Review code changes."#;
     );
 }
 
+pub(crate) fn build_launch_bundle_cli_harness_soft_fail_clears_profile_model_in_final_routing() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = install_fake_harnesses(&temp, &["opencode"]);
+    let agent_content = r#"---
+name: reviewer
+model: claude-opus-4-6
+---
+Review code changes."#;
+
+    let cache_root = temp.path().join("mars-cache");
+    write_opencode_probe_cache(
+        &cache_root,
+        now_unix_secs(),
+        json!({
+            "providers": { "openai": true },
+            "model_slugs": ["openai/gpt-5"],
+            "provider_probe_success": true,
+            "model_probe_success": true,
+            "error": null
+        }),
+    );
+
+    let (server, project_root) =
+        setup_bundle_project(&temp, "bundle-source", agent_content, &[], "");
+
+    let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
+    cmd.args([
+        "build",
+        "launch-bundle",
+        "--agent",
+        "reviewer",
+        "--harness",
+        "opencode",
+    ]);
+    cmd.env("PATH", replace_path_with(&bin_dir));
+    cmd.env("MARS_CACHE_DIR", &cache_root);
+    cmd.env("MARS_PROBE_CACHE_TTL_SECS", "60");
+
+    let output = cmd.assert().success().get_output().clone();
+    let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert_eq!(bundle["routing"]["harness"].as_str(), Some("opencode"));
+    assert_eq!(bundle["routing"]["model"].as_str(), Some(""));
+    assert_eq!(bundle["routing"]["model_token"].as_str(), Some(""));
+    assert_eq!(bundle["routing"]["harness_model"].as_str(), Some(""));
+    assert_eq!(
+        bundle["routing"]["harness_model_source"].as_str(),
+        Some("passthrough")
+    );
+    assert_eq!(
+        bundle["routing"]["match_evidence"].as_str(),
+        Some("passthrough")
+    );
+
+    let warnings = bundle["warnings"]
+        .as_array()
+        .expect("warnings should be an array");
+    assert!(warnings.iter().any(|warning| {
+        warning.as_str().unwrap_or_default()
+            == "profile model 'claude-opus-4-6' cannot run on cli harness 'opencode'; clearing model (harness override takes precedence)."
+    }));
+}
+
 pub(crate) fn build_launch_bundle_alias_harness_beats_settings_harness_order() {
     let temp = TempDir::new().unwrap();
     let bin_dir = install_fake_harnesses(&temp, &["pi", "opencode", "codex"]);
@@ -2772,7 +2835,7 @@ Review code changes."#;
     );
 }
 
-pub(crate) fn build_launch_bundle_explicit_unknown_harness_model_path_fails_closed() {
+pub(crate) fn build_launch_bundle_explicit_unknown_harness_model_path_clears_and_warns() {
     let temp = TempDir::new().unwrap();
     let bin_dir = install_fake_harnesses(&temp, &["opencode"]);
     let agent_content = r#"---
@@ -2795,10 +2858,34 @@ Review code changes."#;
     ]);
     cmd.env("PATH", replace_path_with(&bin_dir));
 
-    let output = cmd.assert().failure().code(2).get_output().clone();
-    let stderr = String::from_utf8(output.stderr).unwrap();
-    assert!(stderr.contains("cli harness `opencode` cannot run requested model"));
-    assert!(stderr.contains("no_model_match"));
+    let output = cmd.assert().success().get_output().clone();
+    let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert_eq!(bundle["routing"]["harness"].as_str(), Some("opencode"));
+    assert_eq!(bundle["routing"]["model"].as_str(), Some(""));
+    assert_eq!(bundle["routing"]["model_token"].as_str(), Some(""));
+    assert_eq!(bundle["routing"]["harness_model"].as_str(), Some(""));
+    assert_eq!(
+        bundle["routing"]["harness_model_source"].as_str(),
+        Some("passthrough")
+    );
+    assert_eq!(
+        bundle["routing"]["match_evidence"].as_str(),
+        Some("passthrough")
+    );
+    assert_eq!(
+        bundle["provenance"]["match_evidence"].as_str(),
+        Some("passthrough")
+    );
+
+    let warnings = bundle["warnings"]
+        .as_array()
+        .expect("warnings should be an array");
+    assert!(warnings.iter().any(|warning| {
+        let message = warning.as_str().unwrap_or_default();
+        message.contains("unknown-model-token")
+            && message.contains("cannot run on cli harness 'opencode'; clearing model")
+    }));
 }
 
 pub(crate) fn build_launch_bundle_alias_fixed_native_harness_rejects_mismatched_provider_constraint()


### PR DESCRIPTION
## Why

`meridian opencode` can request the OpenCode harness via CLI while the selected agent profile still contributes a Claude-oriented model such as `opus`. Before this change, the fixed OpenCode harness would hard-fail on `no_model_match`, even though the CLI harness override should outrank the lower-precedence profile model.

## Goal

A fixed harness may clear an incompatible lower-precedence model on `no_model_match` and fall through to harness passthrough/default behavior, while same-source or higher-precedence model selections remain strict.

## Summary

- Added precedence-aware fixed-harness `no_model_match` handling in launch-bundle policy resolution.
- Clears final routing model/model token/provider fields when a higher-precedence harness overrides a lower-precedence incompatible model.
- Keeps `provider_constraint_unsatisfied` and same/higher-precedence model conflicts as hard errors.
- Centralized policy source precedence ranking and effective routing-model derivation.
- Expanded unit/integration coverage for soft-fail, strict, non-CLI precedence, and provider-constraint regression cases.

## Work Item

mars-harness-model-precedence

## Changes

- `src/build/policy/harness.rs`
  - wraps routing evidence with model source/token evidence,
  - retries fixed harness evaluation with an empty model only for eligible `no_model_match`,
  - emits the model-clearing warning and reports `model_cleared`.
- `src/build/policy/mod.rs`
  - passes model provenance into harness resolution,
  - uses `EffectiveRoutingModel` so final bundle routing is actually cleared.
- `tests/launch_bundle*` and policy unit tests cover the observable JSON contract and hard-error preservation.
- `CHANGELOG.md` documents the user-visible fix.

## Verification

Automated:
- `cargo test build::policy::harness` — 14 passed
- `cargo test` — 1266 lib tests + integration/doc tests passed (1 existing ignored)
- `cargo clippy --all-targets -- -D warnings` — passed
- Pre-push hook: `cargo fmt --check`, clippy, tests with version-run skip, and release build — passed

Manual smoke:
- `cargo run --quiet -- build launch-bundle --root /home/jimyao/gitrepos/meridian-cli --harness opencode --agent product-lead --json` succeeds with empty `routing.model`, `routing.model_token`, `routing.harness_model`, passthrough evidence, and the profile-model clearing warning.
- Same command with `--model opus` fails with `no_model_match`.
- `--harness opencode --json` with no agent succeeds.
- `--agent product-lead --json` with no harness override succeeds and keeps profile model/harness routing.

## Knowledge Updates

No durable KB or `.context/` updates; this is a localized policy/routing behavior fix with tests and changelog coverage.

## Spawn Trace

- p3051 coder — implemented initial precedence-aware soft-fail
- p3053 coder — wired final routing model clearing
- p3055 coder — updated launch-bundle test expectations
- p3061 coder — simplified routing/precedence structure
- p3062 reviewer — final correctness/structural review
- p3063 simplify-reviewer — final simplification audit
- p3064 smoke-tester — end-to-end CLI smoke verification
- p3065 qa-lead — test-suite audit
- p3068 coder — added QA-requested boundary tests

## Release Label Guide

Use `release:patch` — this is a bug fix for launch-bundle harness/model routing.

## Post-Merge Automation

After merge to `main`, CI will read the release label, compute the next patch version, promote `CHANGELOG.md` `[Unreleased]`, create the release commit/tag, and run artifact publishing.

## Cleanup

After merge, clean merged worktrees with:

```bash
scripts/prune-worktrees.sh
```
