### PR TITLE
Document selective native agent copies

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -122,7 +122,7 @@ mars sync [--force] [--diff] [--frozen]
 | `--diff` | Dry run: show what would change without applying |
 | `--frozen` | Error if lock file would change (CI mode) |
 
-This is the core operation. It runs the full [sync pipeline](../internals/sync-pipeline.md): resolve → target → diff → apply.
+This is the core operation. It runs the full [sync pipeline](../internals/sync-pipeline.md): resolve → target → diff → apply. Native agent materialization follows `settings.agent_emission`; `[settings.agent_copy]` can selectively emit qualifying harness-native agent copies even when emission is otherwise suppressed.
 
 ---
 
@@ -297,7 +297,7 @@ mars link <target> [--force]
 - Adds `<target>` as a managed target directory and copies content from `.mars/` into it
 - Persists the target in `mars.toml [settings] targets` and updates `mars.lock` with per-target output records
 - If a path in the target exists on disk but is not tracked for that `target_root`, Mars preserves it and emits `target-unmanaged-collision` (exit 2). Run `mars link <target> --force` to adopt and record ownership (`target-unmanaged-adopted`)
-- Materialization depends on target and `agent_emission` (e.g. `.cursor` receives skills/MCP, not native agent files)
+- Materialization depends on target, `agent_emission`, and optional `[settings.agent_copy]` (e.g. `.cursor` receives skills/MCP unless native agent emission or selective copy applies)
 
 ```bash
 mars link .claude            # Copy managed content into .claude/

--- a/docs/config/agent-compilation.md
+++ b/docs/config/agent-compilation.md
@@ -1,12 +1,12 @@
 # Agent Compilation
 
-During `mars sync`, agents are compiled to two surfaces: a canonical full-fidelity artifact in `.mars/agents/`, and — when the agent declares `harness:` — a native artifact in the corresponding harness directory (`.claude/agents/`, `.codex/agents/`, etc.).
+During `mars sync`, every agent is compiled to a canonical full-fidelity artifact in `.mars/agents/`. Native harness artifacts (`.claude/agents/`, `.codex/agents/`, etc.) are emitted when native agent emission policy allows them: normally for agents that declare `harness:`, or selectively through `[settings.agent_copy]`.
 
 ## The Two Surfaces
 
 Every agent produces a `.mars/agents/<name>.md` artifact regardless of whether `harness:` is set. This is the canonical compiled output: all frontmatter fields preserved, body unchanged. Meridian reads from here at spawn time.
 
-When `harness:` is set, a second artifact is emitted in the harness-native directory:
+When native emission selects an agent for a harness, a second artifact is emitted in the harness-native directory:
 
 | `harness:` value | Native artifact |
 |---|---|
@@ -18,7 +18,7 @@ When `harness:` is set, a second artifact is emitted in the harness-native direc
 
 Harness-native artifacts are format-translated and field-stripped. They serve as agent discovery surfaces for harness-native invocation (e.g. `codex --agent coder`). Meridian always uses the `.mars/` artifact for its own spawn logic and applies all policy fields through its own projection layer.
 
-Universal agents (no `harness:`) are installed to `.mars/agents/` only and can be launched by Meridian against any harness.
+Universal agents (no `harness:`) are installed to `.mars/agents/` only by default and can be launched by Meridian against any harness. `[settings.agent_copy]` can still create a native copy when the agent qualifies through its `model:` alias or, with `include_fanout = true`, its `model-policies`.
 
 ## Emission Control
 
@@ -35,9 +35,29 @@ Native artifact emission is controlled by `settings.agent_emission` in `mars.tom
 agent_emission = "always"
 ```
 
-**`MERIDIAN_MANAGED=1`** — when Meridian invokes mars, it sets this env var. Under `auto`, native artifacts are suppressed: Meridian manages harness-native agent loading itself and doesn't want mars-compiled artifacts competing with its runtime projection. Set `agent_emission = "always"` to override this.
+**`MERIDIAN_MANAGED=1`** — when Meridian invokes mars, it sets this env var. Under `auto`, native artifacts are suppressed: Meridian manages delegation through `.mars/agents/` and `meridian spawn`, and does not want harness-native artifacts competing with that routing. Set `agent_emission = "always"` to emit all native artifacts.
 
-When emission is disabled (via `never` or `MERIDIAN_MANAGED=1` with `auto`), mars removes any previously-emitted native artifacts for harness-bound agents currently in `.mars/agents/`.
+Use `[settings.agent_copy]` for a selective override under managed mode or `agent_emission = "never"`:
+
+```toml
+[settings]
+targets = [".claude"]
+agent_emission = "never"  # optional
+
+[settings.agent_copy]
+harnesses = ["claude"]
+include_fanout = false
+```
+
+Each harness in `harnesses` must also have an effective managed target (from
+`settings.targets`, or legacy `managed_root` when `targets` is unset). Mars
+then emits only agents that qualify for that harness: profiles with a
+matching `harness:`, profiles whose `model:` alias resolves to that harness,
+and, when `include_fanout = true`, matching `model-policies`. This is the
+intentional path for Claude-native `Agent()` copies while Meridian still owns
+normal delegation through `.mars/agents/`.
+
+When a native artifact is not emitted because emission is disabled or selective copy does not qualify it, mars removes the previously-emitted native artifact for agents currently in `.mars/agents/`.
 
 This cleanup only removes the native artifact for the agent's current `harness:` value. If an agent previously targeted a different harness, the old native artifact may remain stale; run `mars sync` after changing an agent's harness to clean up the previous target.
 

--- a/docs/config/mars-toml.md
+++ b/docs/config/mars-toml.md
@@ -40,7 +40,7 @@ For keyed overlay tables:
 
 Present only in source packages — repos that other projects depend on via `mars add`. Consumer projects that just install agents/skills from external packages do not need this section.
 
-To keep project-local agents and skills without publishing, use `.mars-src/` instead. See [local-development.md](local-development.md#mars-src----project-local-agents-and-skills).
+To keep project-local agents and skills without publishing, use `.mars-src/` instead. See [local-development.md](../dev/local-development.md#mars-src----project-local-agents-and-skills).
 
 ```toml
 [package]
