### PR TITLE
feat: prompt composition redesign + frontmatter passthrough

### DIFF
--- a/docs/config/agent-profiles.md
+++ b/docs/config/agent-profiles.md
@@ -274,6 +274,24 @@ skills: [dev-principles, shared-workspace]
 
 ---
 
+### `subagents`
+
+| | |
+|---|---|
+| Type | string[] |
+| Required | no |
+| Default | empty |
+
+The agents this agent is allowed to spawn. `subagents` is a first-class parsed field: mars preserves it in the `.mars/` canonical artifact and uses it during prompt assembly to filter the spawnable-agent **inventory** injected into the system prompt — only listed agents are advertised as spawn options. Meridian reads the same list at spawn time to scope the agent's spawnable roster.
+
+Like `model-policies` and `fanout`, `subagents` is Meridian-oriented metadata — preserved in `.mars/` for runtime consumers, with no harness-native field equivalent.
+
+```yaml
+subagents: [explorer, reviewer, coder]
+```
+
+---
+
 ### `tools`
 
 | | |

--- a/docs/config/skill-compilation.md
+++ b/docs/config/skill-compilation.md
@@ -44,6 +44,36 @@ One-line summary. Shown in `mars list` and passed through to native artifacts.
 
 ---
 
+### `type`
+
+| | |
+|---|---|
+| Type | string (free-form) |
+| Required | no |
+| Default | `reference` |
+
+Classifies the skill for prompt-assembly ordering and `mars skills` filtering. `type` is **not** a restricted enum — any string is accepted and preserved.
+
+Mars uses it for exactly two things:
+
+1. **Sort priority during prompt assembly.** Loaded skills are ordered by tier so higher-priority guidance lands first:
+
+   | `type` | Priority |
+   |---|---|
+   | `principle` | 0 (first) |
+   | `guardrail` | 1 |
+   | `reference`, any other value, or unset | 2 (last) |
+
+2. **Filtering.** `mars skills list --type <value>` matches `type` by exact string.
+
+A skill with no `type` defaults to `reference`. Custom values (e.g. `type: workflow`) are accepted, sort at priority 2, and stay filterable by their exact string — but they gain no behavior beyond `reference`.
+
+```yaml
+type: principle
+```
+
+---
+
 ### `model-invocable`
 
 | | |
@@ -122,6 +152,24 @@ metadata:
 ```
 
 ---
+
+## Unknown Fields
+
+Skill frontmatter fields not listed above are **passed through** to all native targets unchanged. Mars preserves unrecognized fields verbatim during lowering — harness-specific fields like Claude Code's `argument-hint` and `arguments` survive compilation and reach the target artifact.
+
+This means you can add harness-native fields directly to your skill frontmatter and they will appear in the compiled output for every target. Mars does not validate or interpret them — it copies the YAML value as-is.
+
+```yaml
+---
+name: my-skill
+description: Does a thing
+argument-hint: "What should I review?"
+arguments:
+  - name: target
+    description: File or directory to review
+    required: true
+---
+```
 
 ## Per-Harness Lowering
 

--- a/src/build/prompt.rs
+++ b/src/build/prompt.rs
@@ -128,6 +128,7 @@ pub fn compile_prompt_surface(
     let system_instruction = compose_system_instruction(
         agent_body,
         &supplemental_documents,
+        &available_skills,
         &inventory_prompt,
         REPORT_INSTRUCTION,
     );
@@ -308,6 +309,7 @@ fn render_skill_content_block(skill_name: &str, body: &str) -> String {
 fn compose_system_instruction(
     agent_body: &str,
     supplemental_documents: &[SupplementalDoc],
+    available_skills: &[AvailableSkill],
     inventory_prompt: &str,
     report_instruction: &str,
 ) -> String {
@@ -318,11 +320,57 @@ fn compose_system_instruction(
         blocks.push(format!("# Agent Profile\n\n{body}"));
     }
 
+    // Auto-loaded skills: full content, already sorted by type priority
+    // (principles first, then guardrails, then others).
+    // Each skill has its own `# Skill: name` heading — no intermediate
+    // wrapper headings that would break markdown hierarchy.
     for doc in supplemental_documents {
         let content = doc.content.trim();
         if !content.is_empty() {
             blocks.push(content.to_string());
         }
+    }
+
+    // Available skills: names only, grouped by type.
+    // NOTE: meridian-cli recomposes this block independently in
+    // `composition.py::_render_available_skills_block`. Keep format in sync.
+    if !available_skills.is_empty() {
+        let mut avail_block =
+            String::from("# Available Skills\n\nLoad these when needed.");
+        for (type_label, type_key) in &[
+            ("Principles", "principle"),
+            ("Guardrails", "guardrail"),
+            ("Mode-shift", "mode-shift"),
+            ("Checkpoint", "checkpoint"),
+        ] {
+            let skills: Vec<_> = available_skills
+                .iter()
+                .filter(|s| s.skill_type == *type_key)
+                .collect();
+            if !skills.is_empty() {
+                avail_block.push_str(&format!("\n\n## {type_label}"));
+                for skill in skills {
+                    avail_block.push_str(&format!("\n- {}", skill.name));
+                }
+            }
+        }
+        // Remaining (reference and unknown types)
+        let other_skills: Vec<_> = available_skills
+            .iter()
+            .filter(|s| {
+                s.skill_type != "principle"
+                    && s.skill_type != "guardrail"
+                    && s.skill_type != "mode-shift"
+                    && s.skill_type != "checkpoint"
+            })
+            .collect();
+        if !other_skills.is_empty() {
+            avail_block.push_str("\n");
+            for skill in other_skills {
+                avail_block.push_str(&format!("\n- {}", skill.name));
+            }
+        }
+        blocks.push(avail_block);
     }
 
     let inventory = inventory_prompt.trim();
