### PR TITLE
feat: progressive loading — skills bundle split, approval mode, detail fields

### DIFF
--- a/src/build/AGENTS.md
+++ b/src/build/AGENTS.md
@@ -14,7 +14,7 @@ resolve_policy() → Routing + ExecutionPolicy + Provenance
     ↓
 resolve_effective_skills() + compile_prompt_surface() + resolve_bundle_tools()
     ↓
-LaunchBundle {routing, execution_policy, prompt_surface, tools, skills_metadata, provenance, warnings}
+LaunchBundle {routing, execution_policy, prompt_surface, tools, skills, provenance, warnings}
 ```
 
 ## Two Modes

--- a/src/build/bundle.rs
+++ b/src/build/bundle.rs
@@ -15,7 +15,7 @@ pub struct LaunchBundle {
     pub prompt_surface: PromptSurface,
     pub scaffold_slots: ScaffoldSlots,
     pub tools: ToolsSpec,
-    pub skills_metadata: SkillsMetadata,
+    pub skills: Skills,
     pub provenance: BTreeMap<String, String>,
     pub warnings: Vec<String>,
 }
@@ -92,7 +92,6 @@ pub struct SupplementalDoc {
     pub name: String,
     pub content: String,
     pub skill_type: String,
-    pub detail: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -103,7 +102,22 @@ pub struct ToolsSpec {
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct SkillsMetadata {
-    pub loaded: Vec<String>,
+pub struct Skills {
+    pub loaded: Vec<LoadedSkill>,
+    pub available: Vec<AvailableSkill>,
     pub missing: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LoadedSkill {
+    pub name: String,
+    pub skill_type: String,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AvailableSkill {
+    pub name: String,
+    pub skill_type: String,
+    pub description: String,
 }

--- a/src/build/bundle.rs
+++ b/src/build/bundle.rs
@@ -92,6 +92,7 @@ pub struct SupplementalDoc {
     pub name: String,
     pub content: String,
     pub skill_type: String,
+    pub detail: String,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -114,6 +114,7 @@ pub fn build_launch_bundle(
         &policy.routing.harness,
         &policy.routing.model_token,
         &policy.routing.model,
+        &profile.subagents,
     )?;
 
     warnings.extend(prompt.warnings);

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -5,7 +5,7 @@ pub mod tool_normalize;
 
 use std::path::PathBuf;
 
-use bundle::{LaunchBundle, ScaffoldSlots, SkillsMetadata, ToolsSpec};
+use bundle::{LaunchBundle, ScaffoldSlots, Skills, ToolsSpec};
 use policy::{PolicyInput, resolve_policy};
 use prompt::compile_prompt_surface;
 use tool_normalize::{ToolProjectionStatus, is_first_class_harness, normalize_tool_for_harness};
@@ -14,8 +14,9 @@ use crate::cli::MarsContext;
 use crate::compiler::agents::{AgentProfile, HarnessKind, parse_agent_content};
 use crate::config::EffectiveProjectConfig;
 use crate::error::{ConfigError, MarsError};
+use crate::frontmatter::SkillsSpec;
 
-pub const LAUNCH_BUNDLE_VERSION: u32 = 2;
+pub const LAUNCH_BUNDLE_VERSION: u32 = 3;
 
 pub struct LaunchBundleRequest {
     pub agent: Option<String>,
@@ -134,8 +135,9 @@ pub fn build_launch_bundle(
         },
         scaffold_slots: ScaffoldSlots::placeholders(),
         tools: resolved_tools,
-        skills_metadata: SkillsMetadata {
+        skills: Skills {
             loaded: prompt.loaded_skills,
+            available: prompt.available_skills,
             missing: prompt.missing_skills,
         },
         provenance: policy.provenance,
@@ -156,7 +158,7 @@ fn empty_agent_profile() -> AgentProfile {
         effort: None,
         autocompact: None,
         autocompact_pct: None,
-        skills: Vec::new(),
+        skills: SkillsSpec::default(),
         subagents: Vec::new(),
         tools: Vec::new(),
         tools_denied: Vec::new(),
@@ -260,9 +262,9 @@ enum ToolPolicyKind {
 fn resolve_effective_skills(
     profile: &crate::compiler::agents::AgentProfile,
     harness: &str,
-) -> Result<Vec<String>, MarsError> {
+) -> Result<SkillsSpec, MarsError> {
     let harness_kind = parse_harness_kind(harness)?;
-    Ok(profile.effective_skills(&harness_kind).to_vec())
+    Ok(profile.effective_skills(&harness_kind).clone())
 }
 
 fn parse_harness_kind(harness: &str) -> Result<HarnessKind, MarsError> {

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -156,6 +156,7 @@ fn empty_agent_profile() -> AgentProfile {
         autocompact: None,
         autocompact_pct: None,
         skills: Vec::new(),
+        subagents: Vec::new(),
         tools: Vec::new(),
         tools_denied: Vec::new(),
         disallowed_tools: Vec::new(),

--- a/src/build/policy/execution.rs
+++ b/src/build/policy/execution.rs
@@ -300,7 +300,7 @@ fn approval_mode_to_str(mode: &ApprovalMode) -> &'static str {
         ApprovalMode::Default => "default",
         ApprovalMode::Auto => "auto",
         ApprovalMode::Confirm => "confirm",
-        ApprovalMode::Yolo => "yolo",
+        ApprovalMode::Never => "never",
     }
 }
 

--- a/src/build/policy/harness.rs
+++ b/src/build/policy/harness.rs
@@ -560,7 +560,7 @@ mod tests {
             effort: None,
             autocompact: None,
             autocompact_pct: None,
-            skills: Vec::new(),
+            skills: crate::frontmatter::SkillsSpec::default(),
             subagents: Vec::new(),
             tools: Vec::new(),
             tools_denied: Vec::new(),

--- a/src/build/policy/harness.rs
+++ b/src/build/policy/harness.rs
@@ -561,6 +561,7 @@ mod tests {
             autocompact: None,
             autocompact_pct: None,
             skills: Vec::new(),
+            subagents: Vec::new(),
             tools: Vec::new(),
             tools_denied: Vec::new(),
             disallowed_tools: Vec::new(),

--- a/src/build/policy/model.rs
+++ b/src/build/policy/model.rs
@@ -106,6 +106,7 @@ mod tests {
     use super::*;
 
     use crate::compiler::agents::{AgentProfile, HarnessOverrides};
+    use crate::frontmatter::SkillsSpec;
 
     fn empty_profile() -> AgentProfile {
         AgentProfile {
@@ -120,7 +121,7 @@ mod tests {
             effort: None,
             autocompact: None,
             autocompact_pct: None,
-            skills: Vec::new(),
+            skills: SkillsSpec::default(),
             subagents: Vec::new(),
             tools: Vec::new(),
             tools_denied: Vec::new(),

--- a/src/build/policy/model.rs
+++ b/src/build/policy/model.rs
@@ -121,6 +121,7 @@ mod tests {
             autocompact: None,
             autocompact_pct: None,
             skills: Vec::new(),
+            subagents: Vec::new(),
             tools: Vec::new(),
             tools_denied: Vec::new(),
             disallowed_tools: Vec::new(),

--- a/src/build/prompt.rs
+++ b/src/build/prompt.rs
@@ -39,6 +39,7 @@ struct ParsedAgentInventory {
     mode: AgentMode,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn compile_prompt_surface(
     mars_dir: &Path,
     agent_body: &str,
@@ -47,6 +48,7 @@ pub fn compile_prompt_surface(
     harness_id: &str,
     selected_model_token: &str,
     canonical_model_id: &str,
+    subagents_filter: &[String],
 ) -> Result<PromptCompilation, MarsError> {
     let _ = (selected_model_token, canonical_model_id);
 
@@ -95,7 +97,7 @@ pub fn compile_prompt_surface(
         .map(|loaded| loaded.document.name.clone())
         .collect::<Vec<_>>();
 
-    let inventory_prompt = build_inventory_prompt(mars_dir, &mut warnings)?;
+    let inventory_prompt = build_inventory_prompt(mars_dir, subagents_filter, &mut warnings)?;
     let system_instruction = compose_system_instruction(
         agent_body,
         &supplemental_documents,
@@ -170,6 +172,7 @@ fn load_skill_document(
         name: skill_name.to_string(),
         content,
         skill_type,
+        detail: base_profile.detail.clone().unwrap_or_default(),
     }))
 }
 
@@ -261,6 +264,7 @@ fn compose_system_instruction(
 
 fn build_inventory_prompt(
     mars_dir: &Path,
+    subagents_filter: &[String],
     warnings: &mut Vec<String>,
 ) -> Result<String, MarsError> {
     let agents_dir = mars_dir.join("agents");
@@ -304,6 +308,19 @@ fn build_inventory_prompt(
                 return Err(MarsError::Config(ConfigError::Invalid { message: err }));
             }
         }
+    }
+
+    if !subagents_filter.is_empty() {
+        primary_agents.retain(|agent| {
+            subagents_filter
+                .iter()
+                .any(|f| f.eq_ignore_ascii_case(&agent.name))
+        });
+        subagent_agents.retain(|agent| {
+            subagents_filter
+                .iter()
+                .any(|f| f.eq_ignore_ascii_case(&agent.name))
+        });
     }
 
     if primary_agents.is_empty() && subagent_agents.is_empty() {

--- a/src/build/prompt.rs
+++ b/src/build/prompt.rs
@@ -1,12 +1,12 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-use crate::build::bundle::SupplementalDoc;
+use crate::build::bundle::{AvailableSkill, LoadedSkill, SupplementalDoc};
 use crate::compiler::agents::{AgentMode, ModelPolicyMatchType, parse_agent_content};
 use crate::compiler::skills::parse_skill_content;
 use crate::compiler::variants::harness_skill_variant_path;
 use crate::error::{ConfigError, MarsError};
-use crate::frontmatter::Frontmatter;
+use crate::frontmatter::{Frontmatter, SkillsSpec};
 
 const REPORT_INSTRUCTION: &str = "# Report\n\n**IMPORTANT - Your final assistant message must be the run report.**\n\nProvide a plain markdown report in your final assistant message.\n\nInclude: what was done, key decisions made, files created/modified, verification results, and any issues or blockers.";
 
@@ -14,7 +14,8 @@ pub struct PromptCompilation {
     pub system_instruction: String,
     pub supplemental_documents: Vec<SupplementalDoc>,
     pub inventory_prompt: String,
-    pub loaded_skills: Vec<String>,
+    pub loaded_skills: Vec<LoadedSkill>,
+    pub available_skills: Vec<AvailableSkill>,
     pub missing_skills: Vec<String>,
     pub warnings: Vec<String>,
 }
@@ -27,7 +28,12 @@ struct LoadedSkillDocument {
 enum SkillLoadOutcome {
     Loaded(SupplementalDoc),
     Missing,
-    SkippedModelInvocableFalse,
+}
+
+#[derive(Debug, Clone)]
+enum AvailableSkillOutcome {
+    Available(AvailableSkill),
+    Missing,
 }
 
 #[derive(Debug, Clone)]
@@ -43,7 +49,7 @@ struct ParsedAgentInventory {
 pub fn compile_prompt_surface(
     mars_dir: &Path,
     agent_body: &str,
-    profile_skills: &[String],
+    profile_skills: &SkillsSpec,
     extra_skills: &[String],
     harness_id: &str,
     selected_model_token: &str,
@@ -52,13 +58,17 @@ pub fn compile_prompt_surface(
 ) -> Result<PromptCompilation, MarsError> {
     let _ = (selected_model_token, canonical_model_id);
 
-    let requested_skills = requested_skill_order(profile_skills, extra_skills);
+    let requested_load_skills = requested_skill_order(&profile_skills.load, extra_skills);
+    let requested_available_skills = requested_available_skill_order(
+        &profile_skills.available,
+        requested_load_skills.iter().map(String::as_str),
+    );
 
     let mut loaded_documents = Vec::new();
     let mut missing_skills = Vec::new();
     let mut warnings = Vec::new();
 
-    for (requested_index, skill) in requested_skills.iter().enumerate() {
+    for (requested_index, skill) in requested_load_skills.iter().enumerate() {
         match load_skill_document(mars_dir, skill, harness_id) {
             Ok(SkillLoadOutcome::Loaded(document)) => {
                 loaded_documents.push(LoadedSkillDocument {
@@ -67,7 +77,7 @@ pub fn compile_prompt_surface(
                 });
             }
             Ok(SkillLoadOutcome::Missing) => missing_skills.push(skill.clone()),
-            Ok(SkillLoadOutcome::SkippedModelInvocableFalse) => {}
+
             Err(err) => {
                 warnings.push(err);
                 missing_skills.push(skill.clone());
@@ -94,8 +104,25 @@ pub fn compile_prompt_surface(
 
     let loaded_skills = loaded_documents
         .iter()
-        .map(|loaded| loaded.document.name.clone())
+        .map(|loaded| LoadedSkill {
+            name: loaded.document.name.clone(),
+            skill_type: loaded.document.skill_type.clone(),
+            content: loaded.document.content.clone(),
+        })
         .collect::<Vec<_>>();
+
+    let mut available_skills = Vec::new();
+    for skill in &requested_available_skills {
+        match resolve_available_skill(mars_dir, skill, harness_id) {
+            Ok(AvailableSkillOutcome::Available(skill)) => available_skills.push(skill),
+            Ok(AvailableSkillOutcome::Missing) => missing_skills.push(skill.clone()),
+
+            Err(err) => {
+                warnings.push(err);
+                missing_skills.push(skill.clone());
+            }
+        }
+    }
 
     let inventory_prompt = build_inventory_prompt(mars_dir, subagents_filter, &mut warnings)?;
     let system_instruction = compose_system_instruction(
@@ -110,6 +137,7 @@ pub fn compile_prompt_surface(
         supplemental_documents,
         inventory_prompt,
         loaded_skills,
+        available_skills,
         missing_skills,
         warnings,
     })
@@ -129,6 +157,29 @@ fn requested_skill_order(profile_skills: &[String], extra_skills: &[String]) -> 
         }
     }
 
+    ordered
+}
+
+fn requested_available_skill_order<'a>(
+    available_skills: &[String],
+    loaded_skills: impl Iterator<Item = &'a str>,
+) -> Vec<String> {
+    let mut blocked = loaded_skills
+        .map(|name| name.trim().to_string())
+        .collect::<HashSet<_>>();
+    blocked.remove("");
+
+    let mut seen = HashSet::new();
+    let mut ordered = Vec::new();
+    for name in available_skills {
+        let normalized = name.trim();
+        if normalized.is_empty() || blocked.contains(normalized) {
+            continue;
+        }
+        if seen.insert(normalized.to_string()) {
+            ordered.push(normalized.to_string());
+        }
+    }
     ordered
 }
 
@@ -152,10 +203,9 @@ fn load_skill_document(
         return Ok(SkillLoadOutcome::Missing);
     }
 
-    let (base_profile, base_frontmatter) = parse_skill_file(skill_name, &base_skill_path)?;
-    if !base_profile.model_invocable {
-        return Ok(SkillLoadOutcome::SkippedModelInvocableFalse);
-    }
+    // model-invocable gates global discovery, not explicit profile references.
+    // If the agent profile lists a skill, it loads regardless.
+    let (_base_profile, base_frontmatter) = parse_skill_file(skill_name, &base_skill_path)?;
 
     let selected_skill_path =
         harness_skill_variant_path(&skill_dir, harness_id).unwrap_or(base_skill_path);
@@ -172,7 +222,40 @@ fn load_skill_document(
         name: skill_name.to_string(),
         content,
         skill_type,
-        detail: base_profile.detail.clone().unwrap_or_default(),
+    }))
+}
+
+fn resolve_available_skill(
+    mars_dir: &Path,
+    skill_name: &str,
+    harness_id: &str,
+) -> Result<AvailableSkillOutcome, String> {
+    let skill_dir = mars_dir.join("skills").join(skill_name);
+    let base_skill_path = skill_dir.join("SKILL.md");
+    if !base_skill_path.is_file() {
+        return Ok(AvailableSkillOutcome::Missing);
+    }
+
+    // model-invocable gates global discovery, not explicit profile references.
+    let (base_profile, base_frontmatter) = parse_skill_file(skill_name, &base_skill_path)?;
+
+    let selected_skill_path =
+        harness_skill_variant_path(&skill_dir, harness_id).unwrap_or(base_skill_path);
+    let (selected_profile, selected_frontmatter) =
+        parse_skill_file(skill_name, &selected_skill_path)?;
+
+    let skill_type = skill_type_from_frontmatter(&selected_frontmatter)
+        .or_else(|| skill_type_from_frontmatter(&base_frontmatter))
+        .unwrap_or_else(|| "reference".to_string());
+    let description = selected_profile
+        .description
+        .or(base_profile.description)
+        .unwrap_or_default();
+
+    Ok(AvailableSkillOutcome::Available(AvailableSkill {
+        name: skill_name.to_string(),
+        skill_type,
+        description,
     }))
 }
 

--- a/src/cli/agents.rs
+++ b/src/cli/agents.rs
@@ -1,6 +1,6 @@
 //! `mars agents` — list and inspect agents from the .mars/ canonical store.
 
-use crate::compiler::agents::{parse_agent_profile, parse_agent_content};
+use crate::compiler::agents::{parse_agent_content, parse_agent_profile};
 use crate::error::MarsError;
 use crate::frontmatter;
 use crate::lock::ItemKind;
@@ -117,7 +117,12 @@ fn run_list(args: &AgentsArgs, ctx: &super::MarsContext, json: bool) -> Result<i
             println!("  no agents");
         } else {
             // Compute column widths
-            let name_w = entries.iter().map(|e| e.name.len()).max().unwrap_or(4).max(4);
+            let name_w = entries
+                .iter()
+                .map(|e| e.name.len())
+                .max()
+                .unwrap_or(4)
+                .max(4);
             let mode_w = entries
                 .iter()
                 .map(|e| e.mode.len())
@@ -126,7 +131,10 @@ fn run_list(args: &AgentsArgs, ctx: &super::MarsContext, json: bool) -> Result<i
                 .max(4);
             println!("{:<name_w$}  {:<mode_w$}  DESCRIPTION", "NAME", "MODE");
             for e in &entries {
-                println!("{:<name_w$}  {:<mode_w$}  {}", e.name, e.mode, e.description);
+                println!(
+                    "{:<name_w$}  {:<mode_w$}  {}",
+                    e.name, e.mode, e.description
+                );
             }
         }
     }

--- a/src/cli/agents.rs
+++ b/src/cli/agents.rs
@@ -206,7 +206,8 @@ fn run_show(name: &str, ctx: &super::MarsContext, json: bool) -> Result<i32, Mar
                 "mode": mode_str,
                 "harness": harness_str,
                 "model": model_str,
-                "skills": profile.skills,
+                "skills": profile.skills.all(),
+                "skills_structured": profile.skills,
                 "subagents": profile.subagents,
                 "approval": approval_str,
                 "sandbox": sandbox_str,
@@ -225,7 +226,8 @@ fn run_show(name: &str, ctx: &super::MarsContext, json: bool) -> Result<i32, Mar
             println!("approval:    {approval_str}");
             println!("sandbox:     {sandbox_str}");
             println!("effort:      {effort_str}");
-            print_str_list("skills", &profile.skills);
+            print_str_list("skills.load", &profile.skills.load);
+            print_str_list("skills.available", &profile.skills.available);
             print_str_list("subagents", &profile.subagents);
             print_str_list("tools", &profile.tools);
             print_str_list("disallowed-tools", &profile.disallowed_tools);

--- a/src/cli/agents.rs
+++ b/src/cli/agents.rs
@@ -67,12 +67,18 @@ fn run_list(args: &AgentsArgs, ctx: &super::MarsContext, json: bool) -> Result<i
         let disk_path = dest_path.resolve(&mars_dir);
         let content = match std::fs::read_to_string(&disk_path) {
             Ok(c) => c,
-            Err(_) => continue,
+            Err(err) => {
+                eprintln!("warning: skipping {}: {err}", disk_path.display());
+                continue;
+            }
         };
 
         let fm = match frontmatter::parse(&content) {
             Ok(fm) => fm,
-            Err(_) => continue,
+            Err(err) => {
+                eprintln!("warning: skipping {}: {err}", disk_path.display());
+                continue;
+            }
         };
 
         let mut diags = Vec::new();

--- a/src/cli/agents.rs
+++ b/src/cli/agents.rs
@@ -1,0 +1,242 @@
+//! `mars agents` — list and inspect agents from the .mars/ canonical store.
+
+use crate::compiler::agents::{parse_agent_profile, parse_agent_content};
+use crate::error::MarsError;
+use crate::frontmatter;
+use crate::lock::ItemKind;
+
+use super::output;
+
+#[derive(serde::Serialize)]
+struct AgentEntry {
+    name: String,
+    description: String,
+    mode: String,
+}
+
+/// Arguments for `mars agents`.
+#[derive(Debug, clap::Args)]
+pub struct AgentsArgs {
+    /// Filter by mode (primary or subagent).
+    #[arg(long)]
+    pub mode: Option<String>,
+
+    /// Filter by source name.
+    #[arg(long)]
+    pub source: Option<String>,
+
+    #[command(subcommand)]
+    pub command: Option<AgentsCommand>,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum AgentsCommand {
+    /// Show full metadata for a named agent.
+    Show {
+        /// Agent name.
+        name: String,
+    },
+}
+
+/// Run `mars agents`.
+pub fn run(args: &AgentsArgs, ctx: &super::MarsContext, json: bool) -> Result<i32, MarsError> {
+    match &args.command {
+        Some(AgentsCommand::Show { name }) => run_show(name, ctx, json),
+        None => run_list(args, ctx, json),
+    }
+}
+
+fn run_list(args: &AgentsArgs, ctx: &super::MarsContext, json: bool) -> Result<i32, MarsError> {
+    let lock = crate::lock::load(&ctx.project_root)?;
+    let mars_dir = ctx.project_root.join(".mars");
+
+    let mut entries: Vec<AgentEntry> = Vec::new();
+
+    for (dest_path, item) in lock.canonical_flat_items() {
+        if item.kind != ItemKind::Agent {
+            continue;
+        }
+
+        // source filter
+        if let Some(ref filter_source) = args.source
+            && item.source != *filter_source
+        {
+            continue;
+        }
+
+        let disk_path = dest_path.resolve(&mars_dir);
+        let content = match std::fs::read_to_string(&disk_path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        let fm = match frontmatter::parse(&content) {
+            Ok(fm) => fm,
+            Err(_) => continue,
+        };
+
+        let mut diags = Vec::new();
+        let profile = parse_agent_profile(&fm, &mut diags);
+
+        // mode filter
+        let mode_str = match &profile.mode {
+            Some(m) => m.as_str().to_string(),
+            None => String::new(),
+        };
+        if let Some(ref filter_mode) = args.mode
+            && mode_str != *filter_mode
+        {
+            continue;
+        }
+
+        let name = profile
+            .name
+            .clone()
+            .unwrap_or_else(|| path_stem(&disk_path));
+        let description = profile.description.clone().unwrap_or_default();
+
+        entries.push(AgentEntry {
+            name,
+            description,
+            mode: mode_str,
+        });
+    }
+
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+
+    if json {
+        output::print_json(&serde_json::json!({ "agents": entries }));
+    } else {
+        if entries.is_empty() {
+            println!("  no agents");
+        } else {
+            // Compute column widths
+            let name_w = entries.iter().map(|e| e.name.len()).max().unwrap_or(4).max(4);
+            let mode_w = entries
+                .iter()
+                .map(|e| e.mode.len())
+                .max()
+                .unwrap_or(4)
+                .max(4);
+            println!("{:<name_w$}  {:<mode_w$}  DESCRIPTION", "NAME", "MODE");
+            for e in &entries {
+                println!("{:<name_w$}  {:<mode_w$}  {}", e.name, e.mode, e.description);
+            }
+        }
+    }
+
+    Ok(0)
+}
+
+fn run_show(name: &str, ctx: &super::MarsContext, json: bool) -> Result<i32, MarsError> {
+    let lock = crate::lock::load(&ctx.project_root)?;
+    let mars_dir = ctx.project_root.join(".mars");
+
+    for (dest_path, item) in lock.canonical_flat_items() {
+        if item.kind != ItemKind::Agent {
+            continue;
+        }
+
+        let disk_path = dest_path.resolve(&mars_dir);
+        let content = match std::fs::read_to_string(&disk_path) {
+            Ok(c) => c,
+            Err(err) => {
+                eprintln!("warning: skipping {}: {err}", disk_path.display());
+                continue;
+            }
+        };
+
+        let mut diags = Vec::new();
+        let (profile, _fm) = match parse_agent_content(&content, &mut diags) {
+            Ok(p) => p,
+            Err(err) => {
+                eprintln!("warning: skipping {}: {err}", disk_path.display());
+                continue;
+            }
+        };
+
+        let stem = path_stem(&disk_path);
+        let agent_name = profile.name.as_deref().unwrap_or(stem.as_str());
+        if !agent_name.eq_ignore_ascii_case(name) {
+            continue;
+        }
+
+        let mode_str = profile.mode.as_ref().map(|m| m.as_str()).unwrap_or("");
+        let harness_str = profile
+            .harness
+            .as_ref()
+            .map(|h| h.to_harness_id().as_str())
+            .unwrap_or("");
+        let model_str = profile.model.as_deref().unwrap_or("");
+        let approval_str = profile
+            .approval
+            .as_ref()
+            .map(|a| a.as_str())
+            .unwrap_or_default();
+        let sandbox_str = profile
+            .sandbox
+            .as_ref()
+            .map(|s| s.as_str())
+            .unwrap_or_default();
+        let effort_str = profile
+            .effort
+            .as_ref()
+            .map(|e| e.as_str())
+            .unwrap_or_default();
+        let description_str = profile.description.as_deref().unwrap_or("");
+
+        if json {
+            output::print_json(&serde_json::json!({
+                "name": agent_name,
+                "description": description_str,
+                "mode": mode_str,
+                "harness": harness_str,
+                "model": model_str,
+                "skills": profile.skills,
+                "subagents": profile.subagents,
+                "approval": approval_str,
+                "sandbox": sandbox_str,
+                "effort": effort_str,
+                "tools": profile.tools,
+                "disallowed-tools": profile.disallowed_tools,
+                "tools-denied": profile.tools_denied,
+                "mcp-tools": profile.mcp_tools,
+            }));
+        } else {
+            println!("name:        {agent_name}");
+            println!("description: {description_str}");
+            println!("mode:        {mode_str}");
+            println!("harness:     {harness_str}");
+            println!("model:       {model_str}");
+            println!("approval:    {approval_str}");
+            println!("sandbox:     {sandbox_str}");
+            println!("effort:      {effort_str}");
+            print_str_list("skills", &profile.skills);
+            print_str_list("subagents", &profile.subagents);
+            print_str_list("tools", &profile.tools);
+            print_str_list("disallowed-tools", &profile.disallowed_tools);
+            print_str_list("tools-denied", &profile.tools_denied);
+            print_str_list("mcp-tools", &profile.mcp_tools);
+        }
+
+        return Ok(0);
+    }
+
+    eprintln!("error: agent `{name}` not found");
+    Ok(1)
+}
+
+fn print_str_list(label: &str, items: &[String]) {
+    if items.is_empty() {
+        println!("{label}:        (none)");
+    } else {
+        println!("{label}:        {}", items.join(", "));
+    }
+}
+
+fn path_stem(path: &std::path::Path) -> String {
+    path.file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown")
+        .to_string()
+}

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -63,7 +63,7 @@ enum ApprovalArg {
     Default,
     Auto,
     Confirm,
-    Yolo,
+    Never,
 }
 
 impl ApprovalArg {
@@ -72,7 +72,7 @@ impl ApprovalArg {
             Self::Default => "default",
             Self::Auto => "auto",
             Self::Confirm => "confirm",
-            Self::Yolo => "yolo",
+            Self::Never => "never",
         }
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -9,6 +9,7 @@
 
 pub mod add;
 pub mod adopt;
+pub mod agents;
 pub mod build;
 pub mod cache;
 pub mod check;
@@ -25,6 +26,7 @@ pub mod remove;
 pub mod rename;
 pub mod repair;
 pub mod resolve_cmd;
+pub mod skills;
 pub mod sync;
 pub mod target;
 pub mod unlink;
@@ -182,6 +184,12 @@ pub enum Command {
 
     /// Build derived artifacts from static project state.
     Build(build::BuildArgs),
+
+    /// List and inspect agents.
+    Agents(agents::AgentsArgs),
+
+    /// List and inspect skills.
+    Skills(skills::SkillsArgs),
 }
 
 /// Dispatch a parsed CLI command to the appropriate handler and map errors to
@@ -284,6 +292,8 @@ fn dispatch_with_root(cmd: &Command, ctx: &MarsContext, json: bool) -> Result<i3
         Command::Repair(args) => repair::run(args, ctx, json),
         Command::Models(args) => models::run(args, ctx, json),
         Command::Build(args) => build::run(args, ctx, json),
+        Command::Agents(args) => agents::run(args, ctx, json),
+        Command::Skills(args) => skills::run(args, ctx, json),
         // Root-free commands handled in dispatch_result — unreachable here
         Command::Init(_) | Command::Check(_) | Command::Cache(_) => unreachable!(),
     }

--- a/src/cli/skills.rs
+++ b/src/cli/skills.rs
@@ -75,12 +75,18 @@ fn run_list(args: &SkillsArgs, ctx: &super::MarsContext, json: bool) -> Result<i
         let skill_md = disk_path.join("SKILL.md");
         let content = match std::fs::read_to_string(&skill_md) {
             Ok(c) => c,
-            Err(_) => continue,
+            Err(err) => {
+                eprintln!("warning: skipping {}: {err}", skill_md.display());
+                continue;
+            }
         };
 
         let fm = match frontmatter::parse(&content) {
             Ok(fm) => fm,
-            Err(_) => continue,
+            Err(err) => {
+                eprintln!("warning: skipping {}: {err}", skill_md.display());
+                continue;
+            }
         };
 
         let mut diags = Vec::new();

--- a/src/cli/skills.rs
+++ b/src/cli/skills.rs
@@ -1,0 +1,222 @@
+//! `mars skills` — list and inspect skills from the .mars/ canonical store.
+
+use crate::compiler::skills::{parse_skill_profile, parse_skill_content};
+use crate::error::MarsError;
+use crate::frontmatter;
+use crate::lock::ItemKind;
+
+use super::output;
+
+#[derive(serde::Serialize)]
+struct SkillEntry {
+    name: String,
+    description: String,
+    #[serde(rename = "type")]
+    skill_type: String,
+    #[serde(rename = "model-invocable")]
+    model_invocable: bool,
+}
+
+/// Arguments for `mars skills`.
+#[derive(Debug, clap::Args)]
+pub struct SkillsArgs {
+    /// Filter by skill type (e.g. guardrail, reference, principle).
+    #[arg(long = "type", id = "skill_type")]
+    pub skill_type: Option<String>,
+
+    /// Filter to model-invocable skills only.
+    #[arg(long)]
+    pub model_invocable: bool,
+
+    /// Filter by source name.
+    #[arg(long)]
+    pub source: Option<String>,
+
+    #[command(subcommand)]
+    pub command: Option<SkillsCommand>,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum SkillsCommand {
+    /// Show full metadata for a named skill.
+    Show {
+        /// Skill name.
+        name: String,
+    },
+}
+
+/// Run `mars skills`.
+pub fn run(args: &SkillsArgs, ctx: &super::MarsContext, json: bool) -> Result<i32, MarsError> {
+    match &args.command {
+        Some(SkillsCommand::Show { name }) => run_show(name, ctx, json),
+        None => run_list(args, ctx, json),
+    }
+}
+
+fn run_list(args: &SkillsArgs, ctx: &super::MarsContext, json: bool) -> Result<i32, MarsError> {
+    let lock = crate::lock::load(&ctx.project_root)?;
+    let mars_dir = ctx.project_root.join(".mars");
+
+    let mut entries: Vec<SkillEntry> = Vec::new();
+
+    for (dest_path, item) in lock.canonical_flat_items() {
+        if item.kind != ItemKind::Skill {
+            continue;
+        }
+
+        // source filter
+        if let Some(ref filter_source) = args.source
+            && item.source != *filter_source
+        {
+            continue;
+        }
+
+        let disk_path = dest_path.resolve(&mars_dir);
+        let skill_md = disk_path.join("SKILL.md");
+        let content = match std::fs::read_to_string(&skill_md) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        let fm = match frontmatter::parse(&content) {
+            Ok(fm) => fm,
+            Err(_) => continue,
+        };
+
+        let mut diags = Vec::new();
+        let profile = parse_skill_profile(&fm, &mut diags);
+
+        // model_invocable filter
+        if args.model_invocable && !profile.model_invocable {
+            continue;
+        }
+
+        // type filter
+        let type_str = profile.skill_type.clone().unwrap_or_default();
+        if let Some(ref filter_type) = args.skill_type
+            && type_str != *filter_type
+        {
+            continue;
+        }
+
+        let name = profile
+            .name
+            .clone()
+            .unwrap_or_else(|| dir_name(&disk_path));
+        let description = profile.description.clone().unwrap_or_default();
+
+        entries.push(SkillEntry {
+            name,
+            description,
+            skill_type: type_str,
+            model_invocable: profile.model_invocable,
+        });
+    }
+
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+
+    if json {
+        output::print_json(&serde_json::json!({ "skills": entries }));
+    } else {
+        if entries.is_empty() {
+            println!("  no skills");
+        } else {
+            let name_w = entries.iter().map(|e| e.name.len()).max().unwrap_or(4).max(4);
+            let type_w = entries
+                .iter()
+                .map(|e| e.skill_type.len())
+                .max()
+                .unwrap_or(4)
+                .max(4);
+            println!(
+                "{:<name_w$}  {:<type_w$}  {:<5}  DESCRIPTION",
+                "NAME", "TYPE", "M-INV"
+            );
+            for e in &entries {
+                let inv = if e.model_invocable { "yes" } else { "no" };
+                println!(
+                    "{:<name_w$}  {:<type_w$}  {:<5}  {}",
+                    e.name, e.skill_type, inv, e.description
+                );
+            }
+        }
+    }
+
+    Ok(0)
+}
+
+fn run_show(name: &str, ctx: &super::MarsContext, json: bool) -> Result<i32, MarsError> {
+    let lock = crate::lock::load(&ctx.project_root)?;
+    let mars_dir = ctx.project_root.join(".mars");
+
+    for (dest_path, item) in lock.canonical_flat_items() {
+        if item.kind != ItemKind::Skill {
+            continue;
+        }
+
+        let disk_path = dest_path.resolve(&mars_dir);
+        let skill_md = disk_path.join("SKILL.md");
+        let content = match std::fs::read_to_string(&skill_md) {
+            Ok(c) => c,
+            Err(err) => {
+                eprintln!("warning: skipping {}: {err}", skill_md.display());
+                continue;
+            }
+        };
+
+        let mut diags = Vec::new();
+        let (profile, _fm) = match parse_skill_content(&content, &mut diags) {
+            Ok(p) => p,
+            Err(err) => {
+                eprintln!("warning: skipping {}: {err}", skill_md.display());
+                continue;
+            }
+        };
+
+        let fallback = dir_name(&disk_path);
+        let skill_name = profile.name.as_deref().unwrap_or(fallback.as_str());
+        if !skill_name.eq_ignore_ascii_case(name) {
+            continue;
+        }
+
+        let description_str = profile.description.as_deref().unwrap_or("");
+        let detail_str = profile.detail.as_deref().unwrap_or("");
+        let type_str = profile.skill_type.as_deref().unwrap_or("");
+
+        if json {
+            output::print_json(&serde_json::json!({
+                "name": skill_name,
+                "description": description_str,
+                "detail": detail_str,
+                "type": type_str,
+                "model-invocable": profile.model_invocable,
+                "user-invocable": profile.user_invocable,
+                "allowed-tools": profile.allowed_tools,
+            }));
+        } else {
+            println!("name:          {skill_name}");
+            println!("description:   {description_str}");
+            println!("detail:        {detail_str}");
+            println!("type:          {type_str}");
+            println!("model-invocable: {}", profile.model_invocable);
+            println!("user-invocable:  {}", profile.user_invocable);
+            if profile.allowed_tools.is_empty() {
+                println!("allowed-tools: (none)");
+            } else {
+                println!("allowed-tools: {}", profile.allowed_tools.join(", "));
+            }
+        }
+
+        return Ok(0);
+    }
+
+    eprintln!("error: skill `{name}` not found");
+    Ok(1)
+}
+
+fn dir_name(path: &std::path::Path) -> String {
+    path.file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown")
+        .to_string()
+}

--- a/src/cli/skills.rs
+++ b/src/cli/skills.rs
@@ -188,14 +188,12 @@ fn run_show(name: &str, ctx: &super::MarsContext, json: bool) -> Result<i32, Mar
         }
 
         let description_str = profile.description.as_deref().unwrap_or("");
-        let detail_str = profile.detail.as_deref().unwrap_or("");
         let type_str = profile.skill_type.as_deref().unwrap_or("");
 
         if json {
             output::print_json(&serde_json::json!({
                 "name": skill_name,
                 "description": description_str,
-                "detail": detail_str,
                 "type": type_str,
                 "model-invocable": profile.model_invocable,
                 "user-invocable": profile.user_invocable,
@@ -204,7 +202,6 @@ fn run_show(name: &str, ctx: &super::MarsContext, json: bool) -> Result<i32, Mar
         } else {
             println!("name:          {skill_name}");
             println!("description:   {description_str}");
-            println!("detail:        {detail_str}");
             println!("type:          {type_str}");
             println!("model-invocable: {}", profile.model_invocable);
             println!("user-invocable:  {}", profile.user_invocable);

--- a/src/cli/skills.rs
+++ b/src/cli/skills.rs
@@ -1,6 +1,6 @@
 //! `mars skills` — list and inspect skills from the .mars/ canonical store.
 
-use crate::compiler::skills::{parse_skill_profile, parse_skill_content};
+use crate::compiler::skills::{parse_skill_content, parse_skill_profile};
 use crate::error::MarsError;
 use crate::frontmatter;
 use crate::lock::ItemKind;
@@ -105,10 +105,7 @@ fn run_list(args: &SkillsArgs, ctx: &super::MarsContext, json: bool) -> Result<i
             continue;
         }
 
-        let name = profile
-            .name
-            .clone()
-            .unwrap_or_else(|| dir_name(&disk_path));
+        let name = profile.name.clone().unwrap_or_else(|| dir_name(&disk_path));
         let description = profile.description.clone().unwrap_or_default();
 
         entries.push(SkillEntry {
@@ -127,7 +124,12 @@ fn run_list(args: &SkillsArgs, ctx: &super::MarsContext, json: bool) -> Result<i
         if entries.is_empty() {
             println!("  no skills");
         } else {
-            let name_w = entries.iter().map(|e| e.name.len()).max().unwrap_or(4).max(4);
+            let name_w = entries
+                .iter()
+                .map(|e| e.name.len())
+                .max()
+                .unwrap_or(4)
+                .max(4);
             let type_w = entries
                 .iter()
                 .map(|e| e.skill_type.len())

--- a/src/compiler/agents/lower.rs
+++ b/src/compiler/agents/lower.rs
@@ -83,8 +83,8 @@ impl<'a> Effective<'a> {
             .or(self.profile.sandbox.as_ref())
     }
 
-    fn skills(&self) -> &[String] {
-        self.profile.effective_skills(self.harness)
+    fn skills(&self) -> Vec<String> {
+        self.profile.effective_skills(self.harness).all()
     }
 
     fn tools(&self) -> &[String] {

--- a/src/compiler/agents/lower.rs
+++ b/src/compiler/agents/lower.rs
@@ -297,7 +297,7 @@ pub fn lower_to_codex(profile: &AgentProfile, body: &str) -> LoweredOutput {
             ApprovalMode::Default => None,
             ApprovalMode::Auto => Some("on-request"),
             ApprovalMode::Confirm => Some("untrusted"),
-            ApprovalMode::Yolo => Some("never"),
+            ApprovalMode::Never => Some("never"),
         }
     });
 

--- a/src/compiler/agents/mod.rs
+++ b/src/compiler/agents/mod.rs
@@ -1106,10 +1106,7 @@ pub fn parse_agent_profile(fm: &Frontmatter, diags: &mut Vec<AgentDiagnostic>) -
 
     // skills/subagents/tools/disallowed-tools/mcp-tools:
     let skills = fm.skills();
-    let subagents = fm
-        .get("subagents")
-        .map(yaml_str_list)
-        .unwrap_or_default();
+    let subagents = fm.get("subagents").map(yaml_str_list).unwrap_or_default();
     let parsed_tools = fm
         .get("tools")
         .map(|value| parse_tools_field("tools", value, diags))

--- a/src/compiler/agents/mod.rs
+++ b/src/compiler/agents/mod.rs
@@ -97,7 +97,7 @@ pub enum ApprovalMode {
     Default,
     Auto,
     Confirm,
-    Yolo,
+    Never,
 }
 
 impl ApprovalMode {
@@ -106,7 +106,7 @@ impl ApprovalMode {
             "default" => Some(Self::Default),
             "auto" => Some(Self::Auto),
             "confirm" => Some(Self::Confirm),
-            "yolo" => Some(Self::Yolo),
+            "never" | "yolo" => Some(Self::Never),
             _ => None,
         }
     }
@@ -116,7 +116,7 @@ impl ApprovalMode {
             Self::Default => "default",
             Self::Auto => "auto",
             Self::Confirm => "confirm",
-            Self::Yolo => "yolo",
+            Self::Never => "never",
         }
     }
 }
@@ -355,6 +355,8 @@ pub enum AgentDiagnostic {
     },
     /// Deprecated `models:` field was found (use `model-overrides:` instead).
     LegacyModelsField,
+    /// Deprecated `approval: yolo` was found (use `approval: never` instead).
+    DeprecatedApprovalYolo,
     /// Unknown harness name — not one of claude/codex/opencode/pi.
     UnknownHarness { value: String },
     /// Non-overridable field appears inside an override block.
@@ -384,6 +386,9 @@ impl AgentDiagnostic {
             }
             AgentDiagnostic::LegacyModelsField => {
                 "agent uses deprecated `models:` field; rename to `model-overrides:`".to_string()
+            }
+            AgentDiagnostic::DeprecatedApprovalYolo => {
+                "agent uses deprecated `approval: yolo`; use `approval: never` instead".to_string()
             }
             AgentDiagnostic::UnknownHarness { value } => {
                 format!("unknown harness `{value}`; known: claude, codex, opencode, cursor, pi")
@@ -742,12 +747,15 @@ fn parse_override_fields(
             "approval" => {
                 if let Some(s) = v.as_str() {
                     if let Some(a) = ApprovalMode::from_str(s) {
+                        if s == "yolo" {
+                            diags.push(AgentDiagnostic::DeprecatedApprovalYolo);
+                        }
                         out.approval = Some(a);
                     } else {
                         diags.push(AgentDiagnostic::InvalidFieldValue {
                             field: format!("{table_name}.approval"),
                             value: s.to_string(),
-                            allowed: "default, auto, confirm, yolo",
+                            allowed: "default, auto, confirm, never",
                         });
                     }
                 }
@@ -1008,12 +1016,15 @@ pub fn parse_agent_profile(fm: &Frontmatter, diags: &mut Vec<AgentDiagnostic>) -
     // approval:
     let approval = fm.get("approval").and_then(Value::as_str).and_then(|s| {
         if let Some(a) = ApprovalMode::from_str(s) {
+            if s == "yolo" {
+                diags.push(AgentDiagnostic::DeprecatedApprovalYolo);
+            }
             Some(a)
         } else {
             diags.push(AgentDiagnostic::InvalidFieldValue {
                 field: "approval".to_string(),
                 value: s.to_string(),
-                allowed: "default, auto, confirm, yolo",
+                allowed: "default, auto, confirm, never",
             });
             None
         }

--- a/src/compiler/agents/mod.rs
+++ b/src/compiler/agents/mod.rs
@@ -10,7 +10,7 @@ pub mod lower;
 use serde_yaml::Value;
 
 pub use crate::config::{ModelPolicyMatchType, ModelPolicyRule};
-use crate::frontmatter::{Frontmatter, FrontmatterError};
+use crate::frontmatter::{Frontmatter, FrontmatterError, SkillsSpec};
 
 // ---------------------------------------------------------------------------
 // Field enums
@@ -202,7 +202,7 @@ pub struct OverrideFields {
     pub autocompact_pct: Option<u8>,
     pub approval: Option<ApprovalMode>,
     pub sandbox: Option<SandboxMode>,
-    pub skills: Option<Vec<String>>,
+    pub skills: Option<SkillsSpec>,
     pub tools: Option<Vec<String>>,
     pub tools_denied: Option<Vec<String>>,
     pub disallowed_tools: Option<Vec<String>>,
@@ -273,7 +273,7 @@ pub struct AgentProfile {
     pub autocompact_pct: Option<u8>,
 
     // --- Tool fields ---
-    pub skills: Vec<String>,
+    pub skills: SkillsSpec,
     pub subagents: Vec<String>,
     pub tools: Vec<String>,
     pub tools_denied: Vec<String>,
@@ -295,7 +295,7 @@ pub struct EffectiveToolPolicy {
 }
 
 impl AgentProfile {
-    pub fn effective_skills(&self, harness: &HarnessKind) -> &[String] {
+    pub fn effective_skills(&self, harness: &HarnessKind) -> &SkillsSpec {
         self.harness_overrides
             .get(harness)
             .and_then(|entry| entry.skills.as_ref())
@@ -431,6 +431,25 @@ fn yaml_str_list(val: &Value) -> Vec<String> {
             .collect(),
         Value::String(s) => vec![s.clone()],
         _ => vec![],
+    }
+}
+
+fn parse_skills_spec(val: &Value) -> SkillsSpec {
+    match val {
+        Value::Mapping(mapping) => SkillsSpec {
+            load: mapping
+                .get(Value::String("load".to_string()))
+                .map(yaml_str_list)
+                .unwrap_or_default(),
+            available: mapping
+                .get(Value::String("available".to_string()))
+                .map(yaml_str_list)
+                .unwrap_or_default(),
+        },
+        _ => SkillsSpec {
+            load: yaml_str_list(val),
+            available: Vec::new(),
+        },
     }
 }
 
@@ -774,7 +793,7 @@ fn parse_override_fields(
                 }
             }
             "skills" => {
-                out.skills = Some(yaml_str_list(v));
+                out.skills = Some(parse_skills_spec(v));
             }
             "tools" => {
                 let parsed = parse_tools_field(&format!("{table_name}.tools"), v, diags);
@@ -1116,7 +1135,7 @@ pub fn parse_agent_profile(fm: &Frontmatter, diags: &mut Vec<AgentDiagnostic>) -
     };
 
     // skills/subagents/tools/disallowed-tools/mcp-tools:
-    let skills = fm.skills();
+    let skills = fm.skills_structured();
     let subagents = fm.get("subagents").map(yaml_str_list).unwrap_or_default();
     let parsed_tools = fm
         .get("tools")

--- a/src/compiler/agents/mod.rs
+++ b/src/compiler/agents/mod.rs
@@ -110,6 +110,15 @@ impl ApprovalMode {
             _ => None,
         }
     }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Default => "default",
+            Self::Auto => "auto",
+            Self::Confirm => "confirm",
+            Self::Yolo => "yolo",
+        }
+    }
 }
 
 /// Sandbox mode field.
@@ -265,6 +274,7 @@ pub struct AgentProfile {
 
     // --- Tool fields ---
     pub skills: Vec<String>,
+    pub subagents: Vec<String>,
     pub tools: Vec<String>,
     pub tools_denied: Vec<String>,
     pub disallowed_tools: Vec<String>,
@@ -1094,8 +1104,12 @@ pub fn parse_agent_profile(fm: &Frontmatter, diags: &mut Vec<AgentDiagnostic>) -
         }
     };
 
-    // skills/tools/disallowed-tools/mcp-tools:
+    // skills/subagents/tools/disallowed-tools/mcp-tools:
     let skills = fm.skills();
+    let subagents = fm
+        .get("subagents")
+        .map(yaml_str_list)
+        .unwrap_or_default();
     let parsed_tools = fm
         .get("tools")
         .map(|value| parse_tools_field("tools", value, diags))
@@ -1141,6 +1155,7 @@ pub fn parse_agent_profile(fm: &Frontmatter, diags: &mut Vec<AgentDiagnostic>) -
         autocompact,
         autocompact_pct,
         skills,
+        subagents,
         tools,
         tools_denied,
         disallowed_tools,

--- a/src/compiler/agents/tests.rs
+++ b/src/compiler/agents/tests.rs
@@ -528,3 +528,21 @@ fn agent_without_harness_is_universal() {
     let (p, _) = parse("---\nname: planner\nmodel: gpt55\n---\n# Planner");
     assert!(p.harness.is_none());
 }
+
+// --- subagents field ---
+
+#[test]
+fn subagents_list_parses() {
+    let (p, diags) = parse(
+        "---\nname: orchestrator\nsubagents:\n  - coder\n  - reviewer\n---\n# Orchestrator",
+    );
+    assert!(diags.is_empty());
+    assert_eq!(p.subagents, vec!["coder", "reviewer"]);
+}
+
+#[test]
+fn subagents_absent_gives_empty_vec() {
+    let (p, diags) = parse("---\nname: solo\n---\n# Solo agent");
+    assert!(diags.is_empty());
+    assert!(p.subagents.is_empty());
+}

--- a/src/compiler/agents/tests.rs
+++ b/src/compiler/agents/tests.rs
@@ -232,7 +232,8 @@ fn parses_skills_tools_disallowed_mcp() {
     let content = "---\nskills: [review, dev-principles]\ntools: [Bash, Write]\ndisallowed-tools: [Agent]\nmcp-tools: [server]\n---\n";
     let (p, diags) = parse(content);
     assert!(diags.is_empty());
-    assert_eq!(p.skills, vec!["review", "dev-principles"]);
+    assert_eq!(p.skills.load, vec!["review", "dev-principles"]);
+    assert!(p.skills.available.is_empty());
     assert_eq!(p.tools, vec!["Bash", "Write"]);
     assert!(p.tools_denied.is_empty());
     assert_eq!(p.disallowed_tools, vec!["Agent"]);
@@ -274,13 +275,26 @@ fn effective_skills_use_harness_override_replacement() {
     assert!(diags.is_empty());
 
     assert_eq!(
-        p.effective_skills(&HarnessKind::Codex),
-        &vec!["codex-only".to_string()]
+        p.effective_skills(&HarnessKind::Codex).load,
+        vec!["codex-only".to_string()]
     );
     assert_eq!(
-        p.effective_skills(&HarnessKind::Claude),
-        &vec!["base".to_string()]
+        p.effective_skills(&HarnessKind::Claude).load,
+        vec!["base".to_string()]
     );
+}
+
+#[test]
+fn parses_structured_skills_and_override() {
+    let content = "---\nskills:\n  load: [dev-principles]\n  available: [planning, spawn]\nharness-overrides:\n  codex:\n    skills:\n      load: [codex-principles]\n      available: [codex-planning]\n---\n";
+    let (p, diags) = parse(content);
+    assert!(diags.is_empty());
+
+    assert_eq!(p.skills.load, vec!["dev-principles"]);
+    assert_eq!(p.skills.available, vec!["planning", "spawn"]);
+    let codex = p.effective_skills(&HarnessKind::Codex);
+    assert_eq!(codex.load, vec!["codex-principles"]);
+    assert_eq!(codex.available, vec!["codex-planning"]);
 }
 
 #[test]

--- a/src/compiler/agents/tests.rs
+++ b/src/compiler/agents/tests.rs
@@ -131,12 +131,22 @@ fn parses_effort_none_sentinel() {
 
 #[test]
 fn parses_approval_all_values() {
-    for s in ["default", "auto", "confirm", "yolo"] {
+    for s in ["default", "auto", "confirm", "never"] {
         let content = format!("---\napproval: {s}\n---\n");
         let (p, diags) = parse(&content);
         assert!(diags.is_empty(), "unexpected diags for approval={s}");
         assert!(p.approval.is_some());
     }
+}
+
+#[test]
+fn approval_yolo_parses_with_deprecation_warning() {
+    let content = "---\napproval: yolo\n---\n";
+    let (p, diags) = parse(content);
+    assert_eq!(p.approval, Some(ApprovalMode::Never));
+    assert_eq!(diags.len(), 1);
+    assert!(!diags[0].is_error());
+    assert!(diags[0].message().contains("deprecated"));
 }
 
 #[test]

--- a/src/compiler/agents/tests.rs
+++ b/src/compiler/agents/tests.rs
@@ -533,9 +533,8 @@ fn agent_without_harness_is_universal() {
 
 #[test]
 fn subagents_list_parses() {
-    let (p, diags) = parse(
-        "---\nname: orchestrator\nsubagents:\n  - coder\n  - reviewer\n---\n# Orchestrator",
-    );
+    let (p, diags) =
+        parse("---\nname: orchestrator\nsubagents:\n  - coder\n  - reviewer\n---\n# Orchestrator");
     assert!(diags.is_empty());
     assert_eq!(p.subagents, vec!["coder", "reviewer"]);
 }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -628,7 +628,7 @@ mod skill_surface_tests {
             effort: None,
             autocompact: None,
             autocompact_pct: None,
-            skills: Vec::new(),
+            skills: crate::frontmatter::SkillsSpec::default(),
             subagents: Vec::new(),
             tools: Vec::new(),
             tools_denied: Vec::new(),

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -629,6 +629,7 @@ mod skill_surface_tests {
             autocompact: None,
             autocompact_pct: None,
             skills: Vec::new(),
+            subagents: Vec::new(),
             tools: Vec::new(),
             tools_denied: Vec::new(),
             disallowed_tools: Vec::new(),

--- a/src/compiler/skills/mod.rs
+++ b/src/compiler/skills/mod.rs
@@ -10,6 +10,8 @@ use crate::frontmatter::{Frontmatter, FrontmatterError};
 pub struct SkillProfile {
     pub name: Option<String>,
     pub description: Option<String>,
+    pub detail: Option<String>,
+    pub skill_type: Option<String>,
     pub model_invocable: bool,
     pub user_invocable: bool,
     pub allowed_tools: Vec<String>,
@@ -172,6 +174,28 @@ pub fn parse_skill_profile(fm: &Frontmatter, diags: &mut Vec<SkillDiagnostic>) -
             allowed: "string",
         });
     }
+    let detail_raw = fm.get("detail");
+    let detail = detail_raw.and_then(Value::as_str).map(str::to_owned);
+    if let Some(raw) = detail_raw
+        && !raw.is_string()
+    {
+        diags.push(SkillDiagnostic::InvalidFieldType {
+            field: "detail".to_string(),
+            value: value_label(raw),
+            allowed: "string",
+        });
+    }
+    let skill_type_raw = fm.get("type");
+    let skill_type = skill_type_raw.and_then(Value::as_str).map(str::to_owned);
+    if let Some(raw) = skill_type_raw
+        && !raw.is_string()
+    {
+        diags.push(SkillDiagnostic::InvalidFieldType {
+            field: "type".to_string(),
+            value: value_label(raw),
+            allowed: "string",
+        });
+    }
     let metadata = fm.get("metadata").cloned();
 
     let (model_invocable, had_model_invocable_field) =
@@ -194,6 +218,8 @@ pub fn parse_skill_profile(fm: &Frontmatter, diags: &mut Vec<SkillDiagnostic>) -
     SkillProfile {
         name,
         description,
+        detail,
+        skill_type,
         model_invocable,
         user_invocable,
         allowed_tools,
@@ -412,6 +438,46 @@ body",
         assert!(d.iter().any(|d| matches!(
             d,
             SkillDiagnostic::InvalidFieldType { field, .. } if field == "license"
+        )));
+    }
+
+    #[test]
+    fn detail_and_type_parse_from_frontmatter() {
+        let (p, d, _) = parse(
+            "---\nname: a\ndescription: b\ndetail: Long description here\ntype: guardrail\n---\nbody",
+        );
+        assert!(d.is_empty());
+        assert_eq!(p.detail.as_deref(), Some("Long description here"));
+        assert_eq!(p.skill_type.as_deref(), Some("guardrail"));
+    }
+
+    #[test]
+    fn detail_and_type_absent_gives_none() {
+        let (p, d, _) = parse("---\nname: a\ndescription: b\n---\nbody");
+        assert!(d.is_empty());
+        assert!(p.detail.is_none());
+        assert!(p.skill_type.is_none());
+    }
+
+    #[test]
+    fn non_string_detail_emits_diagnostic() {
+        let (p, d, _) = parse("---\nname: a\ndescription: b\ndetail: 42\n---\nbody");
+        assert!(p.detail.is_none());
+        assert!(d.iter().any(|diag| matches!(
+            diag,
+            SkillDiagnostic::InvalidFieldType { field, allowed, .. }
+                if field == "detail" && *allowed == "string"
+        )));
+    }
+
+    #[test]
+    fn non_string_type_emits_diagnostic() {
+        let (p, d, _) = parse("---\nname: a\ndescription: b\ntype: [a, b]\n---\nbody");
+        assert!(p.skill_type.is_none());
+        assert!(d.iter().any(|diag| matches!(
+            diag,
+            SkillDiagnostic::InvalidFieldType { field, allowed, .. }
+                if field == "type" && *allowed == "string"
         )));
     }
 

--- a/src/compiler/skills/mod.rs
+++ b/src/compiler/skills/mod.rs
@@ -10,7 +10,6 @@ use crate::frontmatter::{Frontmatter, FrontmatterError};
 pub struct SkillProfile {
     pub name: Option<String>,
     pub description: Option<String>,
-    pub detail: Option<String>,
     pub skill_type: Option<String>,
     pub model_invocable: bool,
     pub user_invocable: bool,
@@ -174,17 +173,6 @@ pub fn parse_skill_profile(fm: &Frontmatter, diags: &mut Vec<SkillDiagnostic>) -
             allowed: "string",
         });
     }
-    let detail_raw = fm.get("detail");
-    let detail = detail_raw.and_then(Value::as_str).map(str::to_owned);
-    if let Some(raw) = detail_raw
-        && !raw.is_string()
-    {
-        diags.push(SkillDiagnostic::InvalidFieldType {
-            field: "detail".to_string(),
-            value: value_label(raw),
-            allowed: "string",
-        });
-    }
     let skill_type_raw = fm.get("type");
     let skill_type = skill_type_raw.and_then(Value::as_str).map(str::to_owned);
     if let Some(raw) = skill_type_raw
@@ -218,7 +206,6 @@ pub fn parse_skill_profile(fm: &Frontmatter, diags: &mut Vec<SkillDiagnostic>) -
     SkillProfile {
         name,
         description,
-        detail,
         skill_type,
         model_invocable,
         user_invocable,
@@ -442,32 +429,17 @@ body",
     }
 
     #[test]
-    fn detail_and_type_parse_from_frontmatter() {
-        let (p, d, _) = parse(
-            "---\nname: a\ndescription: b\ndetail: Long description here\ntype: guardrail\n---\nbody",
-        );
+    fn type_parses_from_frontmatter() {
+        let (p, d, _) = parse("---\nname: a\ndescription: b\ntype: guardrail\n---\nbody");
         assert!(d.is_empty());
-        assert_eq!(p.detail.as_deref(), Some("Long description here"));
         assert_eq!(p.skill_type.as_deref(), Some("guardrail"));
     }
 
     #[test]
-    fn detail_and_type_absent_gives_none() {
+    fn type_absent_gives_none() {
         let (p, d, _) = parse("---\nname: a\ndescription: b\n---\nbody");
         assert!(d.is_empty());
-        assert!(p.detail.is_none());
         assert!(p.skill_type.is_none());
-    }
-
-    #[test]
-    fn non_string_detail_emits_diagnostic() {
-        let (p, d, _) = parse("---\nname: a\ndescription: b\ndetail: 42\n---\nbody");
-        assert!(p.detail.is_none());
-        assert!(d.iter().any(|diag| matches!(
-            diag,
-            SkillDiagnostic::InvalidFieldType { field, allowed, .. }
-                if field == "detail" && *allowed == "string"
-        )));
     }
 
     #[test]

--- a/src/frontmatter/mod.rs
+++ b/src/frontmatter/mod.rs
@@ -9,6 +9,31 @@ pub struct Frontmatter {
     has_frontmatter: bool,
 }
 
+/// Structured agent skill references.
+///
+/// A flat `skills: [a, b]` list is represented as all `load` entries for
+/// backward compatibility. A structured `skills: { load: [...], available: [...] }`
+/// keeps the two launch-bundle channels separate.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
+pub struct SkillsSpec {
+    pub load: Vec<String>,
+    pub available: Vec<String>,
+}
+
+impl SkillsSpec {
+    pub fn is_empty(&self) -> bool {
+        self.load.is_empty() && self.available.is_empty()
+    }
+
+    pub fn all(&self) -> Vec<String> {
+        self.load
+            .iter()
+            .chain(self.available.iter())
+            .cloned()
+            .collect()
+    }
+}
+
 /// Errors from frontmatter parsing.
 #[derive(Debug, thiserror::Error)]
 pub enum FrontmatterError {
@@ -80,18 +105,30 @@ impl Frontmatter {
         })
     }
 
-    /// Read the `skills` list.
+    /// Read all referenced skills as a flat list (`load` followed by `available`).
     pub fn skills(&self) -> Vec<String> {
-        self.get("skills")
-            .and_then(Value::as_sequence)
-            .map(|skills| {
-                skills
-                    .iter()
-                    .filter_map(Value::as_str)
-                    .map(str::to_owned)
-                    .collect()
-            })
-            .unwrap_or_default()
+        self.skills_structured().all()
+    }
+
+    /// Read `skills` in structured load/available form.
+    pub fn skills_structured(&self) -> SkillsSpec {
+        match self.get("skills") {
+            Some(Value::Mapping(mapping)) => SkillsSpec {
+                load: mapping
+                    .get(yaml_key("load"))
+                    .map(yaml_str_list)
+                    .unwrap_or_default(),
+                available: mapping
+                    .get(yaml_key("available"))
+                    .map(yaml_str_list)
+                    .unwrap_or_default(),
+            },
+            Some(value) => SkillsSpec {
+                load: yaml_str_list(value),
+                available: Vec::new(),
+            },
+            None => SkillsSpec::default(),
+        }
     }
 
     /// Replace the `skills` list.
@@ -156,17 +193,9 @@ pub fn rewrite_skills(
     renames: &IndexMap<String, String>,
 ) -> IndexSet<String> {
     let mut renamed = IndexSet::new();
-    let mut skills = fm.skills();
-
-    for skill in &mut skills {
-        if let Some(new_name) = renames.get(skill.as_str()) {
-            renamed.insert(skill.clone());
-            *skill = new_name.clone();
-        }
-    }
-
-    if !renamed.is_empty() {
-        fm.set_skills(skills);
+    let key = yaml_key("skills");
+    if let Some(value) = fm.yaml.get_mut(&key) {
+        rewrite_skill_value(value, renames, &mut renamed);
     }
 
     renamed
@@ -183,6 +212,52 @@ pub fn rewrite_content_skills(
         Ok(None)
     } else {
         Ok(Some(fm.render()))
+    }
+}
+
+fn yaml_str_list(val: &Value) -> Vec<String> {
+    match val {
+        Value::Sequence(seq) => seq
+            .iter()
+            .filter_map(Value::as_str)
+            .map(str::to_owned)
+            .collect(),
+        Value::String(s) => vec![s.clone()],
+        _ => vec![],
+    }
+}
+
+fn rewrite_skill_value(
+    value: &mut Value,
+    renames: &IndexMap<String, String>,
+    renamed: &mut IndexSet<String>,
+) {
+    match value {
+        Value::Sequence(seq) => {
+            for item in seq {
+                let Some(skill) = item.as_str() else {
+                    continue;
+                };
+                if let Some(new_name) = renames.get(skill) {
+                    renamed.insert(skill.to_string());
+                    *item = Value::String(new_name.clone());
+                }
+            }
+        }
+        Value::String(skill) => {
+            if let Some(new_name) = renames.get(skill.as_str()) {
+                renamed.insert(skill.clone());
+                *skill = new_name.clone();
+            }
+        }
+        Value::Mapping(mapping) => {
+            for field in ["load", "available"] {
+                if let Some(child) = mapping.get_mut(yaml_key(field)) {
+                    rewrite_skill_value(child, renames, renamed);
+                }
+            }
+        }
+        _ => {}
     }
 }
 
@@ -255,6 +330,31 @@ mod tests {
         let input = "---\nskills: [plan, review]\n---\nbody";
         let fm = Frontmatter::parse(input).unwrap();
         assert_eq!(fm.skills(), vec!["plan", "review"]);
+        assert_eq!(fm.skills_structured().load, vec!["plan", "review"]);
+        assert!(fm.skills_structured().available.is_empty());
+    }
+
+    #[test]
+    fn parse_structured_skills() {
+        let input = "---\nskills:\n  load: [principles]\n  available:\n    - planning\n    - spawn\n---\nbody";
+        let fm = Frontmatter::parse(input).unwrap();
+        assert_eq!(fm.skills(), vec!["principles", "planning", "spawn"]);
+        assert_eq!(fm.skills_structured().load, vec!["principles"]);
+        assert_eq!(fm.skills_structured().available, vec!["planning", "spawn"]);
+    }
+
+    #[test]
+    fn rewrite_structured_skills_preserves_split() {
+        let input = "---\nskills:\n  load: [plan]\n  available: [review]\n---\nbody\n";
+        let renames = IndexMap::from([
+            ("plan".to_string(), "plan__org".to_string()),
+            ("review".to_string(), "review__org".to_string()),
+        ]);
+
+        let rewritten = rewrite_content_skills(input, &renames).unwrap().unwrap();
+        let fm = Frontmatter::parse(&rewritten).unwrap();
+        assert_eq!(fm.skills_structured().load, vec!["plan__org"]);
+        assert_eq!(fm.skills_structured().available, vec!["review__org"]);
     }
 
     #[test]

--- a/tests/agents_and_skills_cmd.rs
+++ b/tests/agents_and_skills_cmd.rs
@@ -250,8 +250,8 @@ fn skills_show_json_model_invocable_is_kebab_not_snake() {
     );
     assert_eq!(json["type"], "principle", "'type' field:\n{stdout}");
     assert!(
-        json["detail"].is_string(),
-        "'detail' field required:\n{stdout}"
+        json.get("detail").is_none(),
+        "'detail' field should not be emitted:\n{stdout}"
     );
 }
 

--- a/tests/agents_and_skills_cmd.rs
+++ b/tests/agents_and_skills_cmd.rs
@@ -39,13 +39,8 @@ model-invocable: false
 #[test]
 fn agents_list_json_envelope_and_fields() {
     let dir = TempDir::new().unwrap();
-    let project = setup_synced_project(
-        &dir,
-        "proj",
-        "src",
-        &[("orchestrator", AGENT_CONTENT)],
-        &[],
-    );
+    let project =
+        setup_synced_project(&dir, "proj", "src", &[("orchestrator", AGENT_CONTENT)], &[]);
 
     let output = mars()
         .args(["--json", "agents", "--root", project.to_str().unwrap()])
@@ -79,13 +74,8 @@ fn agents_list_json_envelope_and_fields() {
 #[test]
 fn agents_show_json_subagents_and_kebab_keys() {
     let dir = TempDir::new().unwrap();
-    let project = setup_synced_project(
-        &dir,
-        "proj",
-        "src",
-        &[("orchestrator", AGENT_CONTENT)],
-        &[],
-    );
+    let project =
+        setup_synced_project(&dir, "proj", "src", &[("orchestrator", AGENT_CONTENT)], &[]);
 
     let output = mars()
         .args([
@@ -109,7 +99,10 @@ fn agents_show_json_subagents_and_kebab_keys() {
         json["description"].is_string(),
         "'description' required:\n{stdout}"
     );
-    assert!(json["skills"].is_array(), "'skills' array required:\n{stdout}");
+    assert!(
+        json["skills"].is_array(),
+        "'skills' array required:\n{stdout}"
+    );
     assert!(
         json["subagents"].is_array(),
         "'subagents' array required:\n{stdout}"
@@ -139,13 +132,8 @@ fn agents_show_json_subagents_and_kebab_keys() {
 #[test]
 fn agents_show_not_found_exits_nonzero() {
     let dir = TempDir::new().unwrap();
-    let project = setup_synced_project(
-        &dir,
-        "proj",
-        "src",
-        &[("orchestrator", AGENT_CONTENT)],
-        &[],
-    );
+    let project =
+        setup_synced_project(&dir, "proj", "src", &[("orchestrator", AGENT_CONTENT)], &[]);
 
     let status = mars()
         .args([
@@ -173,13 +161,7 @@ fn skills_list_json_model_invocable_is_kebab_not_snake() {
     // Regression guard: list previously emitted `model_invocable` (snake) while
     // show emitted `model-invocable` (kebab). Both must be kebab.
     let dir = TempDir::new().unwrap();
-    let project = setup_synced_project(
-        &dir,
-        "proj",
-        "src",
-        &[],
-        &[("planning", SKILL_CONTENT)],
-    );
+    let project = setup_synced_project(&dir, "proj", "src", &[], &[("planning", SKILL_CONTENT)]);
 
     let output = mars()
         .args(["--json", "skills", "--root", project.to_str().unwrap()])
@@ -211,8 +193,7 @@ fn skills_list_json_model_invocable_is_kebab_not_snake() {
         "skills list MUST NOT emit 'model_invocable' (snake):\n{stdout}"
     );
     assert_eq!(
-        entry["model-invocable"],
-        false,
+        entry["model-invocable"], false,
         "'model-invocable' value for planning:\n{stdout}"
     );
 
@@ -226,13 +207,7 @@ fn skills_list_json_model_invocable_is_kebab_not_snake() {
 fn skills_show_json_model_invocable_is_kebab_not_snake() {
     // Mirror of the list test — both endpoints must agree on kebab-case.
     let dir = TempDir::new().unwrap();
-    let project = setup_synced_project(
-        &dir,
-        "proj",
-        "src",
-        &[],
-        &[("planning", SKILL_CONTENT)],
-    );
+    let project = setup_synced_project(&dir, "proj", "src", &[], &[("planning", SKILL_CONTENT)]);
 
     let output = mars()
         .args([
@@ -261,8 +236,7 @@ fn skills_show_json_model_invocable_is_kebab_not_snake() {
         "skills show MUST NOT emit 'model_invocable' (snake):\n{stdout}"
     );
     assert_eq!(
-        json["model-invocable"],
-        false,
+        json["model-invocable"], false,
         "'model-invocable' value:\n{stdout}"
     );
 
@@ -275,19 +249,16 @@ fn skills_show_json_model_invocable_is_kebab_not_snake() {
         "'allowed-tools' key required (kebab):\n{stdout}"
     );
     assert_eq!(json["type"], "principle", "'type' field:\n{stdout}");
-    assert!(json["detail"].is_string(), "'detail' field required:\n{stdout}");
+    assert!(
+        json["detail"].is_string(),
+        "'detail' field required:\n{stdout}"
+    );
 }
 
 #[test]
 fn skills_show_not_found_exits_nonzero() {
     let dir = TempDir::new().unwrap();
-    let project = setup_synced_project(
-        &dir,
-        "proj",
-        "src",
-        &[],
-        &[("planning", SKILL_CONTENT)],
-    );
+    let project = setup_synced_project(&dir, "proj", "src", &[], &[("planning", SKILL_CONTENT)]);
 
     let status = mars()
         .args([

--- a/tests/agents_and_skills_cmd.rs
+++ b/tests/agents_and_skills_cmd.rs
@@ -1,0 +1,309 @@
+//! Integration tests for `mars agents` and `mars skills` CLI commands.
+//!
+//! Pins the `--json` output contract:
+//!
+//! - List envelope shapes: `{"agents":[...]}` and `{"skills":[...]}`
+//! - Kebab-case `model-invocable` on both skills list and skills show.
+//!   Regression guard: list previously emitted `model_invocable` (snake)
+//!   while show emitted `model-invocable` (kebab).
+//! - `subagents` array present in agent show output
+//! - Not-found exits non-zero
+
+mod common;
+
+use assert_fs::TempDir;
+
+use common::*;
+
+const AGENT_CONTENT: &str = "---
+name: orchestrator
+description: Orchestrates work
+mode: primary
+subagents:
+  - worker
+---
+# Orchestrator
+";
+
+const SKILL_CONTENT: &str = "---
+name: planning
+description: Planning helper
+type: principle
+model-invocable: false
+---
+# Planning
+";
+
+// ── mars agents --json ────────────────────────────────────────────────────────
+
+#[test]
+fn agents_list_json_envelope_and_fields() {
+    let dir = TempDir::new().unwrap();
+    let project = setup_synced_project(
+        &dir,
+        "proj",
+        "src",
+        &[("orchestrator", AGENT_CONTENT)],
+        &[],
+    );
+
+    let output = mars()
+        .args(["--json", "agents", "--root", project.to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "mars agents should exit 0");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("mars agents --json must be valid JSON:\n{stdout}"));
+
+    let agents = json["agents"]
+        .as_array()
+        .unwrap_or_else(|| panic!("expected top-level 'agents' array in JSON:\n{stdout}"));
+    assert!(!agents.is_empty(), "expected at least one agent:\n{stdout}");
+
+    let entry = agents
+        .iter()
+        .find(|e| e["name"] == "orchestrator")
+        .unwrap_or_else(|| panic!("expected 'orchestrator' in agents list:\n{stdout}"));
+
+    assert!(entry["name"].is_string(), "'name' key required:\n{stdout}");
+    assert!(
+        entry["description"].is_string(),
+        "'description' key required:\n{stdout}"
+    );
+    assert!(entry["mode"].is_string(), "'mode' key required:\n{stdout}");
+    assert_eq!(entry["mode"], "primary", "'mode' value:\n{stdout}");
+}
+
+#[test]
+fn agents_show_json_subagents_and_kebab_keys() {
+    let dir = TempDir::new().unwrap();
+    let project = setup_synced_project(
+        &dir,
+        "proj",
+        "src",
+        &[("orchestrator", AGENT_CONTENT)],
+        &[],
+    );
+
+    let output = mars()
+        .args([
+            "--json",
+            "agents",
+            "show",
+            "orchestrator",
+            "--root",
+            project.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "mars agents show should exit 0");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("mars agents show --json must be valid JSON:\n{stdout}"));
+
+    assert_eq!(json["name"], "orchestrator", "'name' value:\n{stdout}");
+    assert!(
+        json["description"].is_string(),
+        "'description' required:\n{stdout}"
+    );
+    assert!(json["skills"].is_array(), "'skills' array required:\n{stdout}");
+    assert!(
+        json["subagents"].is_array(),
+        "'subagents' array required:\n{stdout}"
+    );
+    let subagents = json["subagents"].as_array().unwrap();
+    assert_eq!(
+        subagents,
+        &[serde_json::json!("worker")],
+        "'subagents' list:\n{stdout}"
+    );
+
+    // Kebab-case keys in the show envelope
+    assert!(
+        json.get("disallowed-tools").is_some(),
+        "'disallowed-tools' key required (kebab):\n{stdout}"
+    );
+    assert!(
+        json.get("tools-denied").is_some(),
+        "'tools-denied' key required (kebab):\n{stdout}"
+    );
+    assert!(
+        json.get("mcp-tools").is_some(),
+        "'mcp-tools' key required (kebab):\n{stdout}"
+    );
+}
+
+#[test]
+fn agents_show_not_found_exits_nonzero() {
+    let dir = TempDir::new().unwrap();
+    let project = setup_synced_project(
+        &dir,
+        "proj",
+        "src",
+        &[("orchestrator", AGENT_CONTENT)],
+        &[],
+    );
+
+    let status = mars()
+        .args([
+            "--json",
+            "agents",
+            "show",
+            "nonexistent",
+            "--root",
+            project.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap()
+        .status;
+
+    assert!(
+        !status.success(),
+        "agents show of missing agent must exit non-zero"
+    );
+}
+
+// ── mars skills --json ────────────────────────────────────────────────────────
+
+#[test]
+fn skills_list_json_model_invocable_is_kebab_not_snake() {
+    // Regression guard: list previously emitted `model_invocable` (snake) while
+    // show emitted `model-invocable` (kebab). Both must be kebab.
+    let dir = TempDir::new().unwrap();
+    let project = setup_synced_project(
+        &dir,
+        "proj",
+        "src",
+        &[],
+        &[("planning", SKILL_CONTENT)],
+    );
+
+    let output = mars()
+        .args(["--json", "skills", "--root", project.to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "mars skills should exit 0");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("mars skills --json must be valid JSON:\n{stdout}"));
+
+    let skills = json["skills"]
+        .as_array()
+        .unwrap_or_else(|| panic!("expected top-level 'skills' array:\n{stdout}"));
+    assert!(!skills.is_empty(), "expected at least one skill:\n{stdout}");
+
+    let entry = skills
+        .iter()
+        .find(|e| e["name"] == "planning")
+        .unwrap_or_else(|| panic!("'planning' skill not found in list:\n{stdout}"));
+
+    // The key contract: kebab-case, not snake_case.
+    assert!(
+        entry.get("model-invocable").is_some(),
+        "skills list MUST emit 'model-invocable' (kebab), not 'model_invocable' (snake):\n{stdout}"
+    );
+    assert!(
+        entry.get("model_invocable").is_none(),
+        "skills list MUST NOT emit 'model_invocable' (snake):\n{stdout}"
+    );
+    assert_eq!(
+        entry["model-invocable"],
+        false,
+        "'model-invocable' value for planning:\n{stdout}"
+    );
+
+    assert_eq!(
+        entry["type"], "principle",
+        "'type' field in skills list:\n{stdout}"
+    );
+}
+
+#[test]
+fn skills_show_json_model_invocable_is_kebab_not_snake() {
+    // Mirror of the list test — both endpoints must agree on kebab-case.
+    let dir = TempDir::new().unwrap();
+    let project = setup_synced_project(
+        &dir,
+        "proj",
+        "src",
+        &[],
+        &[("planning", SKILL_CONTENT)],
+    );
+
+    let output = mars()
+        .args([
+            "--json",
+            "skills",
+            "show",
+            "planning",
+            "--root",
+            project.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "mars skills show should exit 0");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("mars skills show --json must be valid JSON:\n{stdout}"));
+
+    // Kebab-case contract — the regression was snake vs kebab disagreement.
+    assert!(
+        json.get("model-invocable").is_some(),
+        "skills show MUST emit 'model-invocable' (kebab):\n{stdout}"
+    );
+    assert!(
+        json.get("model_invocable").is_none(),
+        "skills show MUST NOT emit 'model_invocable' (snake):\n{stdout}"
+    );
+    assert_eq!(
+        json["model-invocable"],
+        false,
+        "'model-invocable' value:\n{stdout}"
+    );
+
+    assert!(
+        json.get("user-invocable").is_some(),
+        "'user-invocable' key required (kebab):\n{stdout}"
+    );
+    assert!(
+        json.get("allowed-tools").is_some(),
+        "'allowed-tools' key required (kebab):\n{stdout}"
+    );
+    assert_eq!(json["type"], "principle", "'type' field:\n{stdout}");
+    assert!(json["detail"].is_string(), "'detail' field required:\n{stdout}");
+}
+
+#[test]
+fn skills_show_not_found_exits_nonzero() {
+    let dir = TempDir::new().unwrap();
+    let project = setup_synced_project(
+        &dir,
+        "proj",
+        "src",
+        &[],
+        &[("planning", SKILL_CONTENT)],
+    );
+
+    let status = mars()
+        .args([
+            "--json",
+            "skills",
+            "show",
+            "nonexistent",
+            "--root",
+            project.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap()
+        .status;
+
+    assert!(
+        !status.success(),
+        "skills show of missing skill must exit non-zero"
+    );
+}

--- a/tests/launch_bundle.rs
+++ b/tests/launch_bundle.rs
@@ -72,6 +72,11 @@ fn build_launch_bundle_includes_skill_documents_and_system_instruction() {
 }
 
 #[test]
+fn build_launch_bundle_splits_loaded_and_available_skills() {
+    prompt_surface::build_launch_bundle_splits_loaded_and_available_skills();
+}
+
+#[test]
 fn build_launch_bundle_uses_harness_variant_skill_for_codex() {
     prompt_surface::build_launch_bundle_uses_harness_variant_skill_for_codex();
 }
@@ -82,8 +87,8 @@ fn build_launch_bundle_uses_harness_override_skills_for_prompt_surface() {
 }
 
 #[test]
-fn build_launch_bundle_skips_model_non_invocable_skills() {
-    prompt_surface::build_launch_bundle_skips_model_non_invocable_skills();
+fn build_launch_bundle_loads_model_non_invocable_skills_when_explicit() {
+    prompt_surface::build_launch_bundle_loads_model_non_invocable_skills_when_explicit();
 }
 
 #[test]

--- a/tests/launch_bundle/cursor.rs
+++ b/tests/launch_bundle/cursor.rs
@@ -156,9 +156,10 @@ harness = "cursor""#;
         Some("experimental")
     );
     assert_eq!(
-        bundle["skills_metadata"]["loaded"],
-        serde_json::json!(["cursor_skill"])
+        bundle["skills"]["loaded"][0]["name"].as_str(),
+        Some("cursor_skill")
     );
+    assert_eq!(bundle["skills"]["available"], serde_json::json!([]));
     assert_eq!(bundle["tools"]["allowed"], serde_json::json!(["Bash"]));
     assert_eq!(
         bundle["tools"]["disallowed"],

--- a/tests/launch_bundle/execution_policy.rs
+++ b/tests/launch_bundle/execution_policy.rs
@@ -27,7 +27,7 @@ Review code changes."#;
         "--effort",
         "high",
         "--approval",
-        "yolo",
+        "never",
         "--sandbox",
         "danger-full-access",
     ]);
@@ -40,7 +40,7 @@ Review code changes."#;
     assert_eq!(bundle["routing"]["harness"].as_str(), Some("claude"));
     assert_eq!(
         bundle["execution_policy"]["approval"].as_str(),
-        Some("yolo")
+        Some("never")
     );
     assert_eq!(
         bundle["execution_policy"]["sandbox"].as_str(),
@@ -95,7 +95,7 @@ autocompact_pct = 55"#;
         "--agent",
         "reviewer",
         "--approval",
-        "yolo",
+        "never",
     ]);
     cmd.env("PATH", replace_path_with(&bin_dir));
 
@@ -106,7 +106,7 @@ autocompact_pct = 55"#;
     assert_eq!(bundle["execution_policy"]["effort"].as_str(), Some("high"));
     assert_eq!(
         bundle["execution_policy"]["approval"].as_str(),
-        Some("yolo"),
+        Some("never"),
         "CLI approval must beat harness override",
     );
     assert_eq!(

--- a/tests/launch_bundle/prompt_surface.rs
+++ b/tests/launch_bundle/prompt_surface.rs
@@ -44,10 +44,80 @@ Review code changes."#;
     assert!(system_instruction.contains("Use this skill to reason about steps."));
     assert!(system_instruction.contains("# Report"));
     assert_eq!(
-        bundle["skills_metadata"]["loaded"],
-        serde_json::json!(["planning"])
+        bundle["skills"]["loaded"][0]["name"].as_str(),
+        Some("planning")
     );
-    assert_eq!(bundle["skills_metadata"]["missing"], serde_json::json!([]));
+    assert_eq!(bundle["skills"]["available"], serde_json::json!([]));
+    assert_eq!(bundle["skills"]["missing"], serde_json::json!([]));
+}
+
+pub(crate) fn build_launch_bundle_splits_loaded_and_available_skills() {
+    let temp = TempDir::new().unwrap();
+    let agent_content = r#"---
+name: reviewer
+model: claude-opus-4-6
+skills:
+  load: [dev_principles]
+  available: [planning, workspace]
+---
+Review code changes."#;
+    let dev_principles = "---\nname: dev_principles\ndescription: Core principles\ntype: principle\n---\nAlways be precise.";
+    let planning = "---\nname: planning\ndescription: Use when decomposing phased work.\ntype: reference\n---\nPlanning body should stay out of prompt.";
+    let workspace = "---\nname: workspace\ndescription: Use when other agents may have changes.\ntype: guardrail\n---\nWorkspace body should stay out of prompt.";
+
+    let (server, project_root) = setup_bundle_project(
+        &temp,
+        "bundle-source",
+        agent_content,
+        &[
+            ("dev_principles", dev_principles),
+            ("planning", planning),
+            ("workspace", workspace),
+        ],
+        "",
+    );
+
+    let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
+    cmd.args(["build", "launch-bundle", "--agent", "reviewer"]);
+
+    let output = cmd.assert().success().get_output().clone();
+    let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    let loaded = bundle["skills"]["loaded"].as_array().unwrap();
+    assert_eq!(loaded.len(), 1);
+    assert_eq!(loaded[0]["name"].as_str(), Some("dev_principles"));
+    assert_eq!(loaded[0]["skill_type"].as_str(), Some("principle"));
+    assert!(
+        loaded[0]["content"]
+            .as_str()
+            .unwrap()
+            .contains("Always be precise.")
+    );
+
+    let available = bundle["skills"]["available"].as_array().unwrap();
+    assert_eq!(available.len(), 2);
+    assert_eq!(available[0]["name"].as_str(), Some("planning"));
+    assert_eq!(available[0]["skill_type"].as_str(), Some("reference"));
+    assert_eq!(
+        available[0]["description"].as_str(),
+        Some("Use when decomposing phased work.")
+    );
+    assert_eq!(available[1]["name"].as_str(), Some("workspace"));
+    assert_eq!(available[1]["skill_type"].as_str(), Some("guardrail"));
+    assert_eq!(bundle["skills"]["missing"], serde_json::json!([]));
+
+    let docs = bundle["prompt_surface"]["supplemental_documents"]
+        .as_array()
+        .expect("supplemental_documents should be an array");
+    assert_eq!(docs.len(), 1);
+    assert_eq!(docs[0]["name"].as_str(), Some("dev_principles"));
+
+    let system_instruction = bundle["prompt_surface"]["system_instruction"]
+        .as_str()
+        .expect("system instruction should be string");
+    assert!(system_instruction.contains("# Skill: dev_principles"));
+    assert!(!system_instruction.contains("Planning body should stay out of prompt."));
+    assert!(!system_instruction.contains("Workspace body should stay out of prompt."));
 }
 
 pub(crate) fn build_launch_bundle_uses_harness_variant_skill_for_codex() {
@@ -167,13 +237,16 @@ Review code changes."#;
     assert!(!system_instruction.contains("# Skill: planning"));
 
     assert_eq!(
-        bundle["skills_metadata"]["loaded"],
-        serde_json::json!(["codex_skill"])
+        bundle["skills"]["loaded"][0]["name"].as_str(),
+        Some("codex_skill")
     );
-    assert_eq!(bundle["skills_metadata"]["missing"], serde_json::json!([]));
+    assert_eq!(bundle["skills"]["available"], serde_json::json!([]));
+    assert_eq!(bundle["skills"]["missing"], serde_json::json!([]));
 }
 
-pub(crate) fn build_launch_bundle_skips_model_non_invocable_skills() {
+pub(crate) fn build_launch_bundle_loads_model_non_invocable_skills_when_explicit() {
+    // model-invocable gates global discovery, not explicit profile references.
+    // If the agent profile explicitly lists a skill, it loads regardless.
     let temp = TempDir::new().unwrap();
     let agent_content = r#"---
 name: reviewer
@@ -182,7 +255,7 @@ skills: [planning, hidden]
 ---
 Review code changes."#;
     let planning_skill = "---\nname: planning\ndescription: Plan tasks\ntype: reference\n---\nVisible skill content.";
-    let hidden_skill = "---\nname: hidden\ndescription: Hidden skill\nmodel-invocable: false\ntype: principle\n---\nShould not be present.";
+    let hidden_skill = "---\nname: hidden\ndescription: Hidden skill\nmodel-invocable: false\ntype: principle\n---\nExplicitly referenced content.";
 
     let (server, project_root) = setup_bundle_project(
         &temp,
@@ -201,19 +274,19 @@ Review code changes."#;
     let docs = bundle["prompt_surface"]["supplemental_documents"]
         .as_array()
         .expect("supplemental_documents should be an array");
-    assert_eq!(docs.len(), 1);
-    assert_eq!(docs[0]["name"].as_str(), Some("planning"));
+    assert_eq!(docs.len(), 2);
 
-    assert_eq!(
-        bundle["skills_metadata"]["loaded"],
-        serde_json::json!(["planning"])
-    );
-    assert_eq!(bundle["skills_metadata"]["missing"], serde_json::json!([]));
+    let loaded = bundle["skills"]["loaded"]
+        .as_array()
+        .expect("loaded should be an array");
+    assert_eq!(loaded.len(), 2);
+    assert_eq!(bundle["skills"]["available"], serde_json::json!([]));
+    assert_eq!(bundle["skills"]["missing"], serde_json::json!([]));
 
     let system_instruction = bundle["prompt_surface"]["system_instruction"]
         .as_str()
         .expect("system instruction should be string");
-    assert!(!system_instruction.contains("Should not be present."));
+    assert!(system_instruction.contains("Explicitly referenced content."));
 }
 
 pub(crate) fn build_launch_bundle_includes_inventory_prompt_before_report_block() {
@@ -428,12 +501,16 @@ Review code changes."#;
     let output = cmd.assert().success().get_output().clone();
     let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
 
+    let loaded_names = bundle["skills"]["loaded"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|skill| skill["name"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(loaded_names, vec!["planning", "extra_skill"]);
+    assert_eq!(bundle["skills"]["available"], serde_json::json!([]));
     assert_eq!(
-        bundle["skills_metadata"]["loaded"],
-        serde_json::json!(["planning", "extra_skill"])
-    );
-    assert_eq!(
-        bundle["skills_metadata"]["missing"],
+        bundle["skills"]["missing"],
         serde_json::json!(["missing_skill"])
     );
 

--- a/tests/launch_bundle/schema.rs
+++ b/tests/launch_bundle/schema.rs
@@ -56,7 +56,7 @@ Review code changes.
 
     let bundle: Value = serde_json::from_str(&stdout).expect("launch-bundle should emit JSON");
 
-    assert_eq!(bundle["version"].as_u64(), Some(2));
+    assert_eq!(bundle["version"].as_u64(), Some(3));
     assert_eq!(bundle["agent"].as_str(), Some("reviewer"));
     assert_eq!(
         bundle["agent_body"].as_str(),
@@ -130,7 +130,7 @@ Review code changes."#;
     let output = cmd.assert().success().get_output().clone();
     let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
 
-    assert_eq!(bundle["version"].as_u64(), Some(2));
+    assert_eq!(bundle["version"].as_u64(), Some(3));
     assert!(bundle["agent"].is_null());
     assert_field_absent_or_null(&bundle, "agent_body");
     assert_eq!(
@@ -141,10 +141,9 @@ Review code changes."#;
     assert_eq!(bundle["tools"]["allowed"], serde_json::json!([]));
     assert_eq!(bundle["tools"]["disallowed"], serde_json::json!([]));
     assert_eq!(bundle["tools"]["mcp"], serde_json::json!([]));
-    assert_eq!(
-        bundle["skills_metadata"]["loaded"],
-        serde_json::json!(Vec::<String>::new())
-    );
+    assert_eq!(bundle["skills"]["loaded"], serde_json::json!([]));
+    assert_eq!(bundle["skills"]["available"], serde_json::json!([]));
+    assert_eq!(bundle["skills"]["missing"], serde_json::json!([]));
     assert_eq!(
         bundle["prompt_surface"]["supplemental_documents"],
         serde_json::json!(Vec::<Value>::new())
@@ -230,11 +229,12 @@ Review code changes."#;
 
     assert!(bundle["agent"].is_null());
     assert_eq!(
-        bundle["skills_metadata"]["loaded"],
-        serde_json::json!(["planning"])
+        bundle["skills"]["loaded"][0]["name"].as_str(),
+        Some("planning")
     );
+    assert_eq!(bundle["skills"]["available"], serde_json::json!([]));
     assert_eq!(
-        bundle["skills_metadata"]["missing"],
+        bundle["skills"]["missing"],
         serde_json::json!(["missing_skill"])
     );
 

--- a/tests/sync_behavior.rs
+++ b/tests/sync_behavior.rs
@@ -588,7 +588,7 @@ description: |
   Explorer line two
 harness: codex
 model: gpt-5.3-codex
-approval: yolo
+approval: never
 sandbox: workspace-write
 tools: [Bash, Write, Edit]
 ---


### PR DESCRIPTION
## Summary

- **Skills bundle split** — agent profiles support structured `skills: {load: [...], available: [...]}` format. Flat `skills: [list]` backward compatible (all go to `load`). Launch bundle `skills_metadata` renamed to `skills` with structured objects:
  - `loaded[]`: name + skill_type + full body content
  - `available[]`: name + skill_type + description (routing one-liner)
  - `missing[]`: unchanged
- **`model-invocable` scoping change** — no longer gates explicit profile references; only controls global discovery (inventory prompt). If an agent lists a skill, it loads regardless.
- **`detail` field removed** from SkillProfile and SupplementalDoc (added and removed in same branch lifecycle)
- **Canonical approval mode `never`** — replaces `yolo` naming
- **`mars agents`/`mars skills` subcommands** — list installed agents and skills with metadata
- **LAUNCH_BUNDLE_VERSION bumped to 3**

## Compatibility

meridian-cli PR #292 adds v3 bundle parsing with backward compat (accepts both v2 and v3). These can merge independently — meridian-cli works with either mars version.

## Test plan

- [x] `cargo test` passes
- [x] Integration tested with meridian-cli: structured skills agent → bundle → adapter parses loaded + available correctly
- [x] Backward compat: flat `skills: [list]` still works (all go to `load`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)