@@ -174,6 +174,10 @@ agent_emission = "auto"
 min_mars_version = "0.12.0"
 models_cache_ttl_hours = 24
 
+[settings.agent_copy]
+harnesses = ["claude"]
+include_fanout = false
+
 [settings.model_visibility]
 include = ["anthropic/*", "openai/gpt-5*"]  # Show only these
 exclude = ["*-preview*", "*-latest"]         # Then hide these
@@ -184,6 +188,7 @@ exclude = ["*-preview*", "*-latest"]         # Then hide these
 | `targets` | string[] | unset | Managed target directories copied from `.mars/` |
 | `managed_root` | string | unset | Legacy single target directory; used only when `targets` is unset |
 | `agent_emission` | string | `"auto"` | Native harness agent emission: `auto`, `always`, or `never` |
+| `agent_copy` | table | unset | Selective native agent copy override under managed mode / `agent_emission = "never"` |
 | `min_mars_version` | string | unset | Minimum Mars binary version required for this project |
 | `models_cache_ttl_hours` | integer | `24` | Model catalog cache TTL; `0` forces refresh |
 | `default_harness` | string | unset | Default harness for launch routing when profile/alias/provider cannot resolve one |
@@ -191,6 +196,15 @@ exclude = ["*-preview*", "*-latest"]         # Then hide these
 | `model_visibility` | table | `{}` | Consumer-only display filter for `mars models list` output |
 
 `.mars/` is always the canonical compiled store. Target sync is opt-in: if neither `targets` nor legacy `managed_root` is set, Mars creates no target-sync targets by default.
+
+`[settings.agent_copy]` is the intentional exception to blanket native-agent suppression. It emits selected harness-native copies even when `MERIDIAN_MANAGED=1` or `agent_emission = "never"`; `agent_emission = "always"` still emits all native agents instead.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `harnesses` | string[] | `[]` | Harnesses to receive selective native agent copies; each harness target must also be an effective managed target |
+| `include_fanout` | bool | `false` | Also qualify agents through matching `model-policies` / fanout rules |
+
+Qualifying agents have a matching `harness:`, a `model:` alias that resolves to the listed harness, or — with `include_fanout = true` — a matching `model-policies` rule. For Claude, use `harnesses = ["claude"]` with `.claude` as an effective managed target (from `settings.targets`, or legacy `managed_root` when `targets` is unset) to materialize Claude-native `Agent()` copies while Meridian continues to use `.mars/agents/` for normal `meridian spawn` delegation.
 
 ## Model Visibility
 


### PR DESCRIPTION
## Why

Public docs did not explain the selective native-agent copy path added by `[settings.agent_copy]`, or how it interacts with Meridian-managed sync and Claude-native `Agent()` delegation.

## Goal

Make Mars docs describe `.mars/agents/` as canonical, managed-mode native emission suppression, and the intentional `agent_copy` override for selected harness-native copies.

## Summary

- Updated agent compilation docs to distinguish canonical `.mars/agents/` output from native harness artifacts selected by emission policy.
- Documented `[settings.agent_copy]` shape, qualifying rules, and the effective managed-target requirement.
- Clarified `mars sync` / `mars link` wording so target materialization accounts for `agent_emission` plus optional selective copy.
- Fixed a broken relative link in `docs/config/mars-toml.md` found during markdown validation.

## Work Item

- `claude-native-agent-routing`

## Changes

Docs-only. No runtime behavior changed. Changelog left unchanged because the behavior was already released/documented in `0.7.12`; this PR only fills public-doc gaps.

## Verification

- `meridian kg check docs/config/agent-compilation.md` — no issues.
- `meridian kg check docs/config/mars-toml.md` — no issues.
- `meridian kg check docs/cli/commands.md` — no issues.
- `git diff --check` — pass.
- Reviewer `p3521` checked the docs against implementation intent; two medium wording issues fixed before commit.
- Push preflight: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test -- --skip cli::version::tests::run`, `cargo build --release` — pass.

## Knowledge Updates

- Public docs updated: `docs/config/agent-compilation.md`, `docs/config/mars-toml.md`, `docs/cli/commands.md`.
- No `.context` / KB update; no new behavior.

## Spawn Trace

- `p3521` reviewer — reviewed public docs for Claude Agent / Mars `agent_copy` accuracy; findings fixed.

## Release Label Guide

Set one `release:*` label on this PR:

- `release:patch` or `release:stable` — create the next stable patch release after merge
- `release:rc` — create the next RC release after merge
- `release:skip` — no release for this merge

No `release:*` label means no auto-release.
Unknown `release:*` labels default to RC.

Current label: `release:skip`.

## Post-Merge Automation

After merge to `main`, CI (`.github/workflows/release-on-main.yml`) will:

1. Read the PR release label
2. Skip when no `release:*` label is present or when `release:skip` is present
3. Compute the next stable or RC version from existing `v*` tags
4. Update Cargo/PyPI/npm package versions + promote `CHANGELOG.md` `[Unreleased]`
5. Commit `release: vX.Y.Z` or `release: vX.Y.Z-rc.N`, create/push the matching tag
6. Run `.github/workflows/release.yml` from the tag

## Cleanup

After merge, clean merged worktrees with:

```bash
scripts/prune-worktrees.sh
```