@@ -331,16 +379,6 @@ fn compose_system_instruction(
     }
 
     blocks.push(report_instruction.to_string());
-
-    for doc in supplemental_documents
-        .iter()
-        .filter(|doc| doc.skill_type == "principle")
-    {
-        let content = doc.content.trim();
-        if !content.is_empty() {
-            blocks.push(content.to_string());
-        }
-    }
 
     blocks.join("\n\n")
 }

--- a/src/build/prompt.rs
+++ b/src/build/prompt.rs
@@ -364,7 +364,7 @@ fn compose_system_instruction(
             })
             .collect();
         if !other_skills.is_empty() {
-            avail_block.push_str("\n");
+            avail_block.push('\n');
             for skill in other_skills {
                 avail_block.push_str(&format!("\n- {}", skill.name));
             }

--- a/src/build/prompt.rs
+++ b/src/build/prompt.rs
@@ -335,8 +335,7 @@ fn compose_system_instruction(
     // NOTE: meridian-cli recomposes this block independently in
     // `composition.py::_render_available_skills_block`. Keep format in sync.
     if !available_skills.is_empty() {
-        let mut avail_block =
-            String::from("# Available Skills\n\nLoad these when needed.");
+        let mut avail_block = String::from("# Available Skills\n\nLoad these when needed.");
         for (type_label, type_key) in &[
             ("Principles", "principle"),
             ("Guardrails", "guardrail"),

--- a/src/compiler/skills/lower.rs
+++ b/src/compiler/skills/lower.rs
@@ -67,6 +67,12 @@ fn insert_metadata(yaml: &mut Mapping, profile: &SkillProfile) {
     }
 }
 
+fn insert_passthrough(yaml: &mut Mapping, profile: &SkillProfile) {
+    for (key, value) in &profile.passthrough_fields {
+        yaml.insert(yk(key), value.clone());
+    }
+}
+
 fn user_invocation_disabled(profile: &SkillProfile) -> bool {
     let _was_explicitly_set = profile.had_user_invocable_field;
     !profile.user_invocable
@@ -115,6 +121,7 @@ pub fn lower_skill_to_claude(profile: &SkillProfile, body: &str) -> LoweredOutpu
     }
     insert_allowed_tools(&mut yaml, profile);
     insert_metadata(&mut yaml, profile);
+    insert_passthrough(&mut yaml, profile);
     LoweredOutput {
         bytes: render(yaml, body),
         lossy_fields: vec![],
@@ -131,6 +138,7 @@ pub fn lower_skill_to_codex(profile: &SkillProfile, body: &str) -> LoweredOutput
         );
     }
     insert_metadata(&mut yaml, profile);
+    insert_passthrough(&mut yaml, profile);
     let mut lossy_fields = Vec::new();
     if !profile.allowed_tools.is_empty() {
         lossy_fields.push(dropped("allowed-tools", SkillHarness::Codex));
@@ -148,6 +156,7 @@ pub fn lower_skill_to_opencode(profile: &SkillProfile, body: &str) -> LoweredOut
     let mut yaml = Mapping::new();
     insert_identity(&mut yaml, profile);
     insert_metadata(&mut yaml, profile);
+    insert_passthrough(&mut yaml, profile);
     let mut lossy_fields = Vec::new();
     if !profile.model_invocable {
         lossy_fields.push(dropped("model-invocable", SkillHarness::OpenCode));
@@ -172,6 +181,7 @@ pub fn lower_skill_to_pi(profile: &SkillProfile, body: &str) -> LoweredOutput {
     }
     insert_allowed_tools(&mut yaml, profile);
     insert_metadata(&mut yaml, profile);
+    insert_passthrough(&mut yaml, profile);
     let mut lossy_fields = Vec::new();
     if user_invocation_disabled(profile) {
         lossy_fields.push(dropped("user-invocable", SkillHarness::Pi));
@@ -189,6 +199,7 @@ pub fn lower_skill_to_cursor(profile: &SkillProfile, body: &str) -> LoweredOutpu
         yaml.insert(yk("disable-model-invocation"), Value::Bool(true));
     }
     insert_metadata(&mut yaml, profile);
+    insert_passthrough(&mut yaml, profile);
     let mut lossy_fields = Vec::new();
     if !profile.allowed_tools.is_empty() {
         lossy_fields.push(dropped("allowed-tools", SkillHarness::Cursor));
@@ -261,7 +272,8 @@ mod tests {
         assert!(!out.contains("allow_implicit_invocation"));
         assert!(out.contains("license: MIT"));
         assert!(out.contains("owner: team"));
-        assert!(!out.contains("extra:"));
+        // Unknown fields pass through to all targets
+        assert!(out.contains("extra: stripped"));
         assert!(lowered.lossy_fields.is_empty());
     }
 

--- a/src/compiler/skills/mod.rs
+++ b/src/compiler/skills/mod.rs
@@ -21,6 +21,8 @@ pub struct SkillProfile {
     /// true when the source frontmatter explicitly set `user-invocable`
     pub had_user_invocable_field: bool,
     pub has_frontmatter: bool,
+    /// Frontmatter fields not recognized by mars — passed through to all targets.
+    pub passthrough_fields: Vec<(String, Value)>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -150,18 +152,26 @@ fn parse_invocability_bool(
 }
 
 pub fn parse_skill_profile(fm: &Frontmatter, diags: &mut Vec<SkillDiagnostic>) -> SkillProfile {
+    // Track which keys we consume so passthrough = all keys minus consumed.
+    // This avoids a static list that drifts when new fields are added.
+    let mut consumed_keys: Vec<&str> = Vec::new();
+
+    consumed_keys.push("name");
     let name_raw = fm.get("name");
     let name = name_raw.and_then(Value::as_str).map(str::to_owned);
+    consumed_keys.push("description");
     let description_raw = fm.get("description");
     let description = description_raw.and_then(Value::as_str).map(str::to_owned);
     if fm.has_frontmatter() {
         validate_required_string("name", name_raw, diags);
         validate_required_string("description", description_raw, diags);
     }
+    consumed_keys.push("allowed-tools");
     let allowed_tools = fm
         .get("allowed-tools")
         .map(|v| yaml_str_list("allowed-tools", v, diags))
         .unwrap_or_default();
+    consumed_keys.push("license");
     let license_raw = fm.get("license");
     let license = license_raw.and_then(Value::as_str).map(str::to_owned);
     if let Some(raw) = license_raw
@@ -173,6 +183,7 @@ pub fn parse_skill_profile(fm: &Frontmatter, diags: &mut Vec<SkillDiagnostic>) -
             allowed: "string",
         });
     }
+    consumed_keys.push("type");
     let skill_type_raw = fm.get("type");
     let skill_type = skill_type_raw.and_then(Value::as_str).map(str::to_owned);
     if let Some(raw) = skill_type_raw
@@ -184,10 +195,13 @@ pub fn parse_skill_profile(fm: &Frontmatter, diags: &mut Vec<SkillDiagnostic>) -
             allowed: "string",
         });
     }
+    consumed_keys.push("metadata");
     let metadata = fm.get("metadata").cloned();
 
+    consumed_keys.push("model-invocable");
     let (model_invocable, had_model_invocable_field) =
         parse_invocability_bool("model-invocable", fm.get("model-invocable"), diags);
+    consumed_keys.push("user-invocable");
     let (user_invocable, had_user_invocable_field) =
         parse_invocability_bool("user-invocable", fm.get("user-invocable"), diags);
 
@@ -196,12 +210,21 @@ pub fn parse_skill_profile(fm: &Frontmatter, diags: &mut Vec<SkillDiagnostic>) -
         "disable-model-invocation",
         "allow_implicit_invocation",
     ] {
+        consumed_keys.push(field);
         if fm.get(field).is_some() {
             diags.push(SkillDiagnostic::RemovedField {
                 field: field.to_string(),
             });
         }
     }
