### PR TITLE
feat: progressive-loading fields + mars agents/skills subcommands

### DIFF
--- a/src/build/bundle.rs
+++ b/src/build/bundle.rs
@@ -92,6 +92,7 @@ pub struct SupplementalDoc {
     pub name: String,
     pub content: String,
     pub skill_type: String,
+    pub detail: String,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -114,6 +114,7 @@ pub fn build_launch_bundle(
         &policy.routing.harness,
         &policy.routing.model_token,
         &policy.routing.model,
+        &profile.subagents,
     )?;
 
     warnings.extend(prompt.warnings);

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -156,6 +156,7 @@ fn empty_agent_profile() -> AgentProfile {
         autocompact: None,
         autocompact_pct: None,
         skills: Vec::new(),
+        subagents: Vec::new(),
         tools: Vec::new(),
         tools_denied: Vec::new(),
         disallowed_tools: Vec::new(),

--- a/src/build/policy/execution.rs
+++ b/src/build/policy/execution.rs
@@ -300,7 +300,7 @@ fn approval_mode_to_str(mode: &ApprovalMode) -> &'static str {
         ApprovalMode::Default => "default",
         ApprovalMode::Auto => "auto",
         ApprovalMode::Confirm => "confirm",
-        ApprovalMode::Yolo => "yolo",
+        ApprovalMode::Never => "never",
     }
 }
 

