### PR TITLE
Cursor compilation: sandbox and approval as Approximate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Cursor compilation: `sandbox` and `approval` classified as `Approximate` (was `Dropped`). Cursor supports `--sandbox enabled/disabled` and `--force`/`--yolo` CLI flags; runtime projection is in meridian-cli.
+
+### Fixed
+- Compilation matrix docs: Cursor sandbox/approval tables and lossiness matrix updated to match code.
+
 ## [0.7.14] - 2026-06-02
 
 ### Fixed

--- a/docs/config/agent-compilation.md
+++ b/docs/config/agent-compilation.md
@@ -195,8 +195,8 @@ YAML frontmatter + markdown body.
 | `skills` | `skills:` | exact |
 | `mode` | `mode:` | approximate |
 | body | body | exact |
-| `approval` | dropped | dropped |
-| `sandbox` | dropped | dropped |
+| `approval` | runtime-only (meridian projects `--force`/`--yolo`) | approximate |
+| `sandbox` | runtime-only (meridian projects `--sandbox enabled`/`disabled`) | approximate |
 | `tools` | dropped | dropped |
 | `disallowed-tools` | dropped | dropped |
 | `effort` | dropped from frontmatter | approximate |
@@ -206,6 +206,26 @@ YAML frontmatter + markdown body.
 | `model-policies` | dropped | meridian-only |
 | `fanout` | dropped | meridian-only |
 | `harness-overrides.cursor.native-config` | dropped | meridian-only |
+
+**Approval value mapping:**
+
+| `approval:` | Cursor CLI |
+|---|---|
+| `default` | (omitted) |
+| `auto` | `--force` |
+| `confirm` | (omitted — no Cursor equivalent) |
+| `yolo` | `--yolo` |
+
+**Sandbox value mapping:**
+
+| `sandbox:` | Cursor CLI |
+|---|---|
+| `default` | (omitted) |
+| `read-only` | `--sandbox enabled` |
+| `workspace-write` | `--sandbox disabled` |
+| `danger-full-access` | `--sandbox disabled` |
+
+`approval` and `sandbox` are not stored in the Cursor native agent artifact — Cursor IDE doesn't read them from frontmatter. Meridian applies these as runtime CLI flags through its harness projection layer.
 
 Cursor requires a one-line frontmatter description for stable native parsing. Mars normalizes multiline/block descriptions by trimming and collapsing all whitespace to single spaces before emitting `.cursor/agents/*.md`.
 
@@ -260,8 +280,8 @@ Compact per-field, per-target classification:
 | `model` | preserved | exact | exact | exact | exact (internal deterministic adaptation when available) | exact |
 | `harness` | preserved | dropped | dropped | dropped | dropped | dropped |
 | `mode` | preserved | dropped | dropped | approximate | approximate | approximate |
-| `approval` | preserved | dropped | exact | dropped | dropped | dropped |
-| `sandbox` | preserved | dropped | exact | dropped | dropped | dropped |
+| `approval` | preserved | dropped | exact | dropped | approximate | dropped |
+| `sandbox` | preserved | dropped | exact | dropped | approximate | dropped |
 | `tools` | preserved | exact | dropped | dropped | dropped | dropped |
 | `disallowed-tools` | preserved | exact | dropped | dropped | dropped | dropped |
 | `mcp-tools` | preserved | exact | approximate | approximate | approximate | n/a |

--- a/src/compiler/agents/lower.rs
+++ b/src/compiler/agents/lower.rs
@@ -1235,7 +1235,10 @@ mod tests {
 
         // sandbox must not appear in the emitted YAML artifact
         let text = String::from_utf8(out.bytes).unwrap();
-        assert!(!text.contains("sandbox:"), "sandbox leaked into artifact: {text}");
+        assert!(
+            !text.contains("sandbox:"),
+            "sandbox leaked into artifact: {text}"
+        );
 
         // lossiness must be Approximate, not Dropped
         let field = out
@@ -1265,7 +1268,10 @@ mod tests {
 
         // approval must not appear in the emitted YAML artifact
         let text = String::from_utf8(out.bytes).unwrap();
-        assert!(!text.contains("approval:"), "approval leaked into artifact: {text}");
+        assert!(
+            !text.contains("approval:"),
+            "approval leaked into artifact: {text}"
+        );
 
         // lossiness must be Approximate, not Dropped
         let field = out

--- a/src/compiler/agents/lower.rs
+++ b/src/compiler/agents/lower.rs
@@ -634,19 +634,26 @@ fn lower_to_cursor_with_model(
         });
     }
 
-    // Unsupported policy fields retain existing lossiness behavior.
+    // approval — approximate: auto maps to --force, yolo to --yolo; confirm has no Cursor
+    // equivalent and falls back to default.
     if eff.approval().is_some() {
         lossy.push(LossyField {
             field: "approval".into(),
             target: target.into(),
-            classification: Lossiness::Dropped,
+            classification: Lossiness::Approximate {
+                note: "auto maps to --force, yolo to --yolo; confirm has no Cursor equivalent and falls back to default",
+            },
         });
     }
