### PR TITLE
docs: enforce PR template and release label requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,11 +221,9 @@ Integration tests under `tests/`. Prefer keeping changes localized to one module
 
 ## Pull Requests
 
-When creating or updating a GitHub PR, follow `.github/PULL_REQUEST_TEMPLATE.md`.
-Fill every section with the current branch state: why, goal, summary, work item,
-changes, verification, knowledge updates, spawn trace, release label guidance,
-post-merge automation, and cleanup. Keep the PR body current as the branch
-evolves; update it when verification, knowledge capture, risks, or scope changes.
+When creating or updating a GitHub PR, read `.github/PULL_REQUEST_TEMPLATE.md` and fill every section. Do not use any other PR body format. Sections: why, goal, summary, work item, changes, verification, knowledge updates, spawn trace, release label, cleanup. Keep the PR body current as the branch evolves.
+
+**Always set a `release:*` label before merging.** No label = no release. Forgetting the label means the work ships to main without a version bump — consumers won't get it until the next labeled PR triggers a release.
 
 ## Releasing
 


### PR DESCRIPTION
## Why

PR #83 merged without a release label, leaving the skills bundle split unreleased on main. Agents consistently skip the project PR template in favor of their built-in generic format because the AGENTS.md instruction wasn't emphatic enough.

## Goal

AGENTS.md explicitly states: use the template, no other format, always label before merge.

## Summary

Strengthened Pull Requests section — explicitly forbids other formats, adds bold warning that missing labels mean no version bump reaches consumers.

## Work Item

N/A — process fix

## Changes

- `AGENTS.md` Pull Requests section rewritten to be unambiguous

## Verification

- Docs-only change, no code impact
- `cargo test` passes (1274+ tests)

## Knowledge Updates

- AGENTS.md is the knowledge update

## Spawn Trace

- Direct edit (product-lead, c3153)

## Release Label Guide

Label this PR `release:patch` to trigger a stable release that includes the skills bundle split from #83.