--- a/src/build/policy/harness.rs
+++ b/src/build/policy/harness.rs
@@ -561,6 +561,7 @@ mod tests {
             autocompact: None,
             autocompact_pct: None,
             skills: Vec::new(),
+            subagents: Vec::new(),
             tools: Vec::new(),
             tools_denied: Vec::new(),
             disallowed_tools: Vec::new(),

--- a/src/build/policy/model.rs
+++ b/src/build/policy/model.rs
@@ -121,6 +121,7 @@ mod tests {
             autocompact: None,
             autocompact_pct: None,
             skills: Vec::new(),
+            subagents: Vec::new(),
             tools: Vec::new(),
             tools_denied: Vec::new(),
             disallowed_tools: Vec::new(),

--- a/src/build/prompt.rs
+++ b/src/build/prompt.rs
@@ -39,6 +39,7 @@ struct ParsedAgentInventory {
     mode: AgentMode,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn compile_prompt_surface(
     mars_dir: &Path,
     agent_body: &str,
@@ -47,6 +48,7 @@ pub fn compile_prompt_surface(
     harness_id: &str,
     selected_model_token: &str,
     canonical_model_id: &str,
+    subagents_filter: &[String],
 ) -> Result<PromptCompilation, MarsError> {
     let _ = (selected_model_token, canonical_model_id);
 
@@ -95,7 +97,7 @@ pub fn compile_prompt_surface(
         .map(|loaded| loaded.document.name.clone())
         .collect::<Vec<_>>();
 
-    let inventory_prompt = build_inventory_prompt(mars_dir, &mut warnings)?;
+    let inventory_prompt = build_inventory_prompt(mars_dir, subagents_filter, &mut warnings)?;
     let system_instruction = compose_system_instruction(
         agent_body,
         &supplemental_documents,
@@ -170,6 +172,7 @@ fn load_skill_document(
         name: skill_name.to_string(),
         content,
         skill_type,
+        detail: base_profile.detail.clone().unwrap_or_default(),
     }))
 }
 
@@ -261,6 +264,7 @@ fn compose_system_instruction(
 
 fn build_inventory_prompt(
     mars_dir: &Path,
+    subagents_filter: &[String],
     warnings: &mut Vec<String>,
 ) -> Result<String, MarsError> {
     let agents_dir = mars_dir.join("agents");
@@ -304,6 +308,19 @@ fn build_inventory_prompt(
                 return Err(MarsError::Config(ConfigError::Invalid { message: err }));
             }
         }
+    }
+
+    if !subagents_filter.is_empty() {
+        primary_agents.retain(|agent| {
+            subagents_filter
+                .iter()
+                .any(|f| f.eq_ignore_ascii_case(&agent.name))
+        });
+        subagent_agents.retain(|agent| {
+            subagents_filter
+                .iter()
+                .any(|f| f.eq_ignore_ascii_case(&agent.name))
+        });
     }
 
     if primary_agents.is_empty() && subagent_agents.is_empty() {

--- a/src/cli/agents.rs
+++ b/src/cli/agents.rs
@@ -1,6 +1,6 @@
 //! `mars agents` — list and inspect agents from the .mars/ canonical store.
 
-use crate::compiler::agents::{parse_agent_profile, parse_agent_content};
+use crate::compiler::agents::{parse_agent_content, parse_agent_profile};
 use crate::error::MarsError;
 use crate::frontmatter;
 use crate::lock::ItemKind;
@@ -117,7 +117,12 @@ fn run_list(args: &AgentsArgs, ctx: &super::MarsContext, json: bool) -> Result<i
             println!("  no agents");
         } else {
             // Compute column widths
-            let name_w = entries.iter().map(|e| e.name.len()).max().unwrap_or(4).max(4);
+            let name_w = entries
+                .iter()
+                .map(|e| e.name.len())
+                .max()
+                .unwrap_or(4)
+                .max(4);
             let mode_w = entries
                 .iter()
                 .map(|e| e.mode.len())
@@ -126,7 +131,10 @@ fn run_list(args: &AgentsArgs, ctx: &super::MarsContext, json: bool) -> Result<i
                 .max(4);
             println!("{:<name_w$}  {:<mode_w$}  DESCRIPTION", "NAME", "MODE");
             for e in &entries {
-                println!("{:<name_w$}  {:<mode_w$}  {}", e.name, e.mode, e.description);
+                println!(
+                    "{:<name_w$}  {:<mode_w$}  {}",
+                    e.name, e.mode, e.description
+                );
             }
         }
     }

--- a/src/cli/agents.rs
+++ b/src/cli/agents.rs
@@ -67,12 +67,18 @@ fn run_list(args: &AgentsArgs, ctx: &super::MarsContext, json: bool) -> Result<i
         let disk_path = dest_path.resolve(&mars_dir);
         let content = match std::fs::read_to_string(&disk_path) {
             Ok(c) => c,
-            Err(_) => continue,
+            Err(err) => {
+                eprintln!("warning: skipping {}: {err}", disk_path.display());
+                continue;
+            }
         };
 
         let fm = match frontmatter::parse(&content) {
             Ok(fm) => fm,
-            Err(_) => continue,
+            Err(err) => {
+                eprintln!("warning: skipping {}: {err}", disk_path.display());
+                continue;
+            }
         };
 
         let mut diags = Vec::new();

--- a/src/cli/agents.rs
+++ b/src/cli/agents.rs
@@ -1,0 +1,242 @@
+//! `mars agents` — list and inspect agents from the .mars/ canonical store.
+
+use crate::compiler::agents::{parse_agent_profile, parse_agent_content};
+use crate::error::MarsError;
+use crate::frontmatter;
+use crate::lock::ItemKind;
+
+use super::output;
+
+#[derive(serde::Serialize)]
+struct AgentEntry {
+    name: String,
+    description: String,
+    mode: String,
+}
+
+/// Arguments for `mars agents`.
+#[derive(Debug, clap::Args)]
+pub struct AgentsArgs {
+    /// Filter by mode (primary or subagent).
+    #[arg(long)]
+    pub mode: Option<String>,
+
+    /// Filter by source name.
+    #[arg(long)]
+    pub source: Option<String>,
+
+    #[command(subcommand)]
+    pub command: Option<AgentsCommand>,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum AgentsCommand {
+    /// Show full metadata for a named agent.
+    Show {
+        /// Agent name.
+        name: String,
+    },
+}
+
+/// Run `mars agents`.
+pub fn run(args: &AgentsArgs, ctx: &super::MarsContext, json: bool) -> Result<i32, MarsError> {
+    match &args.command {
+        Some(AgentsCommand::Show { name }) => run_show(name, ctx, json),
+        None => run_list(args, ctx, json),
+    }
+}
+
+fn run_list(args: &AgentsArgs, ctx: &super::MarsContext, json: bool) -> Result<i32, MarsError> {
+    let lock = crate::lock::load(&ctx.project_root)?;
+    let mars_dir = ctx.project_root.join(".mars");
+
+    let mut entries: Vec<AgentEntry> = Vec::new();
+
+    for (dest_path, item) in lock.canonical_flat_items() {
+        if item.kind != ItemKind::Agent {
+            continue;
+        }
+
+        // source filter
+        if let Some(ref filter_source) = args.source
+            && item.source != *filter_source
+        {
+            continue;
+        }
+
+        let disk_path = dest_path.resolve(&mars_dir);
+        let content = match std::fs::read_to_string(&disk_path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        let fm = match frontmatter::parse(&content) {
+            Ok(fm) => fm,
+            Err(_) => continue,
+        };
+
+        let mut diags = Vec::new();
+        let profile = parse_agent_profile(&fm, &mut diags);
+
+        // mode filter
+        let mode_str = match &profile.mode {
+            Some(m) => m.as_str().to_string(),
+            None => String::new(),
+        };
+        if let Some(ref filter_mode) = args.mode
+            && mode_str != *filter_mode
+        {
+            continue;
+        }
+
+        let name = profile
+            .name
+            .clone()
+            .unwrap_or_else(|| path_stem(&disk_path));
+        let description = profile.description.clone().unwrap_or_default();
+
+        entries.push(AgentEntry {
+            name,
+            description,
+            mode: mode_str,
+        });
+    }
+
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+
+    if json {
+        output::print_json(&serde_json::json!({ "agents": entries }));
+    } else {
+        if entries.is_empty() {
+            println!("  no agents");
+        } else {
+            // Compute column widths
+            let name_w = entries.iter().map(|e| e.name.len()).max().unwrap_or(4).max(4);
+            let mode_w = entries
+                .iter()
+                .map(|e| e.mode.len())
+                .max()
+                .unwrap_or(4)
+                .max(4);
+            println!("{:<name_w$}  {:<mode_w$}  DESCRIPTION", "NAME", "MODE");
+            for e in &entries {
+                println!("{:<name_w$}  {:<mode_w$}  {}", e.name, e.mode, e.description);
+            }
+        }
+    }
+
+    Ok(0)
+}
+
+fn run_show(name: &str, ctx: &super::MarsContext, json: bool) -> Result<i32, MarsError> {
+    let lock = crate::lock::load(&ctx.project_root)?;
+    let mars_dir = ctx.project_root.join(".mars");
+
+    for (dest_path, item) in lock.canonical_flat_items() {
+        if item.kind != ItemKind::Agent {
+            continue;
+        }
+
+        let disk_path = dest_path.resolve(&mars_dir);
+        let content = match std::fs::read_to_string(&disk_path) {
+            Ok(c) => c,
+            Err(err) => {
+                eprintln!("warning: skipping {}: {err}", disk_path.display());
+                continue;
+            }
+        };
+
+        let mut diags = Vec::new();
+        let (profile, _fm) = match parse_agent_content(&content, &mut diags) {
+            Ok(p) => p,
+            Err(err) => {
+                eprintln!("warning: skipping {}: {err}", disk_path.display());
+                continue;
+            }
+        };
+
+        let stem = path_stem(&disk_path);
+        let agent_name = profile.name.as_deref().unwrap_or(stem.as_str());
+        if !agent_name.eq_ignore_ascii_case(name) {
+            continue;
+        }
+
+        let mode_str = profile.mode.as_ref().map(|m| m.as_str()).unwrap_or("");
+        let harness_str = profile
+            .harness
+            .as_ref()
+            .map(|h| h.to_harness_id().as_str())
+            .unwrap_or("");
+        let model_str = profile.model.as_deref().unwrap_or("");
+        let approval_str = profile
+            .approval
+            .as_ref()
+            .map(|a| a.as_str())
+            .unwrap_or_default();
+        let sandbox_str = profile
+            .sandbox
+            .as_ref()
+            .map(|s| s.as_str())
+            .unwrap_or_default();
+        let effort_str = profile
+            .effort
+            .as_ref()
+            .map(|e| e.as_str())
+            .unwrap_or_default();
+        let description_str = profile.description.as_deref().unwrap_or("");
+
+        if json {
+            output::print_json(&serde_json::json!({
+                "name": agent_name,
+                "description": description_str,
+                "mode": mode_str,
+                "harness": harness_str,
+                "model": model_str,
+                "skills": profile.skills,
+                "subagents": profile.subagents,
+                "approval": approval_str,
+                "sandbox": sandbox_str,
+                "effort": effort_str,
+                "tools": profile.tools,
+                "disallowed-tools": profile.disallowed_tools,
+                "tools-denied": profile.tools_denied,
+                "mcp-tools": profile.mcp_tools,
+            }));
+        } else {
+            println!("name:        {agent_name}");
+            println!("description: {description_str}");
+            println!("mode:        {mode_str}");
+            println!("harness:     {harness_str}");
+            println!("model:       {model_str}");
+            println!("approval:    {approval_str}");
+            println!("sandbox:     {sandbox_str}");
+            println!("effort:      {effort_str}");
+            print_str_list("skills", &profile.skills);
+            print_str_list("subagents", &profile.subagents);
+            print_str_list("tools", &profile.tools);
+            print_str_list("disallowed-tools", &profile.disallowed_tools);
+            print_str_list("tools-denied", &profile.tools_denied);
+            print_str_list("mcp-tools", &profile.mcp_tools);
+        }
+
+        return Ok(0);
+    }
+
+    eprintln!("error: agent `{name}` not found");
+    Ok(1)
+}
+
+fn print_str_list(label: &str, items: &[String]) {
+    if items.is_empty() {
+        println!("{label}:        (none)");
+    } else {
+        println!("{label}:        {}", items.join(", "));
+    }
+}
+
+fn path_stem(path: &std::path::Path) -> String {
+    path.file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown")
+        .to_string()
+}

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -63,7 +63,7 @@ enum ApprovalArg {
     Default,
     Auto,
     Confirm,
-    Yolo,
+    Never,
 }
 
 impl ApprovalArg {
@@ -72,7 +72,7 @@ impl ApprovalArg {
             Self::Default => "default",
             Self::Auto => "auto",
             Self::Confirm => "confirm",
-            Self::Yolo => "yolo",
+            Self::Never => "never",
         }
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -9,6 +9,7 @@
 
 pub mod add;
 pub mod adopt;
+pub mod agents;
 pub mod build;
 pub mod cache;
 pub mod check;
@@ -25,6 +26,7 @@ pub mod remove;
 pub mod rename;
 pub mod repair;
 pub mod resolve_cmd;
+pub mod skills;
 pub mod sync;
 pub mod target;
 pub mod unlink;
@@ -182,6 +184,12 @@ pub enum Command {
 
     /// Build derived artifacts from static project state.
     Build(build::BuildArgs),
+
+    /// List and inspect agents.
+    Agents(agents::AgentsArgs),
+
+    /// List and inspect skills.
+    Skills(skills::SkillsArgs),
 }
 
 /// Dispatch a parsed CLI command to the appropriate handler and map errors to
@@ -284,6 +292,8 @@ fn dispatch_with_root(cmd: &Command, ctx: &MarsContext, json: bool) -> Result<i3
         Command::Repair(args) => repair::run(args, ctx, json),
         Command::Models(args) => models::run(args, ctx, json),
         Command::Build(args) => build::run(args, ctx, json),
+        Command::Agents(args) => agents::run(args, ctx, json),
+        Command::Skills(args) => skills::run(args, ctx, json),
         // Root-free commands handled in dispatch_result — unreachable here
         Command::Init(_) | Command::Check(_) | Command::Cache(_) => unreachable!(),
     }

--- a/src/cli/skills.rs
+++ b/src/cli/skills.rs
@@ -75,12 +75,18 @@ fn run_list(args: &SkillsArgs, ctx: &super::MarsContext, json: bool) -> Result<i
         let skill_md = disk_path.join("SKILL.md");
         let content = match std::fs::read_to_string(&skill_md) {
             Ok(c) => c,
-            Err(_) => continue,
+            Err(err) => {
+                eprintln!("warning: skipping {}: {err}", skill_md.display());
+                continue;
+            }
         };
 
         let fm = match frontmatter::parse(&content) {
             Ok(fm) => fm,
-            Err(_) => continue,
+            Err(err) => {
+                eprintln!("warning: skipping {}: {err}", skill_md.display());
+                continue;
+            }
         };
 
         let mut diags = Vec::new();

--- a/src/cli/skills.rs
+++ b/src/cli/skills.rs
@@ -1,0 +1,222 @@
+//! `mars skills` — list and inspect skills from the .mars/ canonical store.
+
+use crate::compiler::skills::{parse_skill_profile, parse_skill_content};
+use crate::error::MarsError;
+use crate::frontmatter;
+use crate::lock::ItemKind;
+
+use super::output;
+
+#[derive(serde::Serialize)]
+struct SkillEntry {
+    name: String,
+    description: String,
+    #[serde(rename = "type")]
+    skill_type: String,
+    #[serde(rename = "model-invocable")]
+    model_invocable: bool,
+}
+
+/// Arguments for `mars skills`.
+#[derive(Debug, clap::Args)]
+pub struct SkillsArgs {
+    /// Filter by skill type (e.g. guardrail, reference, principle).
+    #[arg(long = "type", id = "skill_type")]
+    pub skill_type: Option<String>,
+
+    /// Filter to model-invocable skills only.
+    #[arg(long)]
+    pub model_invocable: bool,
+
+    /// Filter by source name.
+    #[arg(long)]
+    pub source: Option<String>,
+
+    #[command(subcommand)]
+    pub command: Option<SkillsCommand>,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum SkillsCommand {
+    /// Show full metadata for a named skill.
+    Show {
+        /// Skill name.
+        name: String,
+    },
+}
+
+/// Run `mars skills`.
+pub fn run(args: &SkillsArgs, ctx: &super::MarsContext, json: bool) -> Result<i32, MarsError> {
+    match &args.command {
+        Some(SkillsCommand::Show { name }) => run_show(name, ctx, json),
+        None => run_list(args, ctx, json),
+    }
+}
+
+fn run_list(args: &SkillsArgs, ctx: &super::MarsContext, json: bool) -> Result<i32, MarsError> {
+    let lock = crate::lock::load(&ctx.project_root)?;
+    let mars_dir = ctx.project_root.join(".mars");
+
+    let mut entries: Vec<SkillEntry> = Vec::new();
+
+    for (dest_path, item) in lock.canonical_flat_items() {
+        if item.kind != ItemKind::Skill {
+            continue;
+        }
+
+        // source filter
+        if let Some(ref filter_source) = args.source
+            && item.source != *filter_source
+        {
+            continue;
+        }
+
+        let disk_path = dest_path.resolve(&mars_dir);
+        let skill_md = disk_path.join("SKILL.md");
+        let content = match std::fs::read_to_string(&skill_md) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        let fm = match frontmatter::parse(&content) {
+            Ok(fm) => fm,
+            Err(_) => continue,
+        };
+
+        let mut diags = Vec::new();
+        let profile = parse_skill_profile(&fm, &mut diags);
+
+        // model_invocable filter
+        if args.model_invocable && !profile.model_invocable {
+            continue;
+        }
+
+        // type filter
+        let type_str = profile.skill_type.clone().unwrap_or_default();
+        if let Some(ref filter_type) = args.skill_type
+            && type_str != *filter_type
+        {
+            continue;
+        }
+
+        let name = profile
+            .name
+            .clone()
+            .unwrap_or_else(|| dir_name(&disk_path));
+        let description = profile.description.clone().unwrap_or_default();
+
+        entries.push(SkillEntry {
+            name,
+            description,
+            skill_type: type_str,
+            model_invocable: profile.model_invocable,
+        });
+    }
+
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+
+    if json {
+        output::print_json(&serde_json::json!({ "skills": entries }));
+    } else {
+        if entries.is_empty() {
+            println!("  no skills");
+        } else {
+            let name_w = entries.iter().map(|e| e.name.len()).max().unwrap_or(4).max(4);
+            let type_w = entries
+                .iter()
+                .map(|e| e.skill_type.len())
+                .max()
+                .unwrap_or(4)
+                .max(4);
+            println!(
+                "{:<name_w$}  {:<type_w$}  {:<5}  DESCRIPTION",
+                "NAME", "TYPE", "M-INV"
+            );
+            for e in &entries {
+                let inv = if e.model_invocable { "yes" } else { "no" };
+                println!(
+                    "{:<name_w$}  {:<type_w$}  {:<5}  {}",
+                    e.name, e.skill_type, inv, e.description
+                );
+            }
+        }
+    }
+
+    Ok(0)
+}
+
+fn run_show(name: &str, ctx: &super::MarsContext, json: bool) -> Result<i32, MarsError> {
+    let lock = crate::lock::load(&ctx.project_root)?;
+    let mars_dir = ctx.project_root.join(".mars");
+
+    for (dest_path, item) in lock.canonical_flat_items() {
+        if item.kind != ItemKind::Skill {
+            continue;
+        }
+
+        let disk_path = dest_path.resolve(&mars_dir);
+        let skill_md = disk_path.join("SKILL.md");
+        let content = match std::fs::read_to_string(&skill_md) {
+            Ok(c) => c,
+            Err(err) => {
+                eprintln!("warning: skipping {}: {err}", skill_md.display());
+                continue;
+            }
+        };
+
+        let mut diags = Vec::new();
+        let (profile, _fm) = match parse_skill_content(&content, &mut diags) {
+            Ok(p) => p,
+            Err(err) => {
+                eprintln!("warning: skipping {}: {err}", skill_md.display());
+                continue;
+            }
+        };
+
+        let fallback = dir_name(&disk_path);
+        let skill_name = profile.name.as_deref().unwrap_or(fallback.as_str());
+        if !skill_name.eq_ignore_ascii_case(name) {
+            continue;
+        }
+
+        let description_str = profile.description.as_deref().unwrap_or("");
+        let detail_str = profile.detail.as_deref().unwrap_or("");
+        let type_str = profile.skill_type.as_deref().unwrap_or("");
+
+        if json {
+            output::print_json(&serde_json::json!({
+                "name": skill_name,
+                "description": description_str,
+                "detail": detail_str,
+                "type": type_str,
+                "model-invocable": profile.model_invocable,
+                "user-invocable": profile.user_invocable,
+                "allowed-tools": profile.allowed_tools,
+            }));
+        } else {
+            println!("name:          {skill_name}");
+            println!("description:   {description_str}");
+            println!("detail:        {detail_str}");
+            println!("type:          {type_str}");
+            println!("model-invocable: {}", profile.model_invocable);
+            println!("user-invocable:  {}", profile.user_invocable);
+            if profile.allowed_tools.is_empty() {
+                println!("allowed-tools: (none)");
+            } else {
+                println!("allowed-tools: {}", profile.allowed_tools.join(", "));
+            }
+        }
+
+        return Ok(0);
+    }
+
+    eprintln!("error: skill `{name}` not found");
+    Ok(1)
+}
+
+fn dir_name(path: &std::path::Path) -> String {
+    path.file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown")
+        .to_string()
+}

--- a/src/cli/skills.rs
+++ b/src/cli/skills.rs
@@ -1,6 +1,6 @@
 //! `mars skills` — list and inspect skills from the .mars/ canonical store.
 
-use crate::compiler::skills::{parse_skill_profile, parse_skill_content};
+use crate::compiler::skills::{parse_skill_content, parse_skill_profile};
 use crate::error::MarsError;
 use crate::frontmatter;
 use crate::lock::ItemKind;
@@ -105,10 +105,7 @@ fn run_list(args: &SkillsArgs, ctx: &super::MarsContext, json: bool) -> Result<i
             continue;
         }
 
-        let name = profile
-            .name
-            .clone()
-            .unwrap_or_else(|| dir_name(&disk_path));
+        let name = profile.name.clone().unwrap_or_else(|| dir_name(&disk_path));
         let description = profile.description.clone().unwrap_or_default();
 
         entries.push(SkillEntry {
@@ -127,7 +124,12 @@ fn run_list(args: &SkillsArgs, ctx: &super::MarsContext, json: bool) -> Result<i
         if entries.is_empty() {
             println!("  no skills");
         } else {
-            let name_w = entries.iter().map(|e| e.name.len()).max().unwrap_or(4).max(4);
+            let name_w = entries
+                .iter()
+                .map(|e| e.name.len())
+                .max()
+                .unwrap_or(4)
+                .max(4);
             let type_w = entries
                 .iter()
                 .map(|e| e.skill_type.len())

--- a/src/compiler/agents/lower.rs
+++ b/src/compiler/agents/lower.rs
@@ -297,7 +297,7 @@ pub fn lower_to_codex(profile: &AgentProfile, body: &str) -> LoweredOutput {
             ApprovalMode::Default => None,
             ApprovalMode::Auto => Some("on-request"),
             ApprovalMode::Confirm => Some("untrusted"),
-            ApprovalMode::Yolo => Some("never"),
+            ApprovalMode::Never => Some("never"),
         }
     });
 

--- a/src/compiler/agents/mod.rs
+++ b/src/compiler/agents/mod.rs
@@ -1106,10 +1106,7 @@ pub fn parse_agent_profile(fm: &Frontmatter, diags: &mut Vec<AgentDiagnostic>) -
 
     // skills/subagents/tools/disallowed-tools/mcp-tools:
     let skills = fm.skills();
-    let subagents = fm
-        .get("subagents")
-        .map(yaml_str_list)
-        .unwrap_or_default();
+    let subagents = fm.get("subagents").map(yaml_str_list).unwrap_or_default();
     let parsed_tools = fm
         .get("tools")
         .map(|value| parse_tools_field("tools", value, diags))

--- a/src/compiler/agents/mod.rs
+++ b/src/compiler/agents/mod.rs
@@ -97,7 +97,7 @@ pub enum ApprovalMode {
     Default,
     Auto,
     Confirm,
-    Yolo,
+    Never,
 }
 
 impl ApprovalMode {
@@ -106,7 +106,7 @@ impl ApprovalMode {
             "default" => Some(Self::Default),
             "auto" => Some(Self::Auto),
             "confirm" => Some(Self::Confirm),
-            "yolo" => Some(Self::Yolo),
+            "never" | "yolo" => Some(Self::Never),
             _ => None,
         }
     }
@@ -116,7 +116,7 @@ impl ApprovalMode {
             Self::Default => "default",
             Self::Auto => "auto",
             Self::Confirm => "confirm",
-            Self::Yolo => "yolo",
+            Self::Never => "never",
         }
     }
 }
@@ -355,6 +355,8 @@ pub enum AgentDiagnostic {
     },
     /// Deprecated `models:` field was found (use `model-overrides:` instead).
     LegacyModelsField,
+    /// Deprecated `approval: yolo` was found (use `approval: never` instead).
+    DeprecatedApprovalYolo,
     /// Unknown harness name — not one of claude/codex/opencode/pi.
     UnknownHarness { value: String },
     /// Non-overridable field appears inside an override block.
@@ -384,6 +386,9 @@ impl AgentDiagnostic {
             }
             AgentDiagnostic::LegacyModelsField => {
                 "agent uses deprecated `models:` field; rename to `model-overrides:`".to_string()
+            }
+            AgentDiagnostic::DeprecatedApprovalYolo => {
+                "agent uses deprecated `approval: yolo`; use `approval: never` instead".to_string()
             }
             AgentDiagnostic::UnknownHarness { value } => {
                 format!("unknown harness `{value}`; known: claude, codex, opencode, cursor, pi")
@@ -742,12 +747,15 @@ fn parse_override_fields(
             "approval" => {
                 if let Some(s) = v.as_str() {
                     if let Some(a) = ApprovalMode::from_str(s) {
+                        if s == "yolo" {
+                            diags.push(AgentDiagnostic::DeprecatedApprovalYolo);
+                        }
                         out.approval = Some(a);
                     } else {
                         diags.push(AgentDiagnostic::InvalidFieldValue {
                             field: format!("{table_name}.approval"),
                             value: s.to_string(),
-                            allowed: "default, auto, confirm, yolo",
+                            allowed: "default, auto, confirm, never",
                         });
                     }
                 }
@@ -1008,12 +1016,15 @@ pub fn parse_agent_profile(fm: &Frontmatter, diags: &mut Vec<AgentDiagnostic>) -
     // approval:
     let approval = fm.get("approval").and_then(Value::as_str).and_then(|s| {
         if let Some(a) = ApprovalMode::from_str(s) {
+            if s == "yolo" {
+                diags.push(AgentDiagnostic::DeprecatedApprovalYolo);
+            }
             Some(a)
         } else {
             diags.push(AgentDiagnostic::InvalidFieldValue {
                 field: "approval".to_string(),
                 value: s.to_string(),
-                allowed: "default, auto, confirm, yolo",
+                allowed: "default, auto, confirm, never",
             });
             None
         }

--- a/src/compiler/agents/mod.rs
+++ b/src/compiler/agents/mod.rs
@@ -110,6 +110,15 @@ impl ApprovalMode {
             _ => None,
         }
     }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Default => "default",
+            Self::Auto => "auto",
+            Self::Confirm => "confirm",
+            Self::Yolo => "yolo",
+        }
+    }
 }
 
 /// Sandbox mode field.
@@ -265,6 +274,7 @@ pub struct AgentProfile {
 
     // --- Tool fields ---
     pub skills: Vec<String>,
+    pub subagents: Vec<String>,
     pub tools: Vec<String>,
     pub tools_denied: Vec<String>,
     pub disallowed_tools: Vec<String>,
@@ -1094,8 +1104,12 @@ pub fn parse_agent_profile(fm: &Frontmatter, diags: &mut Vec<AgentDiagnostic>) -
         }
     };
 
-    // skills/tools/disallowed-tools/mcp-tools:
+    // skills/subagents/tools/disallowed-tools/mcp-tools:
     let skills = fm.skills();
+    let subagents = fm
+        .get("subagents")
+        .map(yaml_str_list)
+        .unwrap_or_default();
     let parsed_tools = fm
         .get("tools")
         .map(|value| parse_tools_field("tools", value, diags))
@@ -1141,6 +1155,7 @@ pub fn parse_agent_profile(fm: &Frontmatter, diags: &mut Vec<AgentDiagnostic>) -
         autocompact,
         autocompact_pct,
         skills,
+        subagents,
         tools,
         tools_denied,
         disallowed_tools,

--- a/src/compiler/agents/tests.rs
+++ b/src/compiler/agents/tests.rs
@@ -528,3 +528,21 @@ fn agent_without_harness_is_universal() {
     let (p, _) = parse("---\nname: planner\nmodel: gpt55\n---\n# Planner");
     assert!(p.harness.is_none());
 }
+
+// --- subagents field ---
+
+#[test]
+fn subagents_list_parses() {
+    let (p, diags) = parse(
+        "---\nname: orchestrator\nsubagents:\n  - coder\n  - reviewer\n---\n# Orchestrator",
+    );
+    assert!(diags.is_empty());
+    assert_eq!(p.subagents, vec!["coder", "reviewer"]);
+}
+
+#[test]
+fn subagents_absent_gives_empty_vec() {
+    let (p, diags) = parse("---\nname: solo\n---\n# Solo agent");
+    assert!(diags.is_empty());
+    assert!(p.subagents.is_empty());
+}

--- a/src/compiler/agents/tests.rs
+++ b/src/compiler/agents/tests.rs
@@ -131,12 +131,22 @@ fn parses_effort_none_sentinel() {
 
 #[test]
 fn parses_approval_all_values() {
-    for s in ["default", "auto", "confirm", "yolo"] {
+    for s in ["default", "auto", "confirm", "never"] {
         let content = format!("---\napproval: {s}\n---\n");
         let (p, diags) = parse(&content);
         assert!(diags.is_empty(), "unexpected diags for approval={s}");
         assert!(p.approval.is_some());
     }
+}
+
+#[test]
+fn approval_yolo_parses_with_deprecation_warning() {
+    let content = "---\napproval: yolo\n---\n";
+    let (p, diags) = parse(content);
+    assert_eq!(p.approval, Some(ApprovalMode::Never));
+    assert_eq!(diags.len(), 1);
+    assert!(!diags[0].is_error());
+    assert!(diags[0].message().contains("deprecated"));
 }
 
 #[test]

--- a/src/compiler/agents/tests.rs
+++ b/src/compiler/agents/tests.rs
@@ -533,9 +533,8 @@ fn agent_without_harness_is_universal() {
 
 #[test]
 fn subagents_list_parses() {
-    let (p, diags) = parse(
-        "---\nname: orchestrator\nsubagents:\n  - coder\n  - reviewer\n---\n# Orchestrator",
-    );
+    let (p, diags) =
+        parse("---\nname: orchestrator\nsubagents:\n  - coder\n  - reviewer\n---\n# Orchestrator");
     assert!(diags.is_empty());
     assert_eq!(p.subagents, vec!["coder", "reviewer"]);
 }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -629,6 +629,7 @@ mod skill_surface_tests {
             autocompact: None,
             autocompact_pct: None,
             skills: Vec::new(),
+            subagents: Vec::new(),
             tools: Vec::new(),
             tools_denied: Vec::new(),
             disallowed_tools: Vec::new(),

--- a/src/compiler/skills/mod.rs
+++ b/src/compiler/skills/mod.rs
@@ -10,6 +10,8 @@ use crate::frontmatter::{Frontmatter, FrontmatterError};
 pub struct SkillProfile {
     pub name: Option<String>,
     pub description: Option<String>,
+    pub detail: Option<String>,
+    pub skill_type: Option<String>,
     pub model_invocable: bool,
     pub user_invocable: bool,
     pub allowed_tools: Vec<String>,
@@ -172,6 +174,28 @@ pub fn parse_skill_profile(fm: &Frontmatter, diags: &mut Vec<SkillDiagnostic>) -
             allowed: "string",
         });
     }
+    let detail_raw = fm.get("detail");
+    let detail = detail_raw.and_then(Value::as_str).map(str::to_owned);
+    if let Some(raw) = detail_raw
+        && !raw.is_string()
+    {
+        diags.push(SkillDiagnostic::InvalidFieldType {
+            field: "detail".to_string(),
+            value: value_label(raw),
+            allowed: "string",
+        });
+    }
+    let skill_type_raw = fm.get("type");
+    let skill_type = skill_type_raw.and_then(Value::as_str).map(str::to_owned);
+    if let Some(raw) = skill_type_raw
+        && !raw.is_string()
+    {
+        diags.push(SkillDiagnostic::InvalidFieldType {
+            field: "type".to_string(),
+            value: value_label(raw),
+            allowed: "string",
+        });
+    }
     let metadata = fm.get("metadata").cloned();
 
     let (model_invocable, had_model_invocable_field) =
@@ -194,6 +218,8 @@ pub fn parse_skill_profile(fm: &Frontmatter, diags: &mut Vec<SkillDiagnostic>) -
     SkillProfile {
         name,
         description,
+        detail,
+        skill_type,
         model_invocable,
         user_invocable,
         allowed_tools,
@@ -412,6 +438,46 @@ body",
         assert!(d.iter().any(|d| matches!(
             d,
             SkillDiagnostic::InvalidFieldType { field, .. } if field == "license"
+        )));
+    }
+
+    #[test]
+    fn detail_and_type_parse_from_frontmatter() {
+        let (p, d, _) = parse(
+            "---\nname: a\ndescription: b\ndetail: Long description here\ntype: guardrail\n---\nbody",
+        );
+        assert!(d.is_empty());
+        assert_eq!(p.detail.as_deref(), Some("Long description here"));
+        assert_eq!(p.skill_type.as_deref(), Some("guardrail"));
+    }
+
+    #[test]
+    fn detail_and_type_absent_gives_none() {
+        let (p, d, _) = parse("---\nname: a\ndescription: b\n---\nbody");
+        assert!(d.is_empty());
+        assert!(p.detail.is_none());
+        assert!(p.skill_type.is_none());
+    }
+
+    #[test]
+    fn non_string_detail_emits_diagnostic() {
+        let (p, d, _) = parse("---\nname: a\ndescription: b\ndetail: 42\n---\nbody");
+        assert!(p.detail.is_none());
+        assert!(d.iter().any(|diag| matches!(
+            diag,
+            SkillDiagnostic::InvalidFieldType { field, allowed, .. }
+                if field == "detail" && *allowed == "string"
+        )));
+    }
+
+    #[test]
+    fn non_string_type_emits_diagnostic() {
+        let (p, d, _) = parse("---\nname: a\ndescription: b\ntype: [a, b]\n---\nbody");
+        assert!(p.skill_type.is_none());
+        assert!(d.iter().any(|diag| matches!(
+            diag,
+            SkillDiagnostic::InvalidFieldType { field, allowed, .. }
+                if field == "type" && *allowed == "string"
         )));
     }
 

--- a/tests/agents_and_skills_cmd.rs
+++ b/tests/agents_and_skills_cmd.rs
@@ -39,13 +39,8 @@ model-invocable: false
 #[test]
 fn agents_list_json_envelope_and_fields() {
     let dir = TempDir::new().unwrap();
-    let project = setup_synced_project(
-        &dir,
-        "proj",
-        "src",
-        &[("orchestrator", AGENT_CONTENT)],
-        &[],
-    );
+    let project =
+        setup_synced_project(&dir, "proj", "src", &[("orchestrator", AGENT_CONTENT)], &[]);
 
     let output = mars()
         .args(["--json", "agents", "--root", project.to_str().unwrap()])
@@ -79,13 +74,8 @@ fn agents_list_json_envelope_and_fields() {
 #[test]
 fn agents_show_json_subagents_and_kebab_keys() {
     let dir = TempDir::new().unwrap();
-    let project = setup_synced_project(
-        &dir,
-        "proj",
-        "src",
-        &[("orchestrator", AGENT_CONTENT)],
-        &[],
-    );
+    let project =
+        setup_synced_project(&dir, "proj", "src", &[("orchestrator", AGENT_CONTENT)], &[]);
 
     let output = mars()
         .args([
@@ -109,7 +99,10 @@ fn agents_show_json_subagents_and_kebab_keys() {
         json["description"].is_string(),
         "'description' required:\n{stdout}"
     );
-    assert!(json["skills"].is_array(), "'skills' array required:\n{stdout}");
+    assert!(
+        json["skills"].is_array(),
+        "'skills' array required:\n{stdout}"
+    );
     assert!(
         json["subagents"].is_array(),
         "'subagents' array required:\n{stdout}"
@@ -139,13 +132,8 @@ fn agents_show_json_subagents_and_kebab_keys() {
 #[test]
 fn agents_show_not_found_exits_nonzero() {
     let dir = TempDir::new().unwrap();
-    let project = setup_synced_project(
-        &dir,
-        "proj",
-        "src",
-        &[("orchestrator", AGENT_CONTENT)],
-        &[],
-    );
+    let project =
+        setup_synced_project(&dir, "proj", "src", &[("orchestrator", AGENT_CONTENT)], &[]);
 
     let status = mars()
         .args([
@@ -173,13 +161,7 @@ fn skills_list_json_model_invocable_is_kebab_not_snake() {
     // Regression guard: list previously emitted `model_invocable` (snake) while
     // show emitted `model-invocable` (kebab). Both must be kebab.
     let dir = TempDir::new().unwrap();
-    let project = setup_synced_project(
-        &dir,
-        "proj",
-        "src",
-        &[],
-        &[("planning", SKILL_CONTENT)],
-    );
+    let project = setup_synced_project(&dir, "proj", "src", &[], &[("planning", SKILL_CONTENT)]);
 
     let output = mars()
         .args(["--json", "skills", "--root", project.to_str().unwrap()])
@@ -211,8 +193,7 @@ fn skills_list_json_model_invocable_is_kebab_not_snake() {
         "skills list MUST NOT emit 'model_invocable' (snake):\n{stdout}"
     );
     assert_eq!(
-        entry["model-invocable"],
-        false,
+        entry["model-invocable"], false,
         "'model-invocable' value for planning:\n{stdout}"
     );
 
@@ -226,13 +207,7 @@ fn skills_list_json_model_invocable_is_kebab_not_snake() {
 fn skills_show_json_model_invocable_is_kebab_not_snake() {
     // Mirror of the list test — both endpoints must agree on kebab-case.
     let dir = TempDir::new().unwrap();
-    let project = setup_synced_project(
-        &dir,
-        "proj",
-        "src",
-        &[],
-        &[("planning", SKILL_CONTENT)],
-    );
+    let project = setup_synced_project(&dir, "proj", "src", &[], &[("planning", SKILL_CONTENT)]);
 
     let output = mars()
         .args([
@@ -261,8 +236,7 @@ fn skills_show_json_model_invocable_is_kebab_not_snake() {
         "skills show MUST NOT emit 'model_invocable' (snake):\n{stdout}"
     );
     assert_eq!(
-        json["model-invocable"],
-        false,
+        json["model-invocable"], false,
         "'model-invocable' value:\n{stdout}"
     );
 
@@ -275,19 +249,16 @@ fn skills_show_json_model_invocable_is_kebab_not_snake() {
         "'allowed-tools' key required (kebab):\n{stdout}"
     );
     assert_eq!(json["type"], "principle", "'type' field:\n{stdout}");
-    assert!(json["detail"].is_string(), "'detail' field required:\n{stdout}");
+    assert!(
+        json["detail"].is_string(),
+        "'detail' field required:\n{stdout}"
+    );
 }
 
 #[test]
 fn skills_show_not_found_exits_nonzero() {
     let dir = TempDir::new().unwrap();
-    let project = setup_synced_project(
-        &dir,
-        "proj",
-        "src",
-        &[],
-        &[("planning", SKILL_CONTENT)],
-    );
+    let project = setup_synced_project(&dir, "proj", "src", &[], &[("planning", SKILL_CONTENT)]);
 
     let status = mars()
         .args([

--- a/tests/agents_and_skills_cmd.rs
+++ b/tests/agents_and_skills_cmd.rs
@@ -1,0 +1,309 @@
+//! Integration tests for `mars agents` and `mars skills` CLI commands.
+//!
+//! Pins the `--json` output contract:
+//!
+//! - List envelope shapes: `{"agents":[...]}` and `{"skills":[...]}`
+//! - Kebab-case `model-invocable` on both skills list and skills show.
+//!   Regression guard: list previously emitted `model_invocable` (snake)
+//!   while show emitted `model-invocable` (kebab).
+//! - `subagents` array present in agent show output
+//! - Not-found exits non-zero
+
+mod common;
+
+use assert_fs::TempDir;
+
+use common::*;
+
+const AGENT_CONTENT: &str = "---
+name: orchestrator
+description: Orchestrates work
+mode: primary
+subagents:
+  - worker
+---
+# Orchestrator
+";
+
+const SKILL_CONTENT: &str = "---
+name: planning
+description: Planning helper
+type: principle
+model-invocable: false
+---
+# Planning
+";
+
+// ── mars agents --json ────────────────────────────────────────────────────────
+
+#[test]
+fn agents_list_json_envelope_and_fields() {
+    let dir = TempDir::new().unwrap();
+    let project = setup_synced_project(
+        &dir,
+        "proj",
+        "src",
+        &[("orchestrator", AGENT_CONTENT)],
+        &[],
+    );
+
+    let output = mars()
+        .args(["--json", "agents", "--root", project.to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "mars agents should exit 0");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("mars agents --json must be valid JSON:\n{stdout}"));
+
+    let agents = json["agents"]
+        .as_array()
+        .unwrap_or_else(|| panic!("expected top-level 'agents' array in JSON:\n{stdout}"));
+    assert!(!agents.is_empty(), "expected at least one agent:\n{stdout}");
+
+    let entry = agents
+        .iter()
+        .find(|e| e["name"] == "orchestrator")
+        .unwrap_or_else(|| panic!("expected 'orchestrator' in agents list:\n{stdout}"));
+
+    assert!(entry["name"].is_string(), "'name' key required:\n{stdout}");
+    assert!(
+        entry["description"].is_string(),
+        "'description' key required:\n{stdout}"
+    );
+    assert!(entry["mode"].is_string(), "'mode' key required:\n{stdout}");
+    assert_eq!(entry["mode"], "primary", "'mode' value:\n{stdout}");
+}
+
+#[test]
+fn agents_show_json_subagents_and_kebab_keys() {
+    let dir = TempDir::new().unwrap();
+    let project = setup_synced_project(
+        &dir,
+        "proj",
+        "src",
+        &[("orchestrator", AGENT_CONTENT)],
+        &[],
+    );
+
+    let output = mars()
+        .args([
+            "--json",
+            "agents",
+            "show",
+            "orchestrator",
+            "--root",
+            project.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "mars agents show should exit 0");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("mars agents show --json must be valid JSON:\n{stdout}"));
+
+    assert_eq!(json["name"], "orchestrator", "'name' value:\n{stdout}");
+    assert!(
+        json["description"].is_string(),
+        "'description' required:\n{stdout}"
+    );
+    assert!(json["skills"].is_array(), "'skills' array required:\n{stdout}");
+    assert!(
+        json["subagents"].is_array(),
+        "'subagents' array required:\n{stdout}"
+    );
+    let subagents = json["subagents"].as_array().unwrap();
+    assert_eq!(
+        subagents,
+        &[serde_json::json!("worker")],
+        "'subagents' list:\n{stdout}"
+    );
+
+    // Kebab-case keys in the show envelope
+    assert!(
+        json.get("disallowed-tools").is_some(),
+        "'disallowed-tools' key required (kebab):\n{stdout}"
+    );
+    assert!(
+        json.get("tools-denied").is_some(),
+        "'tools-denied' key required (kebab):\n{stdout}"
+    );
+    assert!(
+        json.get("mcp-tools").is_some(),
+        "'mcp-tools' key required (kebab):\n{stdout}"
+    );
+}
+
+#[test]
+fn agents_show_not_found_exits_nonzero() {
+    let dir = TempDir::new().unwrap();
+    let project = setup_synced_project(
+        &dir,
+        "proj",
+        "src",
+        &[("orchestrator", AGENT_CONTENT)],
+        &[],
+    );
+
+    let status = mars()
+        .args([
+            "--json",
+            "agents",
+            "show",
+            "nonexistent",
+            "--root",
+            project.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap()
+        .status;
+
+    assert!(
+        !status.success(),
+        "agents show of missing agent must exit non-zero"
+    );
+}
+
+// ── mars skills --json ────────────────────────────────────────────────────────
+
+#[test]
+fn skills_list_json_model_invocable_is_kebab_not_snake() {
+    // Regression guard: list previously emitted `model_invocable` (snake) while
+    // show emitted `model-invocable` (kebab). Both must be kebab.
+    let dir = TempDir::new().unwrap();
+    let project = setup_synced_project(
+        &dir,
+        "proj",
+        "src",
+        &[],
+        &[("planning", SKILL_CONTENT)],
+    );
+
+    let output = mars()
+        .args(["--json", "skills", "--root", project.to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "mars skills should exit 0");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("mars skills --json must be valid JSON:\n{stdout}"));
+
+    let skills = json["skills"]
+        .as_array()
+        .unwrap_or_else(|| panic!("expected top-level 'skills' array:\n{stdout}"));
+    assert!(!skills.is_empty(), "expected at least one skill:\n{stdout}");
+
+    let entry = skills
+        .iter()
+        .find(|e| e["name"] == "planning")
+        .unwrap_or_else(|| panic!("'planning' skill not found in list:\n{stdout}"));
+
+    // The key contract: kebab-case, not snake_case.
+    assert!(
+        entry.get("model-invocable").is_some(),
+        "skills list MUST emit 'model-invocable' (kebab), not 'model_invocable' (snake):\n{stdout}"
+    );
+    assert!(
+        entry.get("model_invocable").is_none(),
+        "skills list MUST NOT emit 'model_invocable' (snake):\n{stdout}"
+    );
+    assert_eq!(
+        entry["model-invocable"],
+        false,
+        "'model-invocable' value for planning:\n{stdout}"
+    );
+
+    assert_eq!(
+        entry["type"], "principle",
+        "'type' field in skills list:\n{stdout}"
+    );
+}
+
+#[test]
+fn skills_show_json_model_invocable_is_kebab_not_snake() {
+    // Mirror of the list test — both endpoints must agree on kebab-case.
+    let dir = TempDir::new().unwrap();
+    let project = setup_synced_project(
+        &dir,
+        "proj",
+        "src",
+        &[],
+        &[("planning", SKILL_CONTENT)],
+    );
+
+    let output = mars()
+        .args([
+            "--json",
+            "skills",
+            "show",
+            "planning",
+            "--root",
+            project.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "mars skills show should exit 0");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("mars skills show --json must be valid JSON:\n{stdout}"));
+
+    // Kebab-case contract — the regression was snake vs kebab disagreement.
+    assert!(
+        json.get("model-invocable").is_some(),
+        "skills show MUST emit 'model-invocable' (kebab):\n{stdout}"
+    );
+    assert!(
+        json.get("model_invocable").is_none(),
+        "skills show MUST NOT emit 'model_invocable' (snake):\n{stdout}"
+    );
+    assert_eq!(
+        json["model-invocable"],
+        false,
+        "'model-invocable' value:\n{stdout}"
+    );
+
+    assert!(
+        json.get("user-invocable").is_some(),
+        "'user-invocable' key required (kebab):\n{stdout}"
+    );
+    assert!(
+        json.get("allowed-tools").is_some(),
+        "'allowed-tools' key required (kebab):\n{stdout}"
+    );
+    assert_eq!(json["type"], "principle", "'type' field:\n{stdout}");
+    assert!(json["detail"].is_string(), "'detail' field required:\n{stdout}");
+}
+
+#[test]
+fn skills_show_not_found_exits_nonzero() {
+    let dir = TempDir::new().unwrap();
+    let project = setup_synced_project(
+        &dir,
+        "proj",
+        "src",
+        &[],
+        &[("planning", SKILL_CONTENT)],
+    );
+
+    let status = mars()
+        .args([
+            "--json",
+            "skills",
+            "show",
+            "nonexistent",
+            "--root",
+            project.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap()
+        .status;
+
+    assert!(
+        !status.success(),
+        "skills show of missing skill must exit non-zero"
+    );
+}

--- a/tests/launch_bundle/execution_policy.rs
+++ b/tests/launch_bundle/execution_policy.rs
@@ -27,7 +27,7 @@ Review code changes."#;
         "--effort",
         "high",
         "--approval",
-        "yolo",
+        "never",
         "--sandbox",
         "danger-full-access",
     ]);
@@ -40,7 +40,7 @@ Review code changes."#;
     assert_eq!(bundle["routing"]["harness"].as_str(), Some("claude"));
     assert_eq!(
         bundle["execution_policy"]["approval"].as_str(),
-        Some("yolo")
+        Some("never")
     );
     assert_eq!(
         bundle["execution_policy"]["sandbox"].as_str(),
@@ -95,7 +95,7 @@ autocompact_pct = 55"#;
         "--agent",
         "reviewer",
         "--approval",
-        "yolo",
+        "never",
     ]);
     cmd.env("PATH", replace_path_with(&bin_dir));
 
@@ -106,7 +106,7 @@ autocompact_pct = 55"#;
     assert_eq!(bundle["execution_policy"]["effort"].as_str(), Some("high"));
     assert_eq!(
         bundle["execution_policy"]["approval"].as_str(),
-        Some("yolo"),
+        Some("never"),
         "CLI approval must beat harness override",
     );
     assert_eq!(

--- a/tests/sync_behavior.rs
+++ b/tests/sync_behavior.rs
@@ -588,7 +588,7 @@ description: |
   Explorer line two
 harness: codex
 model: gpt-5.3-codex
-approval: yolo
+approval: never
 sandbox: workspace-write
 tools: [Bash, Write, Edit]
 ---


### PR DESCRIPTION
## Why

Progressive loading architecture needs mars-agents to expose skill type/detail metadata and agent subagents lists, plus first-class CLI subcommands for meridian-cli to query these fields programmatically. Without this, the meridian-cli rendering layer can't distinguish principles (auto-load) from references (curated menu) or filter agent inventories by declared subagents.

Additionally, `approval: yolo` conflates approval policy with sandbox policy. Canonical `approval: never` separates the two concerns cleanly.

## Goal

After merge:
- `mars skills --type principle --json` returns only principle-typed skills with name, description, type, model-invocable
- `mars agents --mode primary --json` returns only primary-mode agents
- `mars agents show <name> --json` / `mars skills show <name> --json` show full metadata including the new fields
- Skills with `detail:` and `type:` in SKILL.md frontmatter preserve those fields through compile/sync
- Agents with `subagents:` in frontmatter preserve that list through compile/sync
- `mars list` continues working unchanged
- Launch bundle carries `detail` on SupplementalDoc for type-based skill rendering
- Launch bundle inventory prompt filters by `subagents` when the launching agent declares them
- `approval: never` is canonical; `approval: yolo` accepted with deprecation warning

## Summary

- Add `detail` and `skill_type` fields to `SkillProfile` (optional string metadata for progressive loading curated menus)
- Add `subagents` field to `AgentProfile` (string list for inventory filtering)
- Add `ApprovalMode::as_str()` for clean serialization
- New `mars agents` subcommand: list with `--mode`/`--source` filters, `show <name>` with full metadata, `--json`
- New `mars skills` subcommand: list with `--type`/`--model-invocable`/`--source` filters, `show <name>` with full metadata, `--json`
- 6 integration tests pinning JSON output contract (kebab-case keys, envelope shapes, subagents array, not-found exit code)
- Warnings on unreadable/malformed files in list and show (no silent skipping)
- **`SupplementalDoc` now carries `detail` field** through the launch bundle for meridian-cli rendering
- **`build_inventory_prompt()` filters by `subagents`** — when non-empty, only declared agents appear in the inventory prompt
- **`ApprovalMode::Yolo` → `ApprovalMode::Never`** — canonical spelling is `never`; `yolo` parses to `Never` with `DeprecatedApprovalYolo` warning diagnostic

## Work Items

- dev-workflow-token-reduction-progressive-loading-paper-descripti
- yolo-permission-schema-cleanup (mars-agents portion)

## Changes

**Data model (additive, no existing behavior changed):**
- `SkillProfile`: `detail: Option<String>`, `skill_type: Option<String>` — same parse/diagnostic pattern as `license`
- `AgentProfile`: `subagents: Vec<String>` — same pattern as `mcp_tools`
- `ApprovalMode::as_str()` — mirrors existing `SandboxMode::as_str()`/`EffortLevel::as_str()`

**Launch bundle (additive):**
- `SupplementalDoc.detail` — populated from skill profile's `detail` field (empty string when absent)
- `compile_prompt_surface()` accepts `subagents_filter: &[String]`; `build_inventory_prompt()` retains only matching agents (case-insensitive) when filter is non-empty

**Approval mode cleanup:**
- `ApprovalMode::Yolo` renamed to `ApprovalMode::Never`; `as_str()` returns `"never"`
- `from_str("yolo")` returns `Never` (backcompat)
- `DeprecatedApprovalYolo` diagnostic variant (warning, not error — same pattern as `LegacyModelsField`)
- Both parse sites (top-level profile and override block) emit deprecation when raw string is `"yolo"`
- Bundle `execution_policy.approval` emits `"never"` (was `"yolo"`)
- CLI `--approval never` replaces `--approval yolo`
- Error messages list `"default, auto, confirm, never"` as allowed values
- New test: `approval_yolo_parses_with_deprecation_warning`

**CLI (new surface, no overlap with existing commands):**
- `src/cli/agents.rs` (248 lines): list + show + filters, mirrors `list.rs` patterns
- `src/cli/skills.rs` (228 lines): list + show + filters, mirrors `list.rs` patterns
- Registered in `cli/mod.rs` — 2 Command enum variants + dispatch arms

**Risks/follow-ups:**
- `agents.rs` and `skills.rs` are ~80% structurally parallel — acceptable duplication for thin CLI modules that will diverge
- Three path-name helpers across three CLI modules (path_stem, dir_name, path_to_name) — noted, not worth extracting yet
- meridian-cli Phase 2 needed: consume bundle `detail`, use bundle inventory prompt, handle `approval: "never"` from bundle
- Prompt source repos Phase 3: update `approval: yolo` → `approval: never` in agent profiles

## Verification

- `cargo test` — 1272 unit + all integration tests, 0 failures
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- Smoke: all 10 CLI commands against real meridian-cli project (agents list/show/filters, skills list/show/filters, mars list regression)
- Round-trip: `detail`/`type`/`subagents` survive source→add→sync→show end-to-end
- Edge cases: not-found→exit 1, bad filter→empty list exit 0
- Error handling: malformed YAML and permission-denied both emit warnings in both list and show (not silent skip)
- JSON key contract: `model-invocable` kebab-case on both skills list and show
- Approval: `yolo` parses to `Never` with 1 non-error diagnostic containing "deprecated"
- Bundle: `execution_policy.approval` emits `"never"` (not `"yolo"`) in integration tests

## Spawn Trace

- p3145 tech-lead — coordinated Phase 1 implementation, smoke, review, fix pass, QA
- p3148 coder — implemented fields + subcommands
- p3149 smoke-tester — 10-command smoke + round-trip verification
- p3150 reviewer — correctness + structural review (found JSON key bug)
- p3151 simplify-reviewer — structural friction audit
- p3152 coder — fix pass (JSON key, swallowed errors, cleanups)
- p3160 qa-lead — test suite audit, added 6 integration tests
- p3138 product-lead — thermo-nuclear review, manual verification, error-warning fix
- p10 coder — detail + subagents in bundle
- p11 coder — yolo→never approval schema cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)