+    // sandbox — approximate: Cursor only supports enabled/disabled; workspace-write and
+    // danger-full-access both map to --sandbox disabled.
     if eff.sandbox().is_some() {
         lossy.push(LossyField {
             field: "sandbox".into(),
             target: target.into(),
-            classification: Lossiness::Dropped,
+            classification: Lossiness::Approximate {
+                note: "Cursor only supports enabled/disabled; workspace-write and danger-full-access both map to disabled",
+            },
         });
     }
     if !eff.tools().is_empty() {
@@ -1218,6 +1225,66 @@ mod tests {
             !text.contains("description: |\n"),
             "block description should be flattened: {text}"
         );
+    }
+
+    #[test]
+    fn cursor_sandbox_is_approximate_not_dropped() {
+        let content = "---\nname: r\nharness: cursor\nsandbox: read-only\n---\n# body";
+        let (profile, fm, _) = profile_from(content);
+        let out = lower_to_cursor_with_model(&profile, fm.body(), None);
+
+        // sandbox must not appear in the emitted YAML artifact
+        let text = String::from_utf8(out.bytes).unwrap();
+        assert!(!text.contains("sandbox:"), "sandbox leaked into artifact: {text}");
+
+        // lossiness must be Approximate, not Dropped
+        let field = out
+            .lossy_fields
+            .iter()
+            .find(|f| f.field == "sandbox")
+            .expect("sandbox should appear in lossy_fields");
+        assert_eq!(field.target, "Cursor");
+        assert!(
+            matches!(field.classification, Lossiness::Approximate { .. }),
+            "expected Approximate, got {:?}",
+            field.classification
+        );
+        if let Lossiness::Approximate { note } = field.classification {
+            assert!(
+                note.contains("workspace-write") && note.contains("disabled"),
+                "note should document workspace-write mapping: {note}"
+            );
+        }
+    }
+
+    #[test]
+    fn cursor_approval_is_approximate_not_dropped() {
+        let content = "---\nname: r\nharness: cursor\napproval: auto\n---\n# body";
+        let (profile, fm, _) = profile_from(content);
+        let out = lower_to_cursor_with_model(&profile, fm.body(), None);
+
+        // approval must not appear in the emitted YAML artifact
+        let text = String::from_utf8(out.bytes).unwrap();
+        assert!(!text.contains("approval:"), "approval leaked into artifact: {text}");
+
+        // lossiness must be Approximate, not Dropped
+        let field = out
+            .lossy_fields
+            .iter()
+            .find(|f| f.field == "approval")
+            .expect("approval should appear in lossy_fields");
+        assert_eq!(field.target, "Cursor");
+        assert!(
+            matches!(field.classification, Lossiness::Approximate { .. }),
+            "expected Approximate, got {:?}",
+            field.classification
+        );
+        if let Lossiness::Approximate { note } = field.classification {
+            assert!(
+                note.contains("--force") && note.contains("--yolo"),
+                "note should document --force/--yolo mapping: {note}"
+            );
+        }
     }
 
     // --- 3.3: Pi lowering ---


### PR DESCRIPTION
## Why

Cursor now supports `--sandbox enabled|disabled` and `--force`/`--yolo` CLI flags, but the mars compilation matrix classified both `sandbox` and `approval` as `Dropped` for Cursor — meaning "no native equivalent exists." This is no longer accurate.

## Goal

Update the Cursor lossiness classification so the compilation matrix reflects reality. No behavioral change to sync output — these fields are still not emitted into the Cursor native YAML artifact (Cursor IDE doesn't read them from frontmatter). The classification change is documentation for downstream consumers (meridian) that these fields have approximate Cursor equivalents.

## Summary

- `approval`: `Dropped` → `Approximate` — auto maps to `--force`, yolo/never to `--yolo`; confirm has no Cursor equivalent
- `sandbox`: `Dropped` → `Approximate` — Cursor only supports `enabled`/`disabled`; `workspace-write` and `danger-full-access` both map to `--sandbox disabled`
- Two new tests verify classification and that values don't leak into the native artifact
- Compilation matrix docs updated: per-target Cursor table and lossiness matrix reflect approximate, with value mapping tables added

## Resulting behavior

`mars sync` output is unchanged. The lossiness diagnostics now report `Approximate` instead of `Dropped` for sandbox/approval when compiling Cursor agents. Meridian's Cursor harness projector (separate fix in meridian-cli#309) will wire the runtime CLI flag projection.

## Work item

Related: [meridian-cli#309](https://github.com/haowjy/meridian-cli/issues/309) — Cursor harness sandbox flag projection

## Verification

- `cargo test` — 1296 tests pass
- `cargo clippy` — clean
- `cargo fmt --check` — clean

## Knowledge updates

- KB: `research/cursor-sandbox-architecture.md` — Cursor sandbox internals, approval flags, mapping decisions

## Release label

`release:patch`

## Cleanup

```bash
scripts/prune-worktrees.sh
```