+
+    // Passthrough = all frontmatter keys we didn't consume above.
+    let passthrough_fields = fm
+        .keys()
+        .into_iter()
+        .filter(|k| !consumed_keys.contains(&k.as_str()))
+        .filter_map(|k| fm.get(&k).map(|v| (k.clone(), v.clone())))
+        .collect::<Vec<_>>();
 
     SkillProfile {
         name,
@@ -215,6 +238,7 @@ pub fn parse_skill_profile(fm: &Frontmatter, diags: &mut Vec<SkillDiagnostic>) -
         had_model_invocable_field,
         had_user_invocable_field,
         has_frontmatter: fm.has_frontmatter(),
+        passthrough_fields,
     }
 }
 

--- a/src/frontmatter/mod.rs
+++ b/src/frontmatter/mod.rs
@@ -163,6 +163,14 @@ impl Frontmatter {
         self.has_frontmatter
     }
 
+    /// All frontmatter keys as strings.
+    pub fn keys(&self) -> Vec<String> {
+        self.yaml
+            .keys()
+            .filter_map(|k| k.as_str().map(str::to_owned))
+            .collect()
+    }
+
     /// Serialize back to full markdown.
     pub fn render(&self) -> String {
         if !self.has_frontmatter && self.yaml.is_empty() {

--- a/tests/launch_bundle/prompt_surface.rs
+++ b/tests/launch_bundle/prompt_surface.rs
@@ -395,19 +395,33 @@ Review code changes."#;
     let system_instruction = bundle["prompt_surface"]["system_instruction"]
         .as_str()
         .expect("system instruction should be string");
-    let first_principle_index = system_instruction
+
+    // Skills are sorted by type priority (principle first, then guardrail, then reference)
+    // but without wrapper headings — each skill keeps its own `# Skill:` heading.
+    let principle_index = system_instruction
         .find("# Skill: principle_a")
         .expect("system instruction should include principle skill");
+    let guardrail_index = system_instruction
+        .find("# Skill: guardrail_a")
+        .expect("system instruction should include guardrail skill");
+    let reference_a_index = system_instruction
+        .find("# Skill: reference_a")
+        .expect("system instruction should include reference skill");
     let report_index = system_instruction
         .find("# Report")
         .expect("system instruction should include report block");
-    assert!(first_principle_index < report_index);
 
-    let second_principle_relative = system_instruction[(report_index + "# Report".len())..]
-        .find("# Skill: principle_a")
-        .expect("system instruction should include trailing principle bookend");
-    let second_principle_index = report_index + "# Report".len() + second_principle_relative;
-    assert!(second_principle_index > report_index);
+    // Order: principle -> guardrail -> reference -> report
+    assert!(principle_index < guardrail_index);
+    assert!(guardrail_index < reference_a_index);
+    assert!(reference_a_index < report_index);
+
+    // No principle bookend after report
+    let after_report = &system_instruction[(report_index + "# Report".len())..];
+    assert!(
+        !after_report.contains("Principle body."),
+        "principle bookend should no longer appear after report"
+    );
 }
 
 pub(crate) fn build_launch_bundle_inventory_hides_model_non_invocable_agents_and_shows_fanout() {
@@ -571,9 +585,7 @@ Review code changes."#;
         "# Report\n\n",
         "**IMPORTANT - Your final assistant message must be the run report.**\n\n",
         "Provide a plain markdown report in your final assistant message.\n\n",
-        "Include: what was done, key decisions made, files created/modified, verification results, and any issues or blockers.\n\n",
-        "# Skill: principle_a\n\n",
-        "Principle body."
+        "Include: what was done, key decisions made, files created/modified, verification results, and any issues or blockers."
     );
     assert_eq!(system_instruction, expected);
 }


