### PR TITLE
fix: deduplicate flat_items() in CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `mars list` / `mars list --status` / `mars why` / `mars doctor` showed every item N× (once per configured target). Used `canonical_flat_items()` for catalog views, `flat_items_for_target()` for divergence checks.
+- Overlay model override (`mars.local.toml`) with incompatible provider now pivots to a compatible harness instead of hard-failing. E.g. profile `harness: codex` + overlay `model: sonnet` → routes to `claude` harness.
+- Harness constraint error messages now include actionable fix suggestions.
+
 ## [0.7.6] - 2026-05-28
 
 ### Changed

--- a/src/build/policy/harness.rs
+++ b/src/build/policy/harness.rs
@@ -140,27 +140,68 @@ pub(super) fn resolve_harness(
             )
         } else {
             if let Err(rejection) = routing::acceptance::accept_assessment(&fixed_assessment) {
-                fixed_route_trace = resolve_fixed_harness_rejection(
-                    rejection,
-                    selection.source,
-                    evidence.model_source,
-                    fixed_input,
-                    &selection.value,
-                    evidence.routing.installed_harnesses,
-                    probe_resolver,
-                )?;
-                warnings.push(format!(
-                    "{} model '{}' cannot run on {} harness '{}'; clearing model (harness override takes precedence).",
-                    evidence.model_source.label(),
-                    evidence.model_token,
-                    selection.source.label(),
-                    selection.value
-                ));
-                model_override = Some(());
+                // When the model source outranks the harness source and the
+                // harness fundamentally can't run the model (provider mismatch),
+                // pivot to candidate evaluation instead of hard-failing.
+                // E.g. profile says `harness: codex` but overlay sets `model: sonnet`
+                // — the overlay model (rank 4) outranks the profile harness (rank 3),
+                // so we should find a harness that can actually run the model.
+                if rejection.is_provider_constraint()
+                    && evidence.model_source.precedence_rank()
+                        > selection.source.precedence_rank()
+                {
+                    warnings.push(format!(
+                        "{} harness '{}' cannot run {} model '{}' (provider mismatch); pivoting to compatible harness",
+                        selection.source.label(),
+                        selection.value,
+                        evidence.model_source.label(),
+                        evidence.model_token,
+                    ));
+                    let trace = evaluate_candidates(
+                        &evidence,
+                        normalized_config_default_harness.as_deref(),
+                        probe_resolver,
+                    );
+                    selected_harness_order_position = trace.selected_harness_order_position();
+                    warnings.extend(trace.selected_diagnostics().to_vec());
+                    let candidates_tried = trace.candidates_tried.clone();
+                    (
+                        ResolvedField {
+                            value: trace.harness.clone(),
+                            source: trace.source.into(),
+                            matched_rule: None,
+                        },
+                        candidates_tried,
+                        trace,
+                        None,
+                    )
+                } else {
+                    fixed_route_trace = resolve_fixed_harness_rejection(
+                        rejection,
+                        selection.source,
+                        evidence.model_source,
+                        fixed_input,
+                        &selection.value,
+                        evidence.routing.installed_harnesses,
+                        probe_resolver,
+                    )?;
+                    warnings.push(format!(
+                        "{} model '{}' cannot run on {} harness '{}'; clearing model (harness override takes precedence).",
+                        evidence.model_source.label(),
+                        evidence.model_token,
+                        selection.source.label(),
+                        selection.value
+                    ));
+                    model_override = Some(());
+                    let route_trace = fixed_route_trace;
+                    let candidates_tried = route_trace.candidates_tried.clone();
+                    (selection, candidates_tried, route_trace, None)
+                }
+            } else {
+                let route_trace = fixed_route_trace;
+                let candidates_tried = route_trace.candidates_tried.clone();
+                (selection, candidates_tried, route_trace, None)
             }
-            let route_trace = fixed_route_trace;
-            let candidates_tried = route_trace.candidates_tried.clone();
-            (selection, candidates_tried, route_trace, None)
         }
     } else {
         let trace = evaluate_candidates(
@@ -411,9 +452,23 @@ fn fixed_harness_constraint_error(
     skip_reason: Option<&str>,
 ) -> MarsError {
     let detail = skip_reason.unwrap_or("unavailable");
+    let hint = if detail == "provider_constraint_unsatisfied" {
+        format!(
+            ". The `{requested_harness}` harness cannot run this model's provider. \
+             Fix: override the harness (--harness <name>), change the model override, \
+             or remove the harness from the agent profile"
+        )
+    } else if detail == "no_model_match" {
+        format!(
+            ". The `{requested_harness}` harness does not recognize this model. \
+             Fix: check the model name or override the harness (--harness <name>)"
+        )
+    } else {
+        String::new()
+    };
     MarsError::Config(ConfigError::Invalid {
         message: format!(
-            "{source} harness `{requested_harness}` cannot run requested model under model-first routing ({detail})",
+            "{source} harness `{requested_harness}` cannot run the requested model ({detail}){hint}",
         ),
     })
 }
@@ -793,7 +848,7 @@ mod tests {
         let error = resolve_harness(&input, None, None, None, evidence, &mut probe_resolver)
             .expect_err("incompatible provider constraint should fail");
         let message = error.to_string();
-        assert!(message.contains("cli harness `codex` cannot run requested model"));
+        assert!(message.contains("cli harness `codex` cannot run the requested model"));
         assert!(message.contains("provider_constraint_unsatisfied"));
     }
 
@@ -930,5 +985,40 @@ mod tests {
         let message = err.to_string();
         assert!(message.contains("provider_constraint_unsatisfied"));
         assert!(!message.contains("no_model_match"));
+    }
+
+    #[test]
+    fn overlay_model_pivots_away_from_profile_harness_on_provider_constraint() {
+        // Scenario: profile says harness=codex, overlay (mars.local.toml) overrides
+        // model to an Anthropic model. Overlay (rank 4) outranks profile (rank 3),
+        // so the harness should pivot to candidate evaluation instead of hard-failing.
+        let installed = installed(&["codex", "claude"]);
+        let profile = profile(Some(HarnessKind::Codex));
+        let input = policy_input(&profile, None, None);
+        let mut probe_resolver = TestProbeResolver::default();
+
+        // Overlay model source (rank 4) > profile harness (rank 3)
+        let overlay = AgentOverlay {
+            model: Some("claude-sonnet-4-6".to_string()),
+            ..Default::default()
+        };
+        let evidence = evidence_for_model(
+            "claude-sonnet-4-6",
+            "sonnet",
+            PolicySource::Overlay,
+            Some("anthropic"),
+            Some("anthropic"),
+            &installed,
+            None,
+            None,
+        );
+
+        let resolution =
+            resolve_harness(&input, None, Some(&overlay), None, evidence, &mut probe_resolver)
+                .expect("should pivot to claude instead of hard-failing");
+
+        assert_eq!(resolution.harness.value, "claude");
+        assert!(resolution.model_override.is_none(), "model should NOT be cleared");
+        assert!(resolution.warnings.iter().any(|w| w.contains("provider mismatch")));
     }
 }

--- a/src/build/policy/harness.rs
+++ b/src/build/policy/harness.rs
@@ -147,8 +147,7 @@ pub(super) fn resolve_harness(
                 // — the overlay model (rank 4) outranks the profile harness (rank 3),
                 // so we should find a harness that can actually run the model.
                 if rejection.is_provider_constraint()
-                    && evidence.model_source.precedence_rank()
-                        > selection.source.precedence_rank()
+                    && evidence.model_source.precedence_rank() > selection.source.precedence_rank()
                 {
                     warnings.push(format!(
                         "{} harness '{}' cannot run {} model '{}' (provider mismatch); pivoting to compatible harness",
@@ -1013,12 +1012,26 @@ mod tests {
             None,
         );
 
-        let resolution =
-            resolve_harness(&input, None, Some(&overlay), None, evidence, &mut probe_resolver)
-                .expect("should pivot to claude instead of hard-failing");
+        let resolution = resolve_harness(
+            &input,
+            None,
+            Some(&overlay),
+            None,
+            evidence,
+            &mut probe_resolver,
+        )
+        .expect("should pivot to claude instead of hard-failing");
 
         assert_eq!(resolution.harness.value, "claude");
-        assert!(resolution.model_override.is_none(), "model should NOT be cleared");
-        assert!(resolution.warnings.iter().any(|w| w.contains("provider mismatch")));
+        assert!(
+            resolution.model_override.is_none(),
+            "model should NOT be cleared"
+        );
+        assert!(
+            resolution
+                .warnings
+                .iter()
+                .any(|w| w.contains("provider mismatch"))
+        );
     }
 }

--- a/src/build/policy/harness.rs
+++ b/src/build/policy/harness.rs
@@ -681,6 +681,27 @@ mod tests {
         }
     }
 
+    /// Test wrapper: calls `resolve_harness` with auth defaulting to all-OK.
+    /// Tests that need custom auth behavior should call `resolve_harness` directly.
+    fn resolve_harness_test(
+        input: &PolicyInput<'_>,
+        alias: Option<&ModelAlias>,
+        overlay: Option<&AgentOverlay>,
+        matched_policy: Option<&MatchedModelPolicy>,
+        evidence: HarnessEvidence<'_>,
+        probe_resolver: &mut dyn routing::ProbeResolver,
+    ) -> Result<HarnessResolution, MarsError> {
+        resolve_harness(
+            input,
+            alias,
+            overlay,
+            matched_policy,
+            evidence,
+            probe_resolver,
+            |_| true,
+        )
+    }
+
     #[test]
     fn cli_override_is_explicit_and_skips_candidate_eval() {
         let installed = installed(&["codex", "pi"]);
@@ -688,14 +709,13 @@ mod tests {
         let input = policy_input(&profile, None, Some("pi"));
         let mut probe_resolver = TestProbeResolver::default();
 
-        let resolution = resolve_harness(
+        let resolution = resolve_harness_test(
             &input,
             Some(&model_alias(Some("codex"))),
             None,
             None,
             evidence(None, None, &installed),
             &mut probe_resolver,
-            |_| true,
         )
         .expect("harness should resolve");
 
@@ -720,14 +740,13 @@ mod tests {
         let input = policy_input(&profile, Some("gptmini"), None);
         let mut probe_resolver = TestProbeResolver::default();
 
-        let resolution = resolve_harness(
+        let resolution = resolve_harness_test(
             &input,
             Some(&model_alias(Some("opencode"))),
             None,
             None,
             evidence(None, None, &installed),
             &mut probe_resolver,
-            |_| true,
         )
         .expect("harness should resolve");
 
@@ -751,14 +770,13 @@ mod tests {
         let input = policy_input(&profile, None, None);
         let mut probe_resolver = TestProbeResolver::default();
 
-        let resolution = resolve_harness(
+        let resolution = resolve_harness_test(
             &input,
             Some(&model_alias(Some("codex"))),
             None,
             None,
             evidence(None, None, &installed),
             &mut probe_resolver,
-            |_| true,
         )
         .expect("harness should resolve");
 
@@ -795,16 +813,9 @@ mod tests {
             None,
         );
 
-        let resolution = resolve_harness(
-            &input,
-            None,
-            None,
-            None,
-            evidence,
-            &mut probe_resolver,
-            |_| true,
-        )
-        .expect("harness should pivot to opencode");
+        let resolution =
+            resolve_harness_test(&input, None, None, None, evidence, &mut probe_resolver)
+                .expect("harness should pivot to opencode");
 
         assert_eq!(resolution.harness.value, "opencode");
         assert_eq!(resolution.harness.source, PolicySource::Provider);
@@ -825,14 +836,13 @@ mod tests {
         let input = policy_input(&profile, None, None);
         let mut probe_resolver = TestProbeResolver::default();
 
-        let resolution = resolve_harness(
+        let resolution = resolve_harness_test(
             &input,
             None,
             None,
             None,
             evidence(None, None, &installed),
             &mut probe_resolver,
-            |_| true,
         )
         .expect("profile harness should pivot to available candidates");
         assert_eq!(resolution.harness.value, "opencode");
@@ -850,14 +860,13 @@ mod tests {
         let input = policy_input(&profile, None, Some("claude"));
         let mut probe_resolver = TestProbeResolver::default();
 
-        let error = resolve_harness(
+        let error = resolve_harness_test(
             &input,
             Some(&model_alias(Some("codex"))),
             None,
             None,
             evidence(None, None, &installed),
             &mut probe_resolver,
-            |_| true,
         )
         .expect_err("unavailable explicit harness should fail");
         let message = error.to_string();
@@ -883,16 +892,8 @@ mod tests {
             None,
         );
 
-        let error = resolve_harness(
-            &input,
-            None,
-            None,
-            None,
-            evidence,
-            &mut probe_resolver,
-            |_| true,
-        )
-        .expect_err("incompatible provider constraint should fail");
+        let error = resolve_harness_test(&input, None, None, None, evidence, &mut probe_resolver)
+            .expect_err("incompatible provider constraint should fail");
         let message = error.to_string();
         assert!(message.contains("cli harness `codex` cannot run the requested model"));
         assert!(message.contains("provider_constraint_unsatisfied"));
@@ -906,14 +907,13 @@ mod tests {
         let input = policy_input(&profile, None, None);
         let mut probe_resolver = TestProbeResolver::default();
 
-        let resolution = resolve_harness(
+        let resolution = resolve_harness_test(
             &input,
             None,
             None,
             None,
             evidence(None, Some(&order), &installed),
             &mut probe_resolver,
-            |_| true,
         )
         .expect("harness should resolve");
 
@@ -934,14 +934,13 @@ mod tests {
         let input = policy_input(&profile, None, None);
         let mut probe_resolver = TestProbeResolver::default();
 
-        let resolution = resolve_harness(
+        let resolution = resolve_harness_test(
             &input,
             None,
             None,
             None,
             evidence(Some("bogus"), None, &installed),
             &mut probe_resolver,
-            |_| true,
         )
         .expect("harness should resolve");
 
@@ -973,16 +972,9 @@ mod tests {
             None,
         );
 
-        let resolution = resolve_harness(
-            &input,
-            None,
-            None,
-            None,
-            evidence,
-            &mut probe_resolver,
-            |_| true,
-        )
-        .expect("cli harness should soft-fail model mismatch and continue");
+        let resolution =
+            resolve_harness_test(&input, None, None, None, evidence, &mut probe_resolver)
+                .expect("cli harness should soft-fail model mismatch and continue");
 
         assert_eq!(resolution.harness.value, "opencode");
         assert!(resolution.warnings.iter().any(|warning| warning.contains(
@@ -1011,16 +1003,8 @@ mod tests {
             None,
         );
 
-        let err = resolve_harness(
-            &input,
-            None,
-            None,
-            None,
-            evidence,
-            &mut probe_resolver,
-            |_| true,
-        )
-        .expect_err("same-precedence model mismatch must remain hard error");
+        let err = resolve_harness_test(&input, None, None, None, evidence, &mut probe_resolver)
+            .expect_err("same-precedence model mismatch must remain hard error");
         assert!(err.to_string().contains("no_model_match"));
     }
 
@@ -1044,16 +1028,8 @@ mod tests {
             None,
         );
 
-        let err = resolve_harness(
-            &input,
-            None,
-            None,
-            None,
-            evidence,
-            &mut probe_resolver,
-            |_| true,
-        )
-        .expect_err("provider constraint failures must remain hard even when probe matches");
+        let err = resolve_harness_test(&input, None, None, None, evidence, &mut probe_resolver)
+            .expect_err("provider constraint failures must remain hard even when probe matches");
         let message = err.to_string();
         assert!(message.contains("provider_constraint_unsatisfied"));
         assert!(!message.contains("no_model_match"));
@@ -1085,14 +1061,13 @@ mod tests {
             None,
         );
 
-        let resolution = resolve_harness(
+        let resolution = resolve_harness_test(
             &input,
             None,
             Some(&overlay),
             None,
             evidence,
             &mut probe_resolver,
-            |_| true,
         )
         .expect("should pivot to claude instead of hard-failing");
 

--- a/src/build/policy/harness.rs
+++ b/src/build/policy/harness.rs
@@ -367,6 +367,7 @@ fn route_source_for_policy_source(source: PolicySource) -> routing::RouteSource 
 /// Classifies a fixed-harness assessment rejection into the appropriate outcome:
 /// soft-fail (returns the retry trace when harness outranks model), or a hard error
 /// (not-installed or constraint cannot be resolved).
+#[allow(clippy::too_many_arguments)]
 fn resolve_fixed_harness_rejection<F>(
     rejection: routing::acceptance::RejectionReason,
     selection_source: PolicySource,

--- a/src/build/policy/harness.rs
+++ b/src/build/policy/harness.rs
@@ -31,14 +31,18 @@ pub(super) struct HarnessEvidence<'a> {
     pub(super) model_source: PolicySource,
 }
 
-pub(super) fn resolve_harness(
+pub(super) fn resolve_harness<F>(
     input: &PolicyInput<'_>,
     alias: Option<&ModelAlias>,
     overlay: Option<&AgentOverlay>,
     matched_policy: Option<&MatchedModelPolicy>,
     evidence: HarnessEvidence<'_>,
     probe_resolver: &mut dyn routing::ProbeResolver,
-) -> Result<HarnessResolution, MarsError> {
+    auth_check: F,
+) -> Result<HarnessResolution, MarsError>
+where
+    F: Fn(&str) -> bool + Copy,
+{
     let mut warnings = Vec::new();
     let mut model_override: Option<()> = None;
 
@@ -93,7 +97,7 @@ pub(super) fn resolve_harness(
             &fixed_input,
             &selection.value,
             probe_resolver,
-            crate::models::harness::native_harness_authenticated,
+            auth_check,
         );
         let mut fixed_route_trace = routing::trace_for_fixed_harness(
             route_source_for_policy_source(selection.source),
@@ -117,6 +121,7 @@ pub(super) fn resolve_harness(
                 &evidence,
                 normalized_config_default_harness.as_deref(),
                 probe_resolver,
+                auth_check,
             );
             selected_harness_order_position = trace.selected_harness_order_position();
             warnings.extend(trace.selected_diagnostics().to_vec());
@@ -164,6 +169,7 @@ pub(super) fn resolve_harness(
                         &evidence,
                         normalized_config_default_harness.as_deref(),
                         probe_resolver,
+                        auth_check,
                     );
                     selected_harness_order_position = trace.selected_harness_order_position();
                     warnings.extend(trace.selected_diagnostics().to_vec());
@@ -187,6 +193,7 @@ pub(super) fn resolve_harness(
                         &selection.value,
                         evidence.routing.installed_harnesses,
                         probe_resolver,
+                        auth_check,
                     )?;
                     warnings.push(format!(
                         "{} model '{}' cannot run on {} harness '{}'; clearing model (harness override takes precedence).",
@@ -211,6 +218,7 @@ pub(super) fn resolve_harness(
             &evidence,
             normalized_config_default_harness.as_deref(),
             probe_resolver,
+            auth_check,
         );
         selected_harness_order_position = trace.selected_harness_order_position();
         warnings.extend(trace.selected_diagnostics().to_vec());
@@ -327,15 +335,19 @@ fn routing_input_from_evidence<'a>(
         .routing_input_with_config_default_harness(normalized_config_default_harness)
 }
 
-fn evaluate_candidates(
+fn evaluate_candidates<F>(
     evidence: &HarnessEvidence<'_>,
     normalized_config_default_harness: Option<&str>,
     probe_resolver: &mut dyn routing::ProbeResolver,
-) -> routing::RoutingTrace {
+    auth_check: F,
+) -> routing::RoutingTrace
+where
+    F: Fn(&str) -> bool,
+{
     routing::evaluate_candidates_with_auth_and_probes(
         &routing_input_from_evidence(evidence, normalized_config_default_harness),
         probe_resolver,
-        crate::models::harness::native_harness_authenticated,
+        auth_check,
     )
 }
 
@@ -355,7 +367,7 @@ fn route_source_for_policy_source(source: PolicySource) -> routing::RouteSource 
 /// Classifies a fixed-harness assessment rejection into the appropriate outcome:
 /// soft-fail (returns the retry trace when harness outranks model), or a hard error
 /// (not-installed or constraint cannot be resolved).
-fn resolve_fixed_harness_rejection(
+fn resolve_fixed_harness_rejection<F>(
     rejection: routing::acceptance::RejectionReason,
     selection_source: PolicySource,
     model_source: PolicySource,
@@ -363,7 +375,11 @@ fn resolve_fixed_harness_rejection(
     requested_harness: &str,
     installed_harnesses: &HashSet<String>,
     probe_resolver: &mut dyn routing::ProbeResolver,
-) -> Result<routing::RoutingTrace, MarsError> {
+    auth_check: F,
+) -> Result<routing::RoutingTrace, MarsError>
+where
+    F: Fn(&str) -> bool,
+{
     if rejection.is_not_installed() {
         return Err(unavailable_fixed_harness_error(
             selection_source.label(),
@@ -384,20 +400,25 @@ fn resolve_fixed_harness_rejection(
         fixed_input,
         requested_harness,
         probe_resolver,
+        auth_check,
     )
     .ok_or_else(|| {
         fixed_harness_constraint_error(selection_source.label(), requested_harness, skip_reason)
     })
 }
 
-fn soft_fail_fixed_harness_no_model_match(
+fn soft_fail_fixed_harness_no_model_match<F>(
     harness_source: PolicySource,
     model_source: PolicySource,
     skip_reason: Option<&str>,
     fixed_input: RoutingInput<'_>,
     requested_harness: &str,
     probe_resolver: &mut dyn routing::ProbeResolver,
-) -> Option<routing::RoutingTrace> {
+    auth_check: F,
+) -> Option<routing::RoutingTrace>
+where
+    F: Fn(&str) -> bool,
+{
     let should_retry = skip_reason == Some("no_model_match")
         && harness_source.precedence_rank() > model_source.precedence_rank();
     if !should_retry {
@@ -410,7 +431,7 @@ fn soft_fail_fixed_harness_no_model_match(
         &passthrough_input,
         requested_harness,
         probe_resolver,
-        crate::models::harness::native_harness_authenticated,
+        auth_check,
     );
     let route_trace = routing::trace_for_fixed_harness(
         route_source_for_policy_source(harness_source),
@@ -673,6 +694,7 @@ mod tests {
             None,
             evidence(None, None, &installed),
             &mut probe_resolver,
+            |_| true,
         )
         .expect("harness should resolve");
 
@@ -704,6 +726,7 @@ mod tests {
             None,
             evidence(None, None, &installed),
             &mut probe_resolver,
+            |_| true,
         )
         .expect("harness should resolve");
 
@@ -734,6 +757,7 @@ mod tests {
             None,
             evidence(None, None, &installed),
             &mut probe_resolver,
+            |_| true,
         )
         .expect("harness should resolve");
 
@@ -770,8 +794,9 @@ mod tests {
             None,
         );
 
-        let resolution = resolve_harness(&input, None, None, None, evidence, &mut probe_resolver)
-            .expect("harness should pivot to opencode");
+        let resolution =
+            resolve_harness(&input, None, None, None, evidence, &mut probe_resolver, |_| true)
+                .expect("harness should pivot to opencode");
 
         assert_eq!(resolution.harness.value, "opencode");
         assert_eq!(resolution.harness.source, PolicySource::Provider);
@@ -799,6 +824,7 @@ mod tests {
             None,
             evidence(None, None, &installed),
             &mut probe_resolver,
+            |_| true,
         )
         .expect("profile harness should pivot to available candidates");
         assert_eq!(resolution.harness.value, "opencode");
@@ -823,6 +849,7 @@ mod tests {
             None,
             evidence(None, None, &installed),
             &mut probe_resolver,
+            |_| true,
         )
         .expect_err("unavailable explicit harness should fail");
         let message = error.to_string();
@@ -848,8 +875,9 @@ mod tests {
             None,
         );
 
-        let error = resolve_harness(&input, None, None, None, evidence, &mut probe_resolver)
-            .expect_err("incompatible provider constraint should fail");
+        let error =
+            resolve_harness(&input, None, None, None, evidence, &mut probe_resolver, |_| true)
+                .expect_err("incompatible provider constraint should fail");
         let message = error.to_string();
         assert!(message.contains("cli harness `codex` cannot run the requested model"));
         assert!(message.contains("provider_constraint_unsatisfied"));
@@ -870,6 +898,7 @@ mod tests {
             None,
             evidence(None, Some(&order), &installed),
             &mut probe_resolver,
+            |_| true,
         )
         .expect("harness should resolve");
 
@@ -897,6 +926,7 @@ mod tests {
             None,
             evidence(Some("bogus"), None, &installed),
             &mut probe_resolver,
+            |_| true,
         )
         .expect("harness should resolve");
 
@@ -928,8 +958,9 @@ mod tests {
             None,
         );
 
-        let resolution = resolve_harness(&input, None, None, None, evidence, &mut probe_resolver)
-            .expect("cli harness should soft-fail model mismatch and continue");
+        let resolution =
+            resolve_harness(&input, None, None, None, evidence, &mut probe_resolver, |_| true)
+                .expect("cli harness should soft-fail model mismatch and continue");
 
         assert_eq!(resolution.harness.value, "opencode");
         assert!(resolution.warnings.iter().any(|warning| warning.contains(
@@ -958,8 +989,9 @@ mod tests {
             None,
         );
 
-        let err = resolve_harness(&input, None, None, None, evidence, &mut probe_resolver)
-            .expect_err("same-precedence model mismatch must remain hard error");
+        let err =
+            resolve_harness(&input, None, None, None, evidence, &mut probe_resolver, |_| true)
+                .expect_err("same-precedence model mismatch must remain hard error");
         assert!(err.to_string().contains("no_model_match"));
     }
 
@@ -983,8 +1015,9 @@ mod tests {
             None,
         );
 
-        let err = resolve_harness(&input, None, None, None, evidence, &mut probe_resolver)
-            .expect_err("provider constraint failures must remain hard even when probe matches");
+        let err =
+            resolve_harness(&input, None, None, None, evidence, &mut probe_resolver, |_| true)
+                .expect_err("provider constraint failures must remain hard even when probe matches");
         let message = err.to_string();
         assert!(message.contains("provider_constraint_unsatisfied"));
         assert!(!message.contains("no_model_match"));
@@ -1023,6 +1056,7 @@ mod tests {
             None,
             evidence,
             &mut probe_resolver,
+            |_| true,
         )
         .expect("should pivot to claude instead of hard-failing");
 

--- a/src/build/policy/harness.rs
+++ b/src/build/policy/harness.rs
@@ -140,13 +140,17 @@ pub(super) fn resolve_harness(
             )
         } else {
             if let Err(rejection) = routing::acceptance::accept_assessment(&fixed_assessment) {
-                // When the model source outranks the harness source and the
-                // harness fundamentally can't run the model (provider mismatch),
-                // pivot to candidate evaluation instead of hard-failing.
-                // E.g. profile says `harness: codex` but overlay sets `model: sonnet`
-                // — the overlay model (rank 4) outranks the profile harness (rank 3),
-                // so we should find a harness that can actually run the model.
+                // When the model comes from a higher-precedence *configuration
+                // layer* (overlay/CLI) and the harness from a lower layer (profile),
+                // pivot to candidate evaluation instead of hard-failing on provider
+                // mismatch. E.g. profile says `harness: codex` but overlay sets
+                // `model: sonnet` — the overlay should win.
+                //
+                // Do NOT pivot when the harness comes from an alias — alias pairs
+                // model+harness intentionally, even if the model source (profile)
+                // technically outranks the alias harness.
                 if rejection.is_provider_constraint()
+                    && selection.source == PolicySource::Profile
                     && evidence.model_source.precedence_rank() > selection.source.precedence_rank()
                 {
                     warnings.push(format!(

--- a/src/build/policy/harness.rs
+++ b/src/build/policy/harness.rs
@@ -794,9 +794,16 @@ mod tests {
             None,
         );
 
-        let resolution =
-            resolve_harness(&input, None, None, None, evidence, &mut probe_resolver, |_| true)
-                .expect("harness should pivot to opencode");
+        let resolution = resolve_harness(
+            &input,
+            None,
+            None,
+            None,
+            evidence,
+            &mut probe_resolver,
+            |_| true,
+        )
+        .expect("harness should pivot to opencode");
 
         assert_eq!(resolution.harness.value, "opencode");
         assert_eq!(resolution.harness.source, PolicySource::Provider);
@@ -875,9 +882,16 @@ mod tests {
             None,
         );
 
-        let error =
-            resolve_harness(&input, None, None, None, evidence, &mut probe_resolver, |_| true)
-                .expect_err("incompatible provider constraint should fail");
+        let error = resolve_harness(
+            &input,
+            None,
+            None,
+            None,
+            evidence,
+            &mut probe_resolver,
+            |_| true,
+        )
+        .expect_err("incompatible provider constraint should fail");
         let message = error.to_string();
         assert!(message.contains("cli harness `codex` cannot run the requested model"));
         assert!(message.contains("provider_constraint_unsatisfied"));
@@ -958,9 +972,16 @@ mod tests {
             None,
         );
 
-        let resolution =
-            resolve_harness(&input, None, None, None, evidence, &mut probe_resolver, |_| true)
-                .expect("cli harness should soft-fail model mismatch and continue");
+        let resolution = resolve_harness(
+            &input,
+            None,
+            None,
+            None,
+            evidence,
+            &mut probe_resolver,
+            |_| true,
+        )
+        .expect("cli harness should soft-fail model mismatch and continue");
 
         assert_eq!(resolution.harness.value, "opencode");
         assert!(resolution.warnings.iter().any(|warning| warning.contains(
@@ -989,9 +1010,16 @@ mod tests {
             None,
         );
 
-        let err =
-            resolve_harness(&input, None, None, None, evidence, &mut probe_resolver, |_| true)
-                .expect_err("same-precedence model mismatch must remain hard error");
+        let err = resolve_harness(
+            &input,
+            None,
+            None,
+            None,
+            evidence,
+            &mut probe_resolver,
+            |_| true,
+        )
+        .expect_err("same-precedence model mismatch must remain hard error");
         assert!(err.to_string().contains("no_model_match"));
     }
 
@@ -1015,9 +1043,16 @@ mod tests {
             None,
         );
 
-        let err =
-            resolve_harness(&input, None, None, None, evidence, &mut probe_resolver, |_| true)
-                .expect_err("provider constraint failures must remain hard even when probe matches");
+        let err = resolve_harness(
+            &input,
+            None,
+            None,
+            None,
+            evidence,
+            &mut probe_resolver,
+            |_| true,
+        )
+        .expect_err("provider constraint failures must remain hard even when probe matches");
         let message = err.to_string();
         assert!(message.contains("provider_constraint_unsatisfied"));
         assert!(!message.contains("no_model_match"));

--- a/src/build/policy/mod.rs
+++ b/src/build/policy/mod.rs
@@ -275,6 +275,7 @@ pub fn resolve_policy(
                 model_source: resolved_model.model_source,
             },
             &mut probe_resolver,
+            crate::models::harness::native_harness_authenticated,
         )?
     };
 

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -36,7 +36,7 @@ pub fn run(_args: &DoctorArgs, ctx: &super::MarsContext, json: bool) -> Result<i
 
     // Check each locked item against .mars/ canonical store
     let mars_dir = ctx.project_root.join(".mars");
-    for (dest_path_str, item) in lock.flat_items() {
+    for (dest_path_str, item) in lock.canonical_flat_items() {
         let disk_path = dest_path_str.resolve(&mars_dir);
 
         // Check file exists
@@ -256,7 +256,7 @@ fn check_target_divergence(
     let mut divergence_count = 0;
 
     for target_name in targets {
-        for (dest_path, item) in lock.flat_items() {
+        for (dest_path, item) in lock.flat_items_for_target(target_name) {
             let relative_path = std::path::Path::new(target_name).join(dest_path.as_str());
             let target_path = project_root.join(&relative_path);
 
@@ -305,23 +305,34 @@ mod tests {
     use super::{check_legacy_agents_directory, check_target_divergence};
 
     /// Returns (key, LockedItemV2) for insertion into LockFile.items.
+    ///
+    /// Creates output records for `.mars` (canonical) plus any additional targets.
     fn make_locked_agent(
         name: &str,
         dest_path: &str,
         expected_content: &str,
+        extra_targets: &[&str],
     ) -> (String, crate::lock::LockedItemV2) {
         let expected_hash = crate::hash::hash_bytes(expected_content.as_bytes());
         let key = format!("agent/{name}");
+        let mut outputs = vec![crate::lock::OutputRecord {
+            target_root: ".mars".to_string(),
+            dest_path: dest_path.into(),
+            installed_checksum: expected_hash.clone().into(),
+        }];
+        for target in extra_targets {
+            outputs.push(crate::lock::OutputRecord {
+                target_root: (*target).to_string(),
+                dest_path: dest_path.into(),
+                installed_checksum: expected_hash.clone().into(),
+            });
+        }
         let item = crate::lock::LockedItemV2 {
             source: "test-source".into(),
             kind: crate::lock::ItemKind::Agent,
             version: None,
             source_checksum: expected_hash.clone().into(),
-            outputs: vec![crate::lock::OutputRecord {
-                target_root: ".mars".to_string(),
-                dest_path: dest_path.into(),
-                installed_checksum: expected_hash.into(),
-            }],
+            outputs,
         };
         (key, item)
     }
@@ -332,9 +343,19 @@ mod tests {
         let root = temp.path();
 
         let mut lock = crate::lock::LockFile::empty();
-        let (k, v) = make_locked_agent("missing", "agents/missing.md", "expected missing");
+        let (k, v) = make_locked_agent(
+            "missing",
+            "agents/missing.md",
+            "expected missing",
+            &[".agents"],
+        );
         lock.items.insert(k, v);
-        let (k, v) = make_locked_agent("modified", "agents/modified.md", "expected content");
+        let (k, v) = make_locked_agent(
+            "modified",
+            "agents/modified.md",
+            "expected content",
+            &[".agents"],
+        );
         lock.items.insert(k, v);
 
         fs::create_dir_all(root.join(".agents/agents")).expect("create target dir");
@@ -365,7 +386,12 @@ mod tests {
         let root = temp.path();
 
         let mut lock = crate::lock::LockFile::empty();
-        let (k, v) = make_locked_agent("test", "agents/test.md", "expected content");
+        let (k, v) = make_locked_agent(
+            "test",
+            "agents/test.md",
+            "expected content",
+            &[".agents", ".claude"],
+        );
         lock.items.insert(k, v);
 
         fs::create_dir_all(root.join(".agents/agents")).expect("create .agents tree");

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -39,7 +39,7 @@ pub fn run(args: &ListArgs, ctx: &super::MarsContext, json: bool) -> Result<i32,
     let mut skills = Vec::new();
     let mut bootstrap = Vec::new();
 
-    for (dest_path, item) in lock.flat_items() {
+    for (dest_path, item) in lock.canonical_flat_items() {
         // Filter by source
         if let Some(ref filter_source) = args.source
             && item.source != *filter_source
@@ -158,7 +158,7 @@ fn run_status(
 ) -> Result<i32, MarsError> {
     let mut entries = Vec::new();
 
-    for (dest_path, item) in lock.flat_items() {
+    for (dest_path, item) in lock.canonical_flat_items() {
         if let Some(ref filter_source) = args.source
             && item.source != *filter_source
         {

--- a/src/cli/why.rs
+++ b/src/cli/why.rs
@@ -32,7 +32,7 @@ pub fn run(args: &WhyArgs, ctx: &super::MarsContext, json: bool) -> Result<i32, 
 
     // Find the item by name (try matching dest_path, name stem, or skill dir name)
     let mut found = None;
-    for (dest_path, item) in lock.flat_items() {
+    for (dest_path, item) in lock.canonical_flat_items() {
         let name_matches =
             dest_path.item_name(item.kind) == args.name || dest_path.as_str() == args.name;
 
@@ -101,7 +101,7 @@ fn find_referencing_agents(
 ) -> Vec<String> {
     let mut refs = Vec::new();
 
-    for (dest_path, item) in lock.flat_items() {
+    for (dest_path, item) in lock.canonical_flat_items() {
         if item.kind != ItemKind::Agent {
             continue;
         }

--- a/src/routing/acceptance.rs
+++ b/src/routing/acceptance.rs
@@ -32,6 +32,22 @@ impl RejectionReason {
     pub fn is_not_installed(&self) -> bool {
         matches!(self, Self::HarnessNotInstalled { .. })
     }
+
+    pub fn skip_reason(&self) -> Option<&str> {
+        match self {
+            Self::AssessmentFailed { skip_reason, .. } => skip_reason.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// Whether the rejection is due to a provider constraint that makes the
+    /// harness fundamentally unable to run the requested model (e.g. codex
+    /// cannot run Anthropic models). Distinguished from `no_model_match` which
+    /// means the harness could potentially run the provider but doesn't
+    /// recognize the specific model slug.
+    pub fn is_provider_constraint(&self) -> bool {
+        self.skip_reason() == Some("provider_constraint_unsatisfied")
+    }
 }
 
 /// Check whether a routing trace meets the given acceptance policy.

--- a/src/sync/apply.rs
+++ b/src/sync/apply.rs
@@ -435,7 +435,7 @@ pub fn prune_orphans(
 ) -> Result<Vec<ActionOutcome>, MarsError> {
     let mut outcomes = Vec::new();
 
-    for (dest_path_str, locked_item) in lock.flat_items() {
+    for (dest_path_str, locked_item) in lock.canonical_flat_items() {
         if !target.items.contains_key(&dest_path_str) {
             let dest = removal_path(root, &dest_path_str, locked_item.kind);
             if dest.exists() {

--- a/tests/launch_bundle/routing.rs
+++ b/tests/launch_bundle/routing.rs
@@ -2912,7 +2912,7 @@ harness = "codex""#;
 
     let output = cmd.assert().failure().code(2).get_output().clone();
     let stderr = String::from_utf8(output.stderr).unwrap();
-    assert!(stderr.contains("alias harness `codex` cannot run requested model"));
+    assert!(stderr.contains("alias harness `codex` cannot run the requested model"));
     assert!(stderr.contains("provider_constraint_unsatisfied"));
 }
 


### PR DESCRIPTION
## Why

Three bugs in mars CLI commands caused by the v2 lock format's per-target output records:

1. `mars list` / `mars why` / `mars doctor` showed every item N× (once per configured target)
2. Overlay model override (mars.local.toml) with incompatible provider hard-failed instead of pivoting to a compatible harness
3. Harness constraint error messages were not actionable

Plus a unit test that depended on host auth state (Claude authenticated locally but not on CI).

## Goal

- Catalog/status views show each logical item exactly once
- `mars.local.toml` model override to a different provider pivots the harness instead of failing
- Constraint errors tell the user what to do
- Unit tests are host-auth-independent

## Summary

- Changed `flat_items()` → `canonical_flat_items()` in list, why, doctor catalog views
- Changed `flat_items()` → `flat_items_for_target()` in doctor target divergence checks
- Added provider-constraint pivot in harness routing: when overlay model (rank 4) outranks profile harness (rank 3) and the provider is incompatible, pivot to candidate evaluation
- Made constraint error messages include actionable fix suggestions
- Injected auth callback into `resolve_harness` so tests don't depend on host auth state
- Added `resolve_harness_test()` helper that centralizes the auth mock — all 13 tests use it, future tests get the right default automatically

## Changes

- `cli/list.rs`: catalog + status views use `canonical_flat_items()` — each item listed once
- `cli/doctor.rs`: canonical store check uses `canonical_flat_items()`; target divergence uses `flat_items_for_target()` with correct per-target checksums
- `cli/why.rs`: item lookup + referencing agents use `canonical_flat_items()`
- `sync/apply.rs`: `prune_orphans` uses `canonical_flat_items()` (pub fn, currently test-only)
- `build/policy/harness.rs`: provider-constraint pivot scoped to profile harness only; `resolve_harness` now takes an `auth_check` callback threaded through all internal helpers; `resolve_harness_test()` fixture centralizes auth mock for all 13 tests
- `build/policy/mod.rs`: production caller passes `native_harness_authenticated`
- `routing/acceptance.rs`: added `skip_reason()` and `is_provider_constraint()` helpers

## Verification

- 1265 unit tests pass (`cargo test --lib`)
- 13 integration tests pass (`cargo test --test launch_bundle`)
- Smoke tested `mars list`, `mars list --status`, `mars why` against meridian-cli — each item appears exactly once
- `overlay_model_pivots_away_from_profile_harness_on_provider_constraint` now passes on hosts without Claude auth
- `cargo clippy --all-targets` clean

## Knowledge Updates

N/A — bugfix, no new concepts.

## Release Label Guide

`release:patch`