### PR TITLE
feat: skills bundle split — loaded/available in launch bundle

### DIFF
--- a/src/build/AGENTS.md
+++ b/src/build/AGENTS.md
@@ -14,7 +14,7 @@ resolve_policy() → Routing + ExecutionPolicy + Provenance
     ↓
 resolve_effective_skills() + compile_prompt_surface() + resolve_bundle_tools()
     ↓
-LaunchBundle {routing, execution_policy, prompt_surface, tools, skills_metadata, provenance, warnings}
+LaunchBundle {routing, execution_policy, prompt_surface, tools, skills, provenance, warnings}
 ```
 
 ## Two Modes

--- a/src/build/bundle.rs
+++ b/src/build/bundle.rs
@@ -15,7 +15,7 @@ pub struct LaunchBundle {
     pub prompt_surface: PromptSurface,
     pub scaffold_slots: ScaffoldSlots,
     pub tools: ToolsSpec,
-    pub skills_metadata: SkillsMetadata,
+    pub skills: Skills,
     pub provenance: BTreeMap<String, String>,
     pub warnings: Vec<String>,
 }
@@ -92,7 +92,6 @@ pub struct SupplementalDoc {
     pub name: String,
     pub content: String,
     pub skill_type: String,
-    pub detail: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -103,7 +102,22 @@ pub struct ToolsSpec {
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct SkillsMetadata {
-    pub loaded: Vec<String>,
+pub struct Skills {
+    pub loaded: Vec<LoadedSkill>,
+    pub available: Vec<AvailableSkill>,
     pub missing: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LoadedSkill {
+    pub name: String,
+    pub skill_type: String,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AvailableSkill {
+    pub name: String,
+    pub skill_type: String,
+    pub description: String,
 }

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -5,7 +5,7 @@ pub mod tool_normalize;
 
 use std::path::PathBuf;
 
-use bundle::{LaunchBundle, ScaffoldSlots, SkillsMetadata, ToolsSpec};
+use bundle::{LaunchBundle, ScaffoldSlots, Skills, ToolsSpec};
 use policy::{PolicyInput, resolve_policy};
 use prompt::compile_prompt_surface;
 use tool_normalize::{ToolProjectionStatus, is_first_class_harness, normalize_tool_for_harness};
@@ -14,8 +14,9 @@ use crate::cli::MarsContext;
 use crate::compiler::agents::{AgentProfile, HarnessKind, parse_agent_content};
 use crate::config::EffectiveProjectConfig;
 use crate::error::{ConfigError, MarsError};
+use crate::frontmatter::SkillsSpec;
 
-pub const LAUNCH_BUNDLE_VERSION: u32 = 2;
+pub const LAUNCH_BUNDLE_VERSION: u32 = 3;
 
 pub struct LaunchBundleRequest {
     pub agent: Option<String>,
@@ -134,8 +135,9 @@ pub fn build_launch_bundle(
         },
         scaffold_slots: ScaffoldSlots::placeholders(),
         tools: resolved_tools,
-        skills_metadata: SkillsMetadata {
+        skills: Skills {
             loaded: prompt.loaded_skills,
+            available: prompt.available_skills,
             missing: prompt.missing_skills,
         },
         provenance: policy.provenance,
@@ -156,7 +158,7 @@ fn empty_agent_profile() -> AgentProfile {
         effort: None,
         autocompact: None,
         autocompact_pct: None,
-        skills: Vec::new(),
+        skills: SkillsSpec::default(),
         subagents: Vec::new(),
         tools: Vec::new(),
         tools_denied: Vec::new(),
@@ -260,9 +262,9 @@ enum ToolPolicyKind {
 fn resolve_effective_skills(
     profile: &crate::compiler::agents::AgentProfile,
     harness: &str,
-) -> Result<Vec<String>, MarsError> {
+) -> Result<SkillsSpec, MarsError> {
     let harness_kind = parse_harness_kind(harness)?;
-    Ok(profile.effective_skills(&harness_kind).to_vec())
+    Ok(profile.effective_skills(&harness_kind).clone())
 }
 
 fn parse_harness_kind(harness: &str) -> Result<HarnessKind, MarsError> {

--- a/src/build/policy/harness.rs
+++ b/src/build/policy/harness.rs
@@ -560,7 +560,7 @@ mod tests {
             effort: None,
             autocompact: None,
             autocompact_pct: None,
-            skills: Vec::new(),
+            skills: crate::frontmatter::SkillsSpec::default(),
             subagents: Vec::new(),
             tools: Vec::new(),
             tools_denied: Vec::new(),

--- a/src/build/policy/model.rs
+++ b/src/build/policy/model.rs
@@ -106,6 +106,7 @@ mod tests {
     use super::*;
 
     use crate::compiler::agents::{AgentProfile, HarnessOverrides};
+    use crate::frontmatter::SkillsSpec;
 
     fn empty_profile() -> AgentProfile {
         AgentProfile {
@@ -120,7 +121,7 @@ mod tests {
             effort: None,
             autocompact: None,
             autocompact_pct: None,
-            skills: Vec::new(),
+            skills: SkillsSpec::default(),
             subagents: Vec::new(),
             tools: Vec::new(),
             tools_denied: Vec::new(),

--- a/src/build/prompt.rs
+++ b/src/build/prompt.rs
@@ -1,12 +1,12 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-use crate::build::bundle::SupplementalDoc;
+use crate::build::bundle::{AvailableSkill, LoadedSkill, SupplementalDoc};
 use crate::compiler::agents::{AgentMode, ModelPolicyMatchType, parse_agent_content};
 use crate::compiler::skills::parse_skill_content;
 use crate::compiler::variants::harness_skill_variant_path;
 use crate::error::{ConfigError, MarsError};
-use crate::frontmatter::Frontmatter;
+use crate::frontmatter::{Frontmatter, SkillsSpec};
 
 const REPORT_INSTRUCTION: &str = "# Report\n\n**IMPORTANT - Your final assistant message must be the run report.**\n\nProvide a plain markdown report in your final assistant message.\n\nInclude: what was done, key decisions made, files created/modified, verification results, and any issues or blockers.";
 
@@ -14,7 +14,8 @@ pub struct PromptCompilation {
     pub system_instruction: String,
     pub supplemental_documents: Vec<SupplementalDoc>,
     pub inventory_prompt: String,
-    pub loaded_skills: Vec<String>,
+    pub loaded_skills: Vec<LoadedSkill>,
+    pub available_skills: Vec<AvailableSkill>,
     pub missing_skills: Vec<String>,
     pub warnings: Vec<String>,
 }
@@ -27,7 +28,12 @@ struct LoadedSkillDocument {
 enum SkillLoadOutcome {
     Loaded(SupplementalDoc),
     Missing,
-    SkippedModelInvocableFalse,
+}
+
+#[derive(Debug, Clone)]
+enum AvailableSkillOutcome {
+    Available(AvailableSkill),
+    Missing,
 }
 
 #[derive(Debug, Clone)]
@@ -43,7 +49,7 @@ struct ParsedAgentInventory {
 pub fn compile_prompt_surface(
     mars_dir: &Path,
     agent_body: &str,
-    profile_skills: &[String],
+    profile_skills: &SkillsSpec,
     extra_skills: &[String],
     harness_id: &str,
     selected_model_token: &str,
@@ -52,13 +58,17 @@ pub fn compile_prompt_surface(
 ) -> Result<PromptCompilation, MarsError> {
     let _ = (selected_model_token, canonical_model_id);
 
-    let requested_skills = requested_skill_order(profile_skills, extra_skills);
+    let requested_load_skills = requested_skill_order(&profile_skills.load, extra_skills);
+    let requested_available_skills = requested_available_skill_order(
+        &profile_skills.available,
+        requested_load_skills.iter().map(String::as_str),
+    );
 
     let mut loaded_documents = Vec::new();
     let mut missing_skills = Vec::new();
     let mut warnings = Vec::new();
 
-    for (requested_index, skill) in requested_skills.iter().enumerate() {
+    for (requested_index, skill) in requested_load_skills.iter().enumerate() {
         match load_skill_document(mars_dir, skill, harness_id) {
             Ok(SkillLoadOutcome::Loaded(document)) => {
                 loaded_documents.push(LoadedSkillDocument {
@@ -67,7 +77,7 @@ pub fn compile_prompt_surface(
                 });
             }
             Ok(SkillLoadOutcome::Missing) => missing_skills.push(skill.clone()),
-            Ok(SkillLoadOutcome::SkippedModelInvocableFalse) => {}
+
             Err(err) => {
                 warnings.push(err);
                 missing_skills.push(skill.clone());
@@ -94,8 +104,25 @@ pub fn compile_prompt_surface(
 
     let loaded_skills = loaded_documents
         .iter()
-        .map(|loaded| loaded.document.name.clone())
+        .map(|loaded| LoadedSkill {
+            name: loaded.document.name.clone(),
+            skill_type: loaded.document.skill_type.clone(),
+            content: loaded.document.content.clone(),
+        })
         .collect::<Vec<_>>();
+
+    let mut available_skills = Vec::new();
+    for skill in &requested_available_skills {
+        match resolve_available_skill(mars_dir, skill, harness_id) {
+            Ok(AvailableSkillOutcome::Available(skill)) => available_skills.push(skill),
+            Ok(AvailableSkillOutcome::Missing) => missing_skills.push(skill.clone()),
+
+            Err(err) => {
+                warnings.push(err);
+                missing_skills.push(skill.clone());
+            }
+        }
+    }
 
     let inventory_prompt = build_inventory_prompt(mars_dir, subagents_filter, &mut warnings)?;
     let system_instruction = compose_system_instruction(
@@ -110,6 +137,7 @@ pub fn compile_prompt_surface(
         supplemental_documents,
         inventory_prompt,
         loaded_skills,
+        available_skills,
         missing_skills,
         warnings,
     })
@@ -129,6 +157,29 @@ fn requested_skill_order(profile_skills: &[String], extra_skills: &[String]) -> 
         }
     }
 
+    ordered
+}
+
+fn requested_available_skill_order<'a>(
+    available_skills: &[String],
+    loaded_skills: impl Iterator<Item = &'a str>,
+) -> Vec<String> {
+    let mut blocked = loaded_skills
+        .map(|name| name.trim().to_string())
+        .collect::<HashSet<_>>();
+    blocked.remove("");
+
+    let mut seen = HashSet::new();
+    let mut ordered = Vec::new();
+    for name in available_skills {
+        let normalized = name.trim();
+        if normalized.is_empty() || blocked.contains(normalized) {
+            continue;
+        }
+        if seen.insert(normalized.to_string()) {
+            ordered.push(normalized.to_string());
+        }
+    }
     ordered
 }
 
@@ -152,10 +203,9 @@ fn load_skill_document(
         return Ok(SkillLoadOutcome::Missing);
     }
 
-    let (base_profile, base_frontmatter) = parse_skill_file(skill_name, &base_skill_path)?;
-    if !base_profile.model_invocable {
-        return Ok(SkillLoadOutcome::SkippedModelInvocableFalse);
-    }
+    // model-invocable gates global discovery, not explicit profile references.
+    // If the agent profile lists a skill, it loads regardless.
+    let (_base_profile, base_frontmatter) = parse_skill_file(skill_name, &base_skill_path)?;
 
     let selected_skill_path =
         harness_skill_variant_path(&skill_dir, harness_id).unwrap_or(base_skill_path);
@@ -172,7 +222,40 @@ fn load_skill_document(
         name: skill_name.to_string(),
         content,
         skill_type,
-        detail: base_profile.detail.clone().unwrap_or_default(),
+    }))
+}
+
+fn resolve_available_skill(
+    mars_dir: &Path,
+    skill_name: &str,
+    harness_id: &str,
+) -> Result<AvailableSkillOutcome, String> {
+    let skill_dir = mars_dir.join("skills").join(skill_name);
+    let base_skill_path = skill_dir.join("SKILL.md");
+    if !base_skill_path.is_file() {
+        return Ok(AvailableSkillOutcome::Missing);
+    }
+
+    // model-invocable gates global discovery, not explicit profile references.
+    let (base_profile, base_frontmatter) = parse_skill_file(skill_name, &base_skill_path)?;
+
+    let selected_skill_path =
+        harness_skill_variant_path(&skill_dir, harness_id).unwrap_or(base_skill_path);
+    let (selected_profile, selected_frontmatter) =
+        parse_skill_file(skill_name, &selected_skill_path)?;
+
+    let skill_type = skill_type_from_frontmatter(&selected_frontmatter)
+        .or_else(|| skill_type_from_frontmatter(&base_frontmatter))
+        .unwrap_or_else(|| "reference".to_string());
+    let description = selected_profile
+        .description
+        .or(base_profile.description)
+        .unwrap_or_default();
+
+    Ok(AvailableSkillOutcome::Available(AvailableSkill {
+        name: skill_name.to_string(),
+        skill_type,
+        description,
     }))
 }
 

--- a/src/cli/agents.rs
+++ b/src/cli/agents.rs
@@ -206,7 +206,8 @@ fn run_show(name: &str, ctx: &super::MarsContext, json: bool) -> Result<i32, Mar
                 "mode": mode_str,
                 "harness": harness_str,
                 "model": model_str,
-                "skills": profile.skills,
+                "skills": profile.skills.all(),
+                "skills_structured": profile.skills,
                 "subagents": profile.subagents,
                 "approval": approval_str,
                 "sandbox": sandbox_str,
@@ -225,7 +226,8 @@ fn run_show(name: &str, ctx: &super::MarsContext, json: bool) -> Result<i32, Mar
             println!("approval:    {approval_str}");
             println!("sandbox:     {sandbox_str}");
             println!("effort:      {effort_str}");
-            print_str_list("skills", &profile.skills);
+            print_str_list("skills.load", &profile.skills.load);
+            print_str_list("skills.available", &profile.skills.available);
             print_str_list("subagents", &profile.subagents);
             print_str_list("tools", &profile.tools);
             print_str_list("disallowed-tools", &profile.disallowed_tools);

--- a/src/cli/skills.rs
+++ b/src/cli/skills.rs
@@ -188,14 +188,12 @@ fn run_show(name: &str, ctx: &super::MarsContext, json: bool) -> Result<i32, Mar
         }
 
         let description_str = profile.description.as_deref().unwrap_or("");
-        let detail_str = profile.detail.as_deref().unwrap_or("");
         let type_str = profile.skill_type.as_deref().unwrap_or("");
 
         if json {
             output::print_json(&serde_json::json!({
                 "name": skill_name,
                 "description": description_str,
-                "detail": detail_str,
                 "type": type_str,
                 "model-invocable": profile.model_invocable,
                 "user-invocable": profile.user_invocable,
@@ -204,7 +202,6 @@ fn run_show(name: &str, ctx: &super::MarsContext, json: bool) -> Result<i32, Mar
         } else {
             println!("name:          {skill_name}");
             println!("description:   {description_str}");
-            println!("detail:        {detail_str}");
             println!("type:          {type_str}");
             println!("model-invocable: {}", profile.model_invocable);
             println!("user-invocable:  {}", profile.user_invocable);

--- a/src/compiler/agents/lower.rs
+++ b/src/compiler/agents/lower.rs
@@ -83,8 +83,8 @@ impl<'a> Effective<'a> {
             .or(self.profile.sandbox.as_ref())
     }
 
-    fn skills(&self) -> &[String] {
-        self.profile.effective_skills(self.harness)
+    fn skills(&self) -> Vec<String> {
+        self.profile.effective_skills(self.harness).all()
     }
 
     fn tools(&self) -> &[String] {

--- a/src/compiler/agents/mod.rs
+++ b/src/compiler/agents/mod.rs
@@ -10,7 +10,7 @@ pub mod lower;
 use serde_yaml::Value;
 
 pub use crate::config::{ModelPolicyMatchType, ModelPolicyRule};
-use crate::frontmatter::{Frontmatter, FrontmatterError};
+use crate::frontmatter::{Frontmatter, FrontmatterError, SkillsSpec};
 
 // ---------------------------------------------------------------------------
 // Field enums
@@ -202,7 +202,7 @@ pub struct OverrideFields {
     pub autocompact_pct: Option<u8>,
     pub approval: Option<ApprovalMode>,
     pub sandbox: Option<SandboxMode>,
-    pub skills: Option<Vec<String>>,
+    pub skills: Option<SkillsSpec>,
     pub tools: Option<Vec<String>>,
     pub tools_denied: Option<Vec<String>>,
     pub disallowed_tools: Option<Vec<String>>,
@@ -273,7 +273,7 @@ pub struct AgentProfile {
     pub autocompact_pct: Option<u8>,
 
     // --- Tool fields ---
-    pub skills: Vec<String>,
+    pub skills: SkillsSpec,
     pub subagents: Vec<String>,
     pub tools: Vec<String>,
     pub tools_denied: Vec<String>,
@@ -295,7 +295,7 @@ pub struct EffectiveToolPolicy {
 }
 
 impl AgentProfile {
-    pub fn effective_skills(&self, harness: &HarnessKind) -> &[String] {
+    pub fn effective_skills(&self, harness: &HarnessKind) -> &SkillsSpec {
         self.harness_overrides
             .get(harness)
             .and_then(|entry| entry.skills.as_ref())
@@ -431,6 +431,25 @@ fn yaml_str_list(val: &Value) -> Vec<String> {
             .collect(),
         Value::String(s) => vec![s.clone()],
         _ => vec![],
+    }
+}
+
+fn parse_skills_spec(val: &Value) -> SkillsSpec {
+    match val {
+        Value::Mapping(mapping) => SkillsSpec {
+            load: mapping
+                .get(Value::String("load".to_string()))
+                .map(yaml_str_list)
+                .unwrap_or_default(),
+            available: mapping
+                .get(Value::String("available".to_string()))
+                .map(yaml_str_list)
+                .unwrap_or_default(),
+        },
+        _ => SkillsSpec {
+            load: yaml_str_list(val),
+            available: Vec::new(),
+        },
     }
 }
 
@@ -774,7 +793,7 @@ fn parse_override_fields(
                 }
             }
             "skills" => {
-                out.skills = Some(yaml_str_list(v));
+                out.skills = Some(parse_skills_spec(v));
             }
             "tools" => {
                 let parsed = parse_tools_field(&format!("{table_name}.tools"), v, diags);
@@ -1116,7 +1135,7 @@ pub fn parse_agent_profile(fm: &Frontmatter, diags: &mut Vec<AgentDiagnostic>) -
     };
 
     // skills/subagents/tools/disallowed-tools/mcp-tools:
-    let skills = fm.skills();
+    let skills = fm.skills_structured();
     let subagents = fm.get("subagents").map(yaml_str_list).unwrap_or_default();
     let parsed_tools = fm
         .get("tools")

--- a/src/compiler/agents/tests.rs
+++ b/src/compiler/agents/tests.rs
@@ -232,7 +232,8 @@ fn parses_skills_tools_disallowed_mcp() {
     let content = "---\nskills: [review, dev-principles]\ntools: [Bash, Write]\ndisallowed-tools: [Agent]\nmcp-tools: [server]\n---\n";
     let (p, diags) = parse(content);
     assert!(diags.is_empty());
-    assert_eq!(p.skills, vec!["review", "dev-principles"]);
+    assert_eq!(p.skills.load, vec!["review", "dev-principles"]);
+    assert!(p.skills.available.is_empty());
     assert_eq!(p.tools, vec!["Bash", "Write"]);
     assert!(p.tools_denied.is_empty());
     assert_eq!(p.disallowed_tools, vec!["Agent"]);
@@ -274,13 +275,26 @@ fn effective_skills_use_harness_override_replacement() {
     assert!(diags.is_empty());
 
     assert_eq!(
-        p.effective_skills(&HarnessKind::Codex),
-        &vec!["codex-only".to_string()]
+        p.effective_skills(&HarnessKind::Codex).load,
+        vec!["codex-only".to_string()]
     );
     assert_eq!(
-        p.effective_skills(&HarnessKind::Claude),
-        &vec!["base".to_string()]
+        p.effective_skills(&HarnessKind::Claude).load,
+        vec!["base".to_string()]
     );
+}
+
+#[test]
+fn parses_structured_skills_and_override() {
+    let content = "---\nskills:\n  load: [dev-principles]\n  available: [planning, spawn]\nharness-overrides:\n  codex:\n    skills:\n      load: [codex-principles]\n      available: [codex-planning]\n---\n";
+    let (p, diags) = parse(content);
+    assert!(diags.is_empty());
+
+    assert_eq!(p.skills.load, vec!["dev-principles"]);
+    assert_eq!(p.skills.available, vec!["planning", "spawn"]);
+    let codex = p.effective_skills(&HarnessKind::Codex);
+    assert_eq!(codex.load, vec!["codex-principles"]);
+    assert_eq!(codex.available, vec!["codex-planning"]);
 }
 
 #[test]

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -628,7 +628,7 @@ mod skill_surface_tests {
             effort: None,
             autocompact: None,
             autocompact_pct: None,
-            skills: Vec::new(),
+            skills: crate::frontmatter::SkillsSpec::default(),
             subagents: Vec::new(),
             tools: Vec::new(),
             tools_denied: Vec::new(),

--- a/src/compiler/skills/mod.rs
+++ b/src/compiler/skills/mod.rs
@@ -10,7 +10,6 @@ use crate::frontmatter::{Frontmatter, FrontmatterError};
 pub struct SkillProfile {
     pub name: Option<String>,
     pub description: Option<String>,
-    pub detail: Option<String>,
     pub skill_type: Option<String>,
     pub model_invocable: bool,
     pub user_invocable: bool,
@@ -174,17 +173,6 @@ pub fn parse_skill_profile(fm: &Frontmatter, diags: &mut Vec<SkillDiagnostic>) -
             allowed: "string",
         });
     }
-    let detail_raw = fm.get("detail");
-    let detail = detail_raw.and_then(Value::as_str).map(str::to_owned);
-    if let Some(raw) = detail_raw
-        && !raw.is_string()
-    {
-        diags.push(SkillDiagnostic::InvalidFieldType {
-            field: "detail".to_string(),
-            value: value_label(raw),
-            allowed: "string",
-        });
-    }
     let skill_type_raw = fm.get("type");
     let skill_type = skill_type_raw.and_then(Value::as_str).map(str::to_owned);
     if let Some(raw) = skill_type_raw
@@ -218,7 +206,6 @@ pub fn parse_skill_profile(fm: &Frontmatter, diags: &mut Vec<SkillDiagnostic>) -
     SkillProfile {
         name,
         description,
-        detail,
         skill_type,
         model_invocable,
         user_invocable,
@@ -442,32 +429,17 @@ body",
     }
 
     #[test]
-    fn detail_and_type_parse_from_frontmatter() {
-        let (p, d, _) = parse(
-            "---\nname: a\ndescription: b\ndetail: Long description here\ntype: guardrail\n---\nbody",
-        );
+    fn type_parses_from_frontmatter() {
+        let (p, d, _) = parse("---\nname: a\ndescription: b\ntype: guardrail\n---\nbody");
         assert!(d.is_empty());
-        assert_eq!(p.detail.as_deref(), Some("Long description here"));
         assert_eq!(p.skill_type.as_deref(), Some("guardrail"));
     }
 
     #[test]
-    fn detail_and_type_absent_gives_none() {
+    fn type_absent_gives_none() {
         let (p, d, _) = parse("---\nname: a\ndescription: b\n---\nbody");
         assert!(d.is_empty());
-        assert!(p.detail.is_none());
         assert!(p.skill_type.is_none());
-    }
-
-    #[test]
-    fn non_string_detail_emits_diagnostic() {
-        let (p, d, _) = parse("---\nname: a\ndescription: b\ndetail: 42\n---\nbody");
-        assert!(p.detail.is_none());
-        assert!(d.iter().any(|diag| matches!(
-            diag,
-            SkillDiagnostic::InvalidFieldType { field, allowed, .. }
-                if field == "detail" && *allowed == "string"
-        )));
     }
 
     #[test]

--- a/src/frontmatter/mod.rs
+++ b/src/frontmatter/mod.rs
@@ -9,6 +9,31 @@ pub struct Frontmatter {
     has_frontmatter: bool,
 }
 
+/// Structured agent skill references.
+///
+/// A flat `skills: [a, b]` list is represented as all `load` entries for
+/// backward compatibility. A structured `skills: { load: [...], available: [...] }`
+/// keeps the two launch-bundle channels separate.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
+pub struct SkillsSpec {
+    pub load: Vec<String>,
+    pub available: Vec<String>,
+}
+
+impl SkillsSpec {
+    pub fn is_empty(&self) -> bool {
+        self.load.is_empty() && self.available.is_empty()
+    }
+
+    pub fn all(&self) -> Vec<String> {
+        self.load
+            .iter()
+            .chain(self.available.iter())
+            .cloned()
+            .collect()
+    }
+}
+
 /// Errors from frontmatter parsing.
 #[derive(Debug, thiserror::Error)]
 pub enum FrontmatterError {
@@ -80,18 +105,30 @@ impl Frontmatter {
         })
     }
 
-    /// Read the `skills` list.
+    /// Read all referenced skills as a flat list (`load` followed by `available`).
     pub fn skills(&self) -> Vec<String> {
-        self.get("skills")
-            .and_then(Value::as_sequence)
-            .map(|skills| {
-                skills
-                    .iter()
-                    .filter_map(Value::as_str)
-                    .map(str::to_owned)
-                    .collect()
-            })
-            .unwrap_or_default()
+        self.skills_structured().all()
+    }
+
+    /// Read `skills` in structured load/available form.
+    pub fn skills_structured(&self) -> SkillsSpec {
+        match self.get("skills") {
+            Some(Value::Mapping(mapping)) => SkillsSpec {
+                load: mapping
+                    .get(yaml_key("load"))
+                    .map(yaml_str_list)
+                    .unwrap_or_default(),
+                available: mapping
+                    .get(yaml_key("available"))
+                    .map(yaml_str_list)
+                    .unwrap_or_default(),
+            },
+            Some(value) => SkillsSpec {
+                load: yaml_str_list(value),
+                available: Vec::new(),
+            },
+            None => SkillsSpec::default(),
+        }
     }
 
     /// Replace the `skills` list.
@@ -156,17 +193,9 @@ pub fn rewrite_skills(
     renames: &IndexMap<String, String>,
 ) -> IndexSet<String> {
     let mut renamed = IndexSet::new();
-    let mut skills = fm.skills();
-
-    for skill in &mut skills {
-        if let Some(new_name) = renames.get(skill.as_str()) {
-            renamed.insert(skill.clone());
-            *skill = new_name.clone();
-        }
-    }
-
-    if !renamed.is_empty() {
-        fm.set_skills(skills);
+    let key = yaml_key("skills");
+    if let Some(value) = fm.yaml.get_mut(&key) {
+        rewrite_skill_value(value, renames, &mut renamed);
     }
 
     renamed
@@ -183,6 +212,52 @@ pub fn rewrite_content_skills(
         Ok(None)
     } else {
         Ok(Some(fm.render()))
+    }
+}
+
+fn yaml_str_list(val: &Value) -> Vec<String> {
+    match val {
+        Value::Sequence(seq) => seq
+            .iter()
+            .filter_map(Value::as_str)
+            .map(str::to_owned)
+            .collect(),
+        Value::String(s) => vec![s.clone()],
+        _ => vec![],
+    }
+}
+
+fn rewrite_skill_value(
+    value: &mut Value,
+    renames: &IndexMap<String, String>,
+    renamed: &mut IndexSet<String>,
+) {
+    match value {
+        Value::Sequence(seq) => {
+            for item in seq {
+                let Some(skill) = item.as_str() else {
+                    continue;
+                };
+                if let Some(new_name) = renames.get(skill) {
+                    renamed.insert(skill.to_string());
+                    *item = Value::String(new_name.clone());
+                }
+            }
+        }
+        Value::String(skill) => {
+            if let Some(new_name) = renames.get(skill.as_str()) {
+                renamed.insert(skill.clone());
+                *skill = new_name.clone();
+            }
+        }
+        Value::Mapping(mapping) => {
+            for field in ["load", "available"] {
+                if let Some(child) = mapping.get_mut(yaml_key(field)) {
+                    rewrite_skill_value(child, renames, renamed);
+                }
+            }
+        }
+        _ => {}
     }
 }
 
@@ -255,6 +330,31 @@ mod tests {
         let input = "---\nskills: [plan, review]\n---\nbody";
         let fm = Frontmatter::parse(input).unwrap();
         assert_eq!(fm.skills(), vec!["plan", "review"]);
+        assert_eq!(fm.skills_structured().load, vec!["plan", "review"]);
+        assert!(fm.skills_structured().available.is_empty());
+    }
+
+    #[test]
+    fn parse_structured_skills() {
+        let input = "---\nskills:\n  load: [principles]\n  available:\n    - planning\n    - spawn\n---\nbody";
+        let fm = Frontmatter::parse(input).unwrap();
+        assert_eq!(fm.skills(), vec!["principles", "planning", "spawn"]);
+        assert_eq!(fm.skills_structured().load, vec!["principles"]);
+        assert_eq!(fm.skills_structured().available, vec!["planning", "spawn"]);
+    }
+
+    #[test]
+    fn rewrite_structured_skills_preserves_split() {
+        let input = "---\nskills:\n  load: [plan]\n  available: [review]\n---\nbody\n";
+        let renames = IndexMap::from([
+            ("plan".to_string(), "plan__org".to_string()),
+            ("review".to_string(), "review__org".to_string()),
+        ]);
+
+        let rewritten = rewrite_content_skills(input, &renames).unwrap().unwrap();
+        let fm = Frontmatter::parse(&rewritten).unwrap();
+        assert_eq!(fm.skills_structured().load, vec!["plan__org"]);
+        assert_eq!(fm.skills_structured().available, vec!["review__org"]);
     }
 
     #[test]

--- a/tests/agents_and_skills_cmd.rs
+++ b/tests/agents_and_skills_cmd.rs
@@ -250,8 +250,8 @@ fn skills_show_json_model_invocable_is_kebab_not_snake() {
     );
     assert_eq!(json["type"], "principle", "'type' field:\n{stdout}");
     assert!(
-        json["detail"].is_string(),
-        "'detail' field required:\n{stdout}"
+        json.get("detail").is_none(),
+        "'detail' field should not be emitted:\n{stdout}"
     );
 }
 

--- a/tests/launch_bundle.rs
+++ b/tests/launch_bundle.rs
@@ -72,6 +72,11 @@ fn build_launch_bundle_includes_skill_documents_and_system_instruction() {
 }
 
 #[test]
+fn build_launch_bundle_splits_loaded_and_available_skills() {
+    prompt_surface::build_launch_bundle_splits_loaded_and_available_skills();
+}
+
+#[test]
 fn build_launch_bundle_uses_harness_variant_skill_for_codex() {
     prompt_surface::build_launch_bundle_uses_harness_variant_skill_for_codex();
 }
@@ -82,8 +87,8 @@ fn build_launch_bundle_uses_harness_override_skills_for_prompt_surface() {
 }
 
 #[test]
-fn build_launch_bundle_skips_model_non_invocable_skills() {
-    prompt_surface::build_launch_bundle_skips_model_non_invocable_skills();
+fn build_launch_bundle_loads_model_non_invocable_skills_when_explicit() {
+    prompt_surface::build_launch_bundle_loads_model_non_invocable_skills_when_explicit();
 }
 
 #[test]

--- a/tests/launch_bundle/cursor.rs
+++ b/tests/launch_bundle/cursor.rs
@@ -156,9 +156,10 @@ harness = "cursor""#;
         Some("experimental")
     );
     assert_eq!(
-        bundle["skills_metadata"]["loaded"],
-        serde_json::json!(["cursor_skill"])
+        bundle["skills"]["loaded"][0]["name"].as_str(),
+        Some("cursor_skill")
     );
+    assert_eq!(bundle["skills"]["available"], serde_json::json!([]));
     assert_eq!(bundle["tools"]["allowed"], serde_json::json!(["Bash"]));
     assert_eq!(
         bundle["tools"]["disallowed"],

--- a/tests/launch_bundle/prompt_surface.rs
+++ b/tests/launch_bundle/prompt_surface.rs
@@ -44,10 +44,80 @@ Review code changes."#;
     assert!(system_instruction.contains("Use this skill to reason about steps."));
     assert!(system_instruction.contains("# Report"));
     assert_eq!(
-        bundle["skills_metadata"]["loaded"],
-        serde_json::json!(["planning"])
+        bundle["skills"]["loaded"][0]["name"].as_str(),
+        Some("planning")
     );
-    assert_eq!(bundle["skills_metadata"]["missing"], serde_json::json!([]));
+    assert_eq!(bundle["skills"]["available"], serde_json::json!([]));
+    assert_eq!(bundle["skills"]["missing"], serde_json::json!([]));
+}
+
+pub(crate) fn build_launch_bundle_splits_loaded_and_available_skills() {
+    let temp = TempDir::new().unwrap();
+    let agent_content = r#"---
+name: reviewer
+model: claude-opus-4-6
+skills:
+  load: [dev_principles]
+  available: [planning, workspace]
+---
+Review code changes."#;
+    let dev_principles = "---\nname: dev_principles\ndescription: Core principles\ntype: principle\n---\nAlways be precise.";
+    let planning = "---\nname: planning\ndescription: Use when decomposing phased work.\ntype: reference\n---\nPlanning body should stay out of prompt.";
+    let workspace = "---\nname: workspace\ndescription: Use when other agents may have changes.\ntype: guardrail\n---\nWorkspace body should stay out of prompt.";
+
+    let (server, project_root) = setup_bundle_project(
+        &temp,
+        "bundle-source",
+        agent_content,
+        &[
+            ("dev_principles", dev_principles),
+            ("planning", planning),
+            ("workspace", workspace),
+        ],
+        "",
+    );
+
+    let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
+    cmd.args(["build", "launch-bundle", "--agent", "reviewer"]);
+
+    let output = cmd.assert().success().get_output().clone();
+    let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    let loaded = bundle["skills"]["loaded"].as_array().unwrap();
+    assert_eq!(loaded.len(), 1);
+    assert_eq!(loaded[0]["name"].as_str(), Some("dev_principles"));
+    assert_eq!(loaded[0]["skill_type"].as_str(), Some("principle"));
+    assert!(
+        loaded[0]["content"]
+            .as_str()
+            .unwrap()
+            .contains("Always be precise.")
+    );
+
+    let available = bundle["skills"]["available"].as_array().unwrap();
+    assert_eq!(available.len(), 2);
+    assert_eq!(available[0]["name"].as_str(), Some("planning"));
+    assert_eq!(available[0]["skill_type"].as_str(), Some("reference"));
+    assert_eq!(
+        available[0]["description"].as_str(),
+        Some("Use when decomposing phased work.")
+    );
+    assert_eq!(available[1]["name"].as_str(), Some("workspace"));
+    assert_eq!(available[1]["skill_type"].as_str(), Some("guardrail"));
+    assert_eq!(bundle["skills"]["missing"], serde_json::json!([]));
+
+    let docs = bundle["prompt_surface"]["supplemental_documents"]
+        .as_array()
+        .expect("supplemental_documents should be an array");
+    assert_eq!(docs.len(), 1);
+    assert_eq!(docs[0]["name"].as_str(), Some("dev_principles"));
+
+    let system_instruction = bundle["prompt_surface"]["system_instruction"]
+        .as_str()
+        .expect("system instruction should be string");
+    assert!(system_instruction.contains("# Skill: dev_principles"));
+    assert!(!system_instruction.contains("Planning body should stay out of prompt."));
+    assert!(!system_instruction.contains("Workspace body should stay out of prompt."));
 }
 
 pub(crate) fn build_launch_bundle_uses_harness_variant_skill_for_codex() {
@@ -167,13 +237,16 @@ Review code changes."#;
     assert!(!system_instruction.contains("# Skill: planning"));
 
     assert_eq!(
-        bundle["skills_metadata"]["loaded"],
-        serde_json::json!(["codex_skill"])
+        bundle["skills"]["loaded"][0]["name"].as_str(),
+        Some("codex_skill")
     );
-    assert_eq!(bundle["skills_metadata"]["missing"], serde_json::json!([]));
+    assert_eq!(bundle["skills"]["available"], serde_json::json!([]));
+    assert_eq!(bundle["skills"]["missing"], serde_json::json!([]));
 }
 
-pub(crate) fn build_launch_bundle_skips_model_non_invocable_skills() {
+pub(crate) fn build_launch_bundle_loads_model_non_invocable_skills_when_explicit() {
+    // model-invocable gates global discovery, not explicit profile references.
+    // If the agent profile explicitly lists a skill, it loads regardless.
     let temp = TempDir::new().unwrap();
     let agent_content = r#"---
 name: reviewer
@@ -182,7 +255,7 @@ skills: [planning, hidden]
 ---
 Review code changes."#;
     let planning_skill = "---\nname: planning\ndescription: Plan tasks\ntype: reference\n---\nVisible skill content.";
-    let hidden_skill = "---\nname: hidden\ndescription: Hidden skill\nmodel-invocable: false\ntype: principle\n---\nShould not be present.";
+    let hidden_skill = "---\nname: hidden\ndescription: Hidden skill\nmodel-invocable: false\ntype: principle\n---\nExplicitly referenced content.";
 
     let (server, project_root) = setup_bundle_project(
         &temp,
@@ -201,19 +274,19 @@ Review code changes."#;
     let docs = bundle["prompt_surface"]["supplemental_documents"]
         .as_array()
         .expect("supplemental_documents should be an array");
-    assert_eq!(docs.len(), 1);
-    assert_eq!(docs[0]["name"].as_str(), Some("planning"));
+    assert_eq!(docs.len(), 2);
 
-    assert_eq!(
-        bundle["skills_metadata"]["loaded"],
-        serde_json::json!(["planning"])
-    );
-    assert_eq!(bundle["skills_metadata"]["missing"], serde_json::json!([]));
+    let loaded = bundle["skills"]["loaded"]
+        .as_array()
+        .expect("loaded should be an array");
+    assert_eq!(loaded.len(), 2);
+    assert_eq!(bundle["skills"]["available"], serde_json::json!([]));
+    assert_eq!(bundle["skills"]["missing"], serde_json::json!([]));
 
     let system_instruction = bundle["prompt_surface"]["system_instruction"]
         .as_str()
         .expect("system instruction should be string");
-    assert!(!system_instruction.contains("Should not be present."));
+    assert!(system_instruction.contains("Explicitly referenced content."));
 }
 
 pub(crate) fn build_launch_bundle_includes_inventory_prompt_before_report_block() {
@@ -428,12 +501,16 @@ Review code changes."#;
     let output = cmd.assert().success().get_output().clone();
     let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
 
+    let loaded_names = bundle["skills"]["loaded"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|skill| skill["name"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(loaded_names, vec!["planning", "extra_skill"]);
+    assert_eq!(bundle["skills"]["available"], serde_json::json!([]));
     assert_eq!(
-        bundle["skills_metadata"]["loaded"],
-        serde_json::json!(["planning", "extra_skill"])
-    );
-    assert_eq!(
-        bundle["skills_metadata"]["missing"],
+        bundle["skills"]["missing"],
         serde_json::json!(["missing_skill"])
     );
 

--- a/tests/launch_bundle/schema.rs
+++ b/tests/launch_bundle/schema.rs
@@ -56,7 +56,7 @@ Review code changes.
 
     let bundle: Value = serde_json::from_str(&stdout).expect("launch-bundle should emit JSON");
 
-    assert_eq!(bundle["version"].as_u64(), Some(2));
+    assert_eq!(bundle["version"].as_u64(), Some(3));
     assert_eq!(bundle["agent"].as_str(), Some("reviewer"));
     assert_eq!(
         bundle["agent_body"].as_str(),
@@ -130,7 +130,7 @@ Review code changes."#;
     let output = cmd.assert().success().get_output().clone();
     let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
 
-    assert_eq!(bundle["version"].as_u64(), Some(2));
+    assert_eq!(bundle["version"].as_u64(), Some(3));
     assert!(bundle["agent"].is_null());
     assert_field_absent_or_null(&bundle, "agent_body");
     assert_eq!(
@@ -141,10 +141,9 @@ Review code changes."#;
     assert_eq!(bundle["tools"]["allowed"], serde_json::json!([]));
     assert_eq!(bundle["tools"]["disallowed"], serde_json::json!([]));
     assert_eq!(bundle["tools"]["mcp"], serde_json::json!([]));
-    assert_eq!(
-        bundle["skills_metadata"]["loaded"],
-        serde_json::json!(Vec::<String>::new())
-    );
+    assert_eq!(bundle["skills"]["loaded"], serde_json::json!([]));
+    assert_eq!(bundle["skills"]["available"], serde_json::json!([]));
+    assert_eq!(bundle["skills"]["missing"], serde_json::json!([]));
     assert_eq!(
         bundle["prompt_surface"]["supplemental_documents"],
         serde_json::json!(Vec::<Value>::new())
@@ -230,11 +229,12 @@ Review code changes."#;
 
     assert!(bundle["agent"].is_null());
     assert_eq!(
-        bundle["skills_metadata"]["loaded"],
-        serde_json::json!(["planning"])
+        bundle["skills"]["loaded"][0]["name"].as_str(),
+        Some("planning")
     );
+    assert_eq!(bundle["skills"]["available"], serde_json::json!([]));
     assert_eq!(
-        bundle["skills_metadata"]["missing"],
+        bundle["skills"]["missing"],
         serde_json::json!(["missing_skill"])
     );
 


### PR DESCRIPTION
## Why

Agent profiles can only declare skills as a flat list — all skills get full body content injected, wasting context on reference skills that only need a routing description. No way to distinguish "load this fully" from "make this discoverable."

## Goal

Agent authors can explicitly separate skills into `load` (full body injected) and `available` (name + description for routing). Launch bundle emits structured metadata so consumers can render each category appropriately.

## Summary

- Structured skills format: `skills: {load: [...], available: [...]}`
- Flat `skills: [list]` backward compatible (all go to `load`)
- `skills_metadata` renamed to `skills` in launch bundle output
- `loaded[]`: name + skill_type + full content; `available[]`: name + skill_type + description
- `model-invocable` scoped to global discovery only — explicit profile refs always load
- `detail` field removed from SkillProfile and SupplementalDoc
- `LAUNCH_BUNDLE_VERSION` bumped to 3

## Work Item

progressive-loading

## Changes

- `src/frontmatter/mod.rs` — `SkillsSpec` parser for structured format with flat-list fallback
- `src/build/prompt.rs` — separate compilation paths for load vs available skills
- `src/build/bundle.rs` — `Skills` struct replaces `SkillsMetadata`, new `LoadedSkill`/`AvailableSkill` types
- `model-invocable: false` no longer prevents loading when explicitly listed in a profile
- Tests updated for new schema shape

## Verification

- `cargo test` — 1274+ tests pass, 0 failures
- Integration tested end-to-end with meridian-cli (PR #292 adds v3 adapter)
- Backward compat: flat `skills: [list]` produces same behavior as before

## Knowledge Updates

- `src/build/AGENTS.md` updated
- No KB changes needed (mars-agents has no KB context)

## Spawn Trace

- p3190 product-lead (c3141) — designed skills bundle split
- p12 tech-lead (c3141) — implemented in mars-agents

## Release Label Guide

Set one `release:*` label on this PR:

- `release:patch` or `release:stable` — create the next stable patch release after merge
- `release:skip` — no release for this merge

## Cleanup

After merge, clean merged worktrees with:

```bash
scripts/prune-worktrees.sh
```