### PR DESCRIPTION
## Why

The current prompt composition duplicates principles at the end (bookend pattern) wasting context, doesn't surface available skills in the system prompt, and silently drops harness-specific frontmatter fields like `argument-hint` and `arguments`.

## Goal

Clean prompt composition with proper skill ordering, available skill discovery, and lossless frontmatter passthrough.

## Summary

- **Remove principle bookend**: principles no longer duplicated after the report instruction
- **Available skills listing**: `compose_system_instruction` now renders available skills (names grouped by type) between loaded skills and inventory
- **Frontmatter passthrough**: unknown fields survive lowering to all 5 harness targets (Claude, Codex, OpenCode, Pi, Cursor)
- **Consumed-keys pattern**: `parse_skill_profile` tracks consumed keys dynamically instead of a static `known_fields` list that drifts
- **Docs**: documented `type` field sort semantics, `subagents` field, and corrected "Unknown Fields" section (was claiming fields are dropped; they're now passed through)

## Resulting behavior

- Skills are sorted by type priority (principle → guardrail → reference) without wrapper headings
- Available skills appear as a name-only listing grouped by type
- `argument-hint`, `arguments`, or any other unknown frontmatter field now appears in compiled skill output
- Adding a new recognized field to `parse_skill_profile` automatically excludes it from passthrough (no list to forget)

## Verification

- `cargo test` — all 1274 tests pass
- `cargo clippy` — clean
- `cargo fmt` — clean
- Updated `prompt_surface.rs` tests assert new ordering and absence of bookend

## Release label

`release:patch`

## Cleanup

None needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)