### PR TITLE
Harness-aware agent inventory + standalone provisioning (launch_actions experimental)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,13 +10,17 @@
 
 <!-- What changed? Paste the agent-generated summary, then adjust for clarity. -->
 
-## Work Item
+## Resulting Behavior
 
-<!-- Meridian work item slug, for example: mars-capability-cache-resolver -->
+<!-- User-facing end state. What can someone do after this merges that they could not do before? Prefer examples/CLI outcomes over implementation details. -->
 
 ## Changes
 
 <!-- Notable implementation details, behavior changes, risks, and follow-ups. -->
+
+## Work Item
+
+<!-- Meridian work item slug, for example: harness-aware-agent-inventory -->
 
 ## Verification
 
@@ -39,22 +43,23 @@
 
 Set one `release:*` label on this PR:
 
-- `release:patch` or `release:stable` — create the next stable patch release after merge
-- `release:rc` — create the next RC release after merge
+- `release:patch` / `release:stable` — next stable **patch** release after merge
+- `release:minor` — next stable **minor** release after merge
+- `release:major` — next stable **major** release after merge
+- `release:rc` — next **prerelease (RC)** after merge
 - `release:skip` — no release for this merge
 
-No `release:*` label means no auto-release.
-Unknown `release:*` labels default to RC.
+No `release:*` label defaults to a prerelease (RC). Unknown `release:*` labels also default to RC.
 
 ## Post-Merge Automation
 
 After merge to `main`, CI (`.github/workflows/release-on-main.yml`) will:
 
 1. Read the PR release label
-2. Skip when no `release:*` label is present or when `release:skip` is present
+2. Skip only when `release:skip` is present (no label defaults to RC)
 3. Compute the next stable or RC version from existing `v*` tags
 4. Update Cargo/PyPI/npm package versions + promote `CHANGELOG.md` `[Unreleased]`
-5. Commit `release: vX.Y.Z` or `release: vX.Y.Z-rc.N`, create/push the matching tag
+5. Commit `release: vX.Y.Z` (or `release: vX.Y.Z-rc.N`), create/push the matching tag
 6. Run `.github/workflows/release.yml` from the tag
 
 ## Cleanup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 ### Added
-- `mars build launch-bundle --context` emits v4 `launch_actions` executable argv/env/files/protocol shape; Cursor, Claude, Codex, OpenCode, and Pi subprocess projections first.
+- `mars build launch-bundle --context` emits v4 `launch_actions` with subprocess/streaming `kind`, `cwd`, stdin, files, env, and bootstrap/turn protocol shapes for Cursor, Claude, Codex, OpenCode, and Pi.
 
 ## [0.7.17] - 2026-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Added
 - `mars build launch-bundle --context` emits v4 `launch_actions` with subprocess/streaming `kind`, `cwd`, stdin, files, env, and bootstrap/turn protocol shapes for Cursor, Claude, Codex, OpenCode, and Pi.
+- `.mars/native-agents.json` manifest after sync/link; launch-bundle inventory splits Meridian spawn agents from harness-native agents.
 
 ## [0.7.17] - 2026-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [SemVer](https://semver.org/).
 
 ## [Unreleased]
+### Added
+- `mars build launch-bundle --context` emits v4 `launch_actions` executable argv/env/files/protocol shape; Cursor subprocess projection first.
 
 ## [0.7.17] - 2026-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 ### Added
-- `mars build launch-bundle --context` emits v4 `launch_actions` executable argv/env/files/protocol shape; Cursor subprocess projection first.
+- `mars build launch-bundle --context` emits v4 `launch_actions` executable argv/env/files/protocol shape; Cursor and Claude subprocess projections first.
 
 ## [0.7.17] - 2026-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `mars build launch-bundle --context` / `launch_actions` projection marked EXPERIMENTAL — not consumed by meridian; may be removed.
 
 ### Added
+- `mars sync` summary now reports native-agent emissions and removals (`emitted N native agents` / `removed N native agents`, with per-line `+/-  <target>/<path> (native agent)`). Previously a managed/SuppressAll sync that pruned native agents printed "already up to date" — the prune was silent. Emissions are diffed against the prior lock so steady-state re-syncs stay quiet; counts also added to `--json`.
 - `mars build launch-bundle --context` emits v4 `launch_actions` with subprocess/streaming `kind`, `cwd`, stdin, files, env, and bootstrap/turn protocol shapes for Cursor, Claude, Codex, OpenCode, and Pi.
 - `.mars/native-agents.json` manifest after sync/link; launch-bundle inventory splits Meridian spawn agents from harness-native agents.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 ### Changed
+- `[settings.agent_copy]` renamed to `[settings.meridian.agent_copy]` (clean break, no shim) — marks selective native copy as meridian-managed-only.
 - `mars build launch-bundle --context` / `launch_actions` projection marked EXPERIMENTAL — not consumed by meridian; may be removed.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 ### Added
-- `mars build launch-bundle --context` emits v4 `launch_actions` executable argv/env/files/protocol shape; Cursor and Claude subprocess projections first.
+- `mars build launch-bundle --context` emits v4 `launch_actions` executable argv/env/files/protocol shape; Cursor, Claude, Codex, OpenCode, and Pi subprocess projections first.
 
 ## [0.7.17] - 2026-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [SemVer](https://semver.org/).
 
 ## [Unreleased]
+### Changed
+- `mars build launch-bundle --context` / `launch_actions` projection marked EXPERIMENTAL — not consumed by meridian; may be removed.
+
 ### Added
 - `mars build launch-bundle --context` emits v4 `launch_actions` with subprocess/streaming `kind`, `cwd`, stdin, files, env, and bootstrap/turn protocol shapes for Cursor, Claude, Codex, OpenCode, and Pi.
 - `.mars/native-agents.json` manifest after sync/link; launch-bundle inventory splits Meridian spawn agents from harness-native agents.

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -122,7 +122,7 @@ mars sync [--force] [--diff] [--frozen]
 | `--diff` | Dry run: show what would change without applying |
 | `--frozen` | Error if lock file would change (CI mode) |
 
-This is the core operation. It runs the full [sync pipeline](../internals/sync-pipeline.md): resolve → target → diff → apply. Native agent materialization follows `settings.agent_emission`; `[settings.agent_copy]` can selectively emit qualifying harness-native agent copies even when emission is otherwise suppressed.
+This is the core operation. It runs the full [sync pipeline](../internals/sync-pipeline.md): resolve → target → diff → apply. Native agent materialization follows `settings.agent_emission`; `[settings.meridian.agent_copy]` can selectively emit qualifying harness-native agent copies even when emission is otherwise suppressed.
 
 ---
 
@@ -297,7 +297,7 @@ mars link <target> [--force]
 - Adds `<target>` as a managed target directory and copies content from `.mars/` into it
 - Persists the target in `mars.toml [settings] targets` and updates `mars.lock` with per-target output records
 - If a path in the target exists on disk but is not tracked for that `target_root`, Mars preserves it and emits `target-unmanaged-collision` (exit 2). Run `mars link <target> --force` to adopt and record ownership (`target-unmanaged-adopted`)
-- Materialization depends on target, `agent_emission`, and optional `[settings.agent_copy]` (e.g. `.cursor` receives skills/MCP unless native agent emission or selective copy applies)
+- Materialization depends on target, `agent_emission`, and optional `[settings.meridian.agent_copy]` (e.g. `.cursor` receives skills/MCP unless native agent emission or selective copy applies)
 
 ```bash
 mars link .claude            # Copy managed content into .claude/

--- a/docs/config/agent-compilation.md
+++ b/docs/config/agent-compilation.md
@@ -1,6 +1,6 @@
 # Agent Compilation
 
-During `mars sync`, every agent is compiled to a canonical full-fidelity artifact in `.mars/agents/`. Native harness artifacts (`.claude/agents/`, `.codex/agents/`, etc.) are emitted when native agent emission policy allows them: normally for agents that declare `harness:`, or selectively through `[settings.agent_copy]`.
+During `mars sync`, every agent is compiled to a canonical full-fidelity artifact in `.mars/agents/`. Native harness artifacts (`.claude/agents/`, `.codex/agents/`, etc.) are emitted when native agent emission policy allows them: normally for agents that declare `harness:`, or selectively through `[settings.meridian.agent_copy]`.
 
 ## The Two Surfaces
 
@@ -18,7 +18,7 @@ When native emission selects an agent for a harness, a second artifact is emitte
 
 Harness-native artifacts are format-translated and field-stripped. They serve as agent discovery surfaces for harness-native invocation (e.g. `codex --agent coder`). Meridian always uses the `.mars/` artifact for its own spawn logic and applies all policy fields through its own projection layer.
 
-Universal agents (no `harness:`) are installed to `.mars/agents/` only by default and can be launched by Meridian against any harness. `[settings.agent_copy]` can still create a native copy when the agent qualifies through its `model:` alias or, with `include_fanout = true`, its `model-policies`.
+Universal agents (no `harness:`) are installed to `.mars/agents/` only by default and can be launched by Meridian against any harness. `[settings.meridian.agent_copy]` can still create a native copy when the agent qualifies through its `model:` alias or, with `include_fanout = true`, its `model-policies`.
 
 ## Emission Control
 
@@ -37,14 +37,14 @@ agent_emission = "always"
 
 **`MERIDIAN_MANAGED=1`** — when Meridian invokes mars, it sets this env var. Under `auto`, native artifacts are suppressed: Meridian manages delegation through `.mars/agents/` and `meridian spawn`, and does not want harness-native artifacts competing with that routing. Set `agent_emission = "always"` to emit all native artifacts.
 
-Use `[settings.agent_copy]` for a selective override under managed mode or `agent_emission = "never"`:
+Use `[settings.meridian.agent_copy]` for a selective override under managed mode or `agent_emission = "never"`:
 
 ```toml
 [settings]
 targets = [".claude"]
 agent_emission = "never"  # optional
 
-[settings.agent_copy]
+[settings.meridian.agent_copy]
 harnesses = ["claude"]
 include_fanout = false
 ```

--- a/docs/config/mars-toml.md
+++ b/docs/config/mars-toml.md
@@ -174,7 +174,7 @@ agent_emission = "auto"
 min_mars_version = "0.12.0"
 models_cache_ttl_hours = 24
 
-[settings.agent_copy]
+[settings.meridian.agent_copy]
 harnesses = ["claude"]
 include_fanout = false
 
@@ -197,7 +197,7 @@ exclude = ["*-preview*", "*-latest"]         # Then hide these
 
 `.mars/` is always the canonical compiled store. Target sync is opt-in: if neither `targets` nor legacy `managed_root` is set, Mars creates no target-sync targets by default.
 
-`[settings.agent_copy]` is the intentional exception to blanket native-agent suppression. It emits selected harness-native copies even when `MERIDIAN_MANAGED=1` or `agent_emission = "never"`; `agent_emission = "always"` still emits all native agents instead.
+`[settings.meridian.agent_copy]` is the intentional exception to blanket native-agent suppression. It emits selected harness-native copies even when `MERIDIAN_MANAGED=1` or `agent_emission = "never"`; `agent_emission = "always"` still emits all native agents instead.
 
 | Field | Type | Default | Description |
 |---|---|---|---|

--- a/src/build/bundle.rs
+++ b/src/build/bundle.rs
@@ -40,6 +40,13 @@ pub struct RuntimeContext {
     #[serde(default)]
     pub pi_extension_entrypoints: Vec<String>,
     pub prompt: Option<String>,
+    pub report_output_path: Option<String>,
+    pub base_instructions: Option<String>,
+    pub developer_instructions: Option<String>,
+    pub user_turn_content: Option<String>,
+    pub pi_session_dir: Option<String>,
+    #[serde(default)]
+    pub load_all_pi_extensions: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/build/bundle.rs
+++ b/src/build/bundle.rs
@@ -41,9 +41,6 @@ pub struct RuntimeContext {
     pub pi_extension_entrypoints: Vec<String>,
     pub prompt: Option<String>,
     pub report_output_path: Option<String>,
-    pub base_instructions: Option<String>,
-    pub developer_instructions: Option<String>,
-    pub user_turn_content: Option<String>,
     pub pi_session_dir: Option<String>,
     #[serde(default)]
     pub load_all_pi_extensions: bool,
@@ -56,17 +53,56 @@ pub struct StreamingContext {
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct LaunchActions {
-    pub argv: Vec<String>,
-    pub env: BTreeMap<String, String>,
-    pub files: Vec<LaunchFile>,
-    pub protocol_payload: Option<serde_json::Value>,
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum LaunchActions {
+    Subprocess {
+        argv: Vec<String>,
+        env: BTreeMap<String, String>,
+        cwd: String,
+        files: Vec<LaunchFile>,
+        stdin: Option<String>,
+    },
+    Streaming {
+        argv: Vec<String>,
+        env: BTreeMap<String, String>,
+        cwd: String,
+        protocol: LaunchProtocol,
+    },
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct LaunchFile {
     pub path: String,
     pub content: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LaunchProtocol {
+    pub transport: String,
+    pub bootstrap: ProtocolBootstrap,
+    pub turn: ProtocolTurn,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ProtocolBootstrap {
+    pub method: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub params: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ProtocolTurn {
+    pub method: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path_template: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub params_template: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body_template: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/build/bundle.rs
+++ b/src/build/bundle.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 pub const SLOT_PLACEHOLDER: &str = "###SLOT###";
 
@@ -12,12 +12,54 @@ pub struct LaunchBundle {
     pub agent_body: Option<String>,
     pub routing: Routing,
     pub execution_policy: ExecutionPolicy,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub launch_actions: Option<LaunchActions>,
     pub prompt_surface: PromptSurface,
     pub scaffold_slots: ScaffoldSlots,
     pub tools: ToolsSpec,
     pub skills: Skills,
     pub provenance: BTreeMap<String, String>,
     pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RuntimeContext {
+    pub cwd: Option<String>,
+    pub temp_dir: Option<String>,
+    pub streaming: Option<StreamingContext>,
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub fork: bool,
+    #[serde(default)]
+    pub workspace_roots: Vec<String>,
+    #[serde(default)]
+    pub interactive: bool,
+    #[serde(default)]
+    pub extra_args: Vec<String>,
+    pub opencode_config_content: Option<String>,
+    #[serde(default)]
+    pub pi_extension_entrypoints: Vec<String>,
+    pub prompt: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct StreamingContext {
+    pub host: String,
+    pub port: u16,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LaunchActions {
+    pub argv: Vec<String>,
+    pub env: BTreeMap<String, String>,
+    pub files: Vec<LaunchFile>,
+    pub protocol_payload: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LaunchFile {
+    pub path: String,
+    pub content: String,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/build/bundle.rs
+++ b/src/build/bundle.rs
@@ -12,6 +12,7 @@ pub struct LaunchBundle {
     pub agent_body: Option<String>,
     pub routing: Routing,
     pub execution_policy: ExecutionPolicy,
+    /// EXPERIMENTAL — see `build/project` module doc.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub launch_actions: Option<LaunchActions>,
     pub prompt_surface: PromptSurface,
@@ -22,6 +23,7 @@ pub struct LaunchBundle {
     pub warnings: Vec<String>,
 }
 
+/// EXPERIMENTAL — see `build/project` module doc.
 #[derive(Debug, Clone, Deserialize)]
 pub struct RuntimeContext {
     pub cwd: Option<String>,

--- a/src/build/inventory.rs
+++ b/src/build/inventory.rs
@@ -1,0 +1,486 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use crate::compiler::agents::{AgentMode, HarnessKind, ModelPolicyMatchType, parse_agent_content};
+use crate::compiler::native_agent_manifest::{
+    agent_is_native_for_harness, read_native_agent_manifest,
+};
+use crate::error::{ConfigError, MarsError};
+
+#[derive(Debug, Clone)]
+struct ParsedAgentInventory {
+    name: String,
+    description: String,
+    model: Option<String>,
+    fanout: Vec<String>,
+    mode: AgentMode,
+}
+
+pub fn build_inventory_prompt(
+    mars_dir: &Path,
+    subagents_filter: &[String],
+    harness: &str,
+    warnings: &mut Vec<String>,
+) -> Result<String, MarsError> {
+    let agents_dir = mars_dir.join("agents");
+    if !agents_dir.is_dir() {
+        return Ok(String::new());
+    }
+
+    let read_dir = match std::fs::read_dir(&agents_dir) {
+        Ok(entries) => entries,
+        Err(err) => {
+            warnings.push(format!(
+                "failed to read agent inventory from {}: {err}",
+                agents_dir.display()
+            ));
+            return Ok(String::new());
+        }
+    };
+
+    let mut agent_paths: Vec<PathBuf> = read_dir
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("md"))
+        .collect();
+    agent_paths.sort();
+
+    let mut primary_agents = Vec::new();
+    let mut subagent_agents = Vec::new();
+
+    for path in agent_paths {
+        match parse_inventory_agent(&path) {
+            Ok((Some(agent), agent_warnings)) => {
+                warnings.extend(agent_warnings);
+                if agent.mode == AgentMode::Primary {
+                    primary_agents.push(agent);
+                } else {
+                    subagent_agents.push(agent);
+                }
+            }
+            Ok((None, agent_warnings)) => warnings.extend(agent_warnings),
+            Err(err) => {
+                return Err(MarsError::Config(ConfigError::Invalid { message: err }));
+            }
+        }
+    }
+
+    if !subagents_filter.is_empty() {
+        primary_agents.retain(|agent| {
+            subagents_filter
+                .iter()
+                .any(|f| f.eq_ignore_ascii_case(&agent.name))
+        });
+        subagent_agents.retain(|agent| {
+            subagents_filter
+                .iter()
+                .any(|f| f.eq_ignore_ascii_case(&agent.name))
+        });
+    }
+
+    if primary_agents.is_empty() && subagent_agents.is_empty() {
+        return Ok(String::new());
+    }
+
+    primary_agents.sort_by(|left, right| left.name.cmp(&right.name));
+    subagent_agents.sort_by(|left, right| left.name.cmp(&right.name));
+
+    let manifest = read_native_agent_manifest(mars_dir);
+    let is_native_for_harness = |agent: &ParsedAgentInventory| -> bool {
+        agent_is_native_for_harness(&manifest, &agent.name, harness)
+    };
+
+    let mut meridian_primary = Vec::new();
+    let mut meridian_subagent = Vec::new();
+    let mut native_agents = Vec::new();
+
+    for agent in primary_agents {
+        if is_native_for_harness(&agent) {
+            native_agents.push(agent);
+        } else {
+            meridian_primary.push(agent);
+        }
+    }
+    for agent in subagent_agents {
+        if is_native_for_harness(&agent) {
+            native_agents.push(agent);
+        } else {
+            meridian_subagent.push(agent);
+        }
+    }
+    native_agents.sort_by(|left, right| left.name.cmp(&right.name));
+
+    let mut lines = vec![
+        "# Meridian Agents".to_string(),
+        "".to_string(),
+        "Write prompts to `/tmp/<name>.md`.".to_string(),
+        "Use `--bg` + `meridian spawn wait` for parallel work.".to_string(),
+        "Use `/handoff` when passing control back to the user.".to_string(),
+    ];
+
+    if !meridian_subagent.is_empty() {
+        lines.extend(["".to_string(), "## Subagent".to_string()]);
+        for agent in &meridian_subagent {
+            lines.push(render_meridian_agent_line(agent));
+        }
+    }
+
+    if !meridian_primary.is_empty() {
+        lines.extend(["".to_string(), "## Primary".to_string()]);
+        for agent in &meridian_primary {
+            lines.push(render_meridian_agent_line(agent));
+        }
+    }
+
+    if !native_agents.is_empty() {
+        lines.extend(render_native_section_heading(harness));
+        for agent in &native_agents {
+            lines.push(render_native_agent_line(agent));
+        }
+    }
+
+    Ok(lines.join("\n").trim().to_string())
+}
+
+fn parse_inventory_agent(
+    path: &Path,
+) -> Result<(Option<ParsedAgentInventory>, Vec<String>), String> {
+    let content = std::fs::read_to_string(path).map_err(|err| {
+        format!(
+            "failed to read agent inventory file {}: {err}",
+            path.display()
+        )
+    })?;
+
+    let mut parse_diags = Vec::new();
+    let (profile, _frontmatter) =
+        parse_agent_content(&content, &mut parse_diags).map_err(|err| {
+            format!(
+                "failed to parse agent inventory file {}: {err}",
+                path.display()
+            )
+        })?;
+
+    let mut warnings = Vec::new();
+    for diag in parse_diags {
+        if diag.is_error() {
+            return Err(format!(
+                "agent inventory file {} has invalid frontmatter: {}",
+                path.display(),
+                diag.message()
+            ));
+        }
+        warnings.push(format!(
+            "agent inventory parse warning in {}: {}",
+            path.display(),
+            diag.message()
+        ));
+    }
+    if !profile.model_invocable {
+        return Ok((None, warnings));
+    }
+
+    let fallback_name = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("unknown-agent")
+        .to_string();
+    let fanout = fallback_model_policies_for_inventory(&profile);
+    let name = profile.name.unwrap_or(fallback_name);
+    let description = profile.description.unwrap_or_default();
+    let mode = profile.mode.clone().unwrap_or(AgentMode::Subagent);
+
+    Ok((
+        Some(ParsedAgentInventory {
+            name,
+            description,
+            model: profile.model,
+            fanout,
+            mode,
+        }),
+        warnings,
+    ))
+}
+
+fn fallback_model_policies_for_inventory(
+    profile: &crate::compiler::agents::AgentProfile,
+) -> Vec<String> {
+    let mut entries = Vec::new();
+    let mut seen = HashSet::new();
+
+    // Limitation: this deduplicates exact fallback labels only. Alias-to-model
+    // canonical dedupe requires alias catalog context not currently loaded here.
+    for policy in &profile.model_policies {
+        if policy.no_fallback {
+            continue;
+        }
+        if !matches!(
+            policy.match_type,
+            ModelPolicyMatchType::Alias | ModelPolicyMatchType::Model
+        ) {
+            continue;
+        }
+        let value = policy.match_value.trim();
+        if value.is_empty() {
+            continue;
+        }
+        if seen.insert(value.to_string()) {
+            entries.push(value.to_string());
+        }
+    }
+
+    entries
+}
+
+fn render_meridian_agent_line(agent: &ParsedAgentInventory) -> String {
+    let description = agent.description.trim();
+    let mut line = if description.is_empty() {
+        format!("- `meridian spawn -a {}`", agent.name)
+    } else {
+        format!("- `meridian spawn -a {}`: {}", agent.name, description)
+    };
+
+    if let Some(model) = agent.model.as_ref().map(|value| value.trim())
+        && !model.is_empty()
+    {
+        line.push_str(" | Model: ");
+        line.push_str(model);
+    }
+
+    if !agent.fanout.is_empty() {
+        line.push_str(" | Fan-out: ");
+        line.push_str(&agent.fanout.join(", "));
+    }
+
+    line
+}
+
+fn render_native_agent_line(agent: &ParsedAgentInventory) -> String {
+    let description = agent.description.trim();
+    if description.is_empty() {
+        format!("- {}", agent.name)
+    } else {
+        format!("- {}: {}", agent.name, description)
+    }
+}
+
+fn render_native_section_heading(harness: &str) -> Vec<String> {
+    match HarnessKind::from_str(harness) {
+        Some(HarnessKind::Claude) => vec![
+            "".to_string(),
+            "## Claude Agents (use `Agent({subagent_type: \"...\"})` tool)".to_string(),
+        ],
+        Some(_) => vec![
+            "".to_string(),
+            "## Native Agents".to_string(),
+            "Use your native subagent tool for agents listed here.".to_string(),
+        ],
+        None => vec![
+            "".to_string(),
+            "## Native Agents".to_string(),
+            "Use your native subagent tool for agents listed here.".to_string(),
+        ],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compiler::agents::HarnessKind;
+    use crate::compiler::write_native_agent_manifest_from_lock;
+    use crate::lock::{ItemKind, LockFile, LockedItemV2, OutputRecord};
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_agent(mars_dir: &Path, name: &str, content: &str) {
+        let agents_dir = mars_dir.join("agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+        fs::write(agents_dir.join(format!("{name}.md")), content).unwrap();
+    }
+
+    fn sample_agent_content(name: &str, mode: &str, description: &str) -> String {
+        format!(
+            "---\nname: {name}\ndescription: {description}\nmode: {mode}\nmodel: test-model\n---\nBody."
+        )
+    }
+
+    fn lock_with_native_agent_paths(
+        agent_key: &str,
+        canonical_dest: &str,
+        native_dest: &str,
+        harness: HarnessKind,
+    ) -> LockFile {
+        let mut lock = LockFile::empty();
+        lock.items.insert(
+            agent_key.to_string(),
+            LockedItemV2 {
+                source: "test".into(),
+                kind: ItemKind::Agent,
+                version: None,
+                source_checksum: "sha256:src".into(),
+                outputs: vec![
+                    OutputRecord {
+                        target_root: ".mars".to_string(),
+                        dest_path: canonical_dest.into(),
+                        installed_checksum: "sha256:mars".into(),
+                    },
+                    OutputRecord {
+                        target_root: harness.target_dir().to_string(),
+                        dest_path: native_dest.into(),
+                        installed_checksum: "sha256:native".into(),
+                    },
+                ],
+            },
+        );
+        lock
+    }
+
+    fn lock_with_native_agent(agent_name: &str, harness: HarnessKind) -> LockFile {
+        let canonical = format!("agents/{agent_name}.md");
+        lock_with_native_agent_paths(
+            &format!("agent/{agent_name}"),
+            &canonical,
+            &canonical,
+            harness,
+        )
+    }
+
+    #[test]
+    fn inventory_without_manifest_renders_all_as_meridian() {
+        let temp = TempDir::new().unwrap();
+        let mars_dir = temp.path().join(".mars");
+        write_agent(
+            &mars_dir,
+            "coder",
+            &sample_agent_content("coder", "subagent", "Features and refactors"),
+        );
+        write_agent(
+            &mars_dir,
+            "product-lead",
+            &sample_agent_content("product-lead", "primary", "Intent capture"),
+        );
+
+        let mut warnings = Vec::new();
+        let inventory = build_inventory_prompt(&mars_dir, &[], "claude", &mut warnings).unwrap();
+
+        assert!(inventory.contains("Write prompts to `/tmp/<name>.md`."));
+        assert!(inventory.contains("## Subagent"));
+        assert!(
+            inventory.contains(
+                "- `meridian spawn -a coder`: Features and refactors | Model: test-model"
+            )
+        );
+        assert!(inventory.contains("## Primary"));
+        assert!(
+            inventory
+                .contains("- `meridian spawn -a product-lead`: Intent capture | Model: test-model")
+        );
+        assert!(!inventory.contains("## Claude Agents"));
+        assert!(!inventory.contains("## Native Agents"));
+    }
+
+    #[test]
+    fn inventory_with_manifest_renders_split_sections_for_claude() {
+        let temp = TempDir::new().unwrap();
+        let project_root = temp.path();
+        let mars_dir = project_root.join(".mars");
+        write_agent(
+            &mars_dir,
+            "coder",
+            &sample_agent_content("coder", "subagent", "Features and refactors"),
+        );
+        write_agent(
+            &mars_dir,
+            "explorer",
+            &sample_agent_content("explorer", "subagent", "Codebase structure"),
+        );
+        write_agent(
+            &mars_dir,
+            "frontend-coder",
+            &sample_agent_content("frontend-coder", "subagent", "Frontend implementation"),
+        );
+
+        write_native_agent_manifest_from_lock(
+            project_root,
+            &lock_with_native_agent("frontend-coder", HarnessKind::Claude),
+        )
+        .unwrap();
+
+        let mut warnings = Vec::new();
+        let inventory = build_inventory_prompt(&mars_dir, &[], "claude", &mut warnings).unwrap();
+
+        assert!(
+            inventory.contains(
+                "- `meridian spawn -a coder`: Features and refactors | Model: test-model"
+            )
+        );
+        assert!(
+            inventory
+                .contains("- `meridian spawn -a explorer`: Codebase structure | Model: test-model")
+        );
+        assert!(
+            inventory.contains("## Claude Agents (use `Agent({subagent_type: \"...\"})` tool)")
+        );
+        assert!(inventory.contains("- frontend-coder: Frontend implementation"));
+        assert!(!inventory.contains("meridian spawn -a frontend-coder"));
+    }
+
+    #[test]
+    fn inventory_with_renamed_profile_lands_in_native_section() {
+        let temp = TempDir::new().unwrap();
+        let project_root = temp.path();
+        let mars_dir = project_root.join(".mars");
+        write_agent(
+            &mars_dir,
+            "my-file",
+            &sample_agent_content("logical-name", "subagent", "Renamed profile agent"),
+        );
+
+        write_native_agent_manifest_from_lock(
+            project_root,
+            &lock_with_native_agent_paths(
+                "agent/my-file",
+                "agents/my-file.md",
+                "agents/logical-name.md",
+                HarnessKind::Claude,
+            ),
+        )
+        .unwrap();
+
+        let mut warnings = Vec::new();
+        let inventory = build_inventory_prompt(&mars_dir, &[], "claude", &mut warnings).unwrap();
+
+        assert!(
+            inventory.contains("## Claude Agents (use `Agent({subagent_type: \"...\"})` tool)")
+        );
+        assert!(inventory.contains("- logical-name: Renamed profile agent"));
+        assert!(!inventory.contains("meridian spawn -a logical-name"));
+    }
+
+    #[test]
+    fn inventory_with_manifest_on_other_harness_keeps_native_agents_in_meridian_section() {
+        let temp = TempDir::new().unwrap();
+        let project_root = temp.path();
+        let mars_dir = project_root.join(".mars");
+        write_agent(
+            &mars_dir,
+            "frontend-coder",
+            &sample_agent_content("frontend-coder", "subagent", "Frontend implementation"),
+        );
+
+        write_native_agent_manifest_from_lock(
+            project_root,
+            &lock_with_native_agent("frontend-coder", HarnessKind::Claude),
+        )
+        .unwrap();
+
+        let mut warnings = Vec::new();
+        let inventory = build_inventory_prompt(&mars_dir, &[], "codex", &mut warnings).unwrap();
+
+        assert!(inventory.contains(
+            "- `meridian spawn -a frontend-coder`: Frontend implementation | Model: test-model"
+        ));
+        assert!(!inventory.contains("## Native Agents"));
+        assert!(!inventory.contains("## Claude Agents"));
+    }
+}

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1,4 +1,5 @@
 pub mod bundle;
+pub mod inventory;
 pub mod policy;
 pub mod project;
 pub mod prompt;

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1,11 +1,12 @@
 pub mod bundle;
 pub mod policy;
+pub mod project;
 pub mod prompt;
 pub mod tool_normalize;
 
 use std::path::PathBuf;
 
-use bundle::{LaunchBundle, ScaffoldSlots, Skills, ToolsSpec};
+use bundle::{LaunchBundle, RuntimeContext, ScaffoldSlots, Skills, ToolsSpec};
 use policy::{PolicyInput, resolve_policy};
 use prompt::compile_prompt_surface;
 use tool_normalize::{ToolProjectionStatus, is_first_class_harness, normalize_tool_for_harness};
@@ -16,7 +17,7 @@ use crate::config::EffectiveProjectConfig;
 use crate::error::{ConfigError, MarsError};
 use crate::frontmatter::SkillsSpec;
 
-pub const LAUNCH_BUNDLE_VERSION: u32 = 3;
+pub const LAUNCH_BUNDLE_VERSION: u32 = 4;
 
 pub struct LaunchBundleRequest {
     pub agent: Option<String>,
@@ -27,6 +28,8 @@ pub struct LaunchBundleRequest {
     pub sandbox: Option<String>,
     pub extra_skills: Vec<String>,
     pub models_refresh: crate::models::ModelsRefreshControl,
+    pub runtime_context: Option<RuntimeContext>,
+    pub transport: project::Transport,
 }
 
 pub fn build_launch_bundle(
@@ -122,12 +125,13 @@ pub fn build_launch_bundle(
     let (resolved_tools, tool_warnings) = resolve_bundle_tools(&profile, &policy.routing.harness)?;
     warnings.extend(tool_warnings);
 
-    Ok(LaunchBundle {
+    let mut bundle = LaunchBundle {
         version: LAUNCH_BUNDLE_VERSION,
         agent: request.agent,
         agent_body,
         routing: policy.routing,
         execution_policy: policy.execution_policy,
+        launch_actions: None,
         prompt_surface: bundle::PromptSurface {
             system_instruction: prompt.system_instruction,
             supplemental_documents: prompt.supplemental_documents,
@@ -142,7 +146,17 @@ pub fn build_launch_bundle(
         },
         provenance: policy.provenance,
         warnings,
-    })
+    };
+
+    if let Some(context) = request.runtime_context.as_ref() {
+        bundle.launch_actions = Some(project::project_launch_actions(
+            &bundle,
+            context,
+            request.transport,
+        )?);
+    }
+
+    Ok(bundle)
 }
 
 fn empty_agent_profile() -> AgentProfile {

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -149,6 +149,7 @@ pub fn build_launch_bundle(
         warnings,
     };
 
+    // EXPERIMENTAL optional projection — see `build/project` module doc.
     if let Some(context) = request.runtime_context.as_ref() {
         bundle.launch_actions = Some(project::project_launch_actions(
             &bundle,

--- a/src/build/policy/mod.rs
+++ b/src/build/policy/mod.rs
@@ -737,21 +737,17 @@ fn effective_policies<'a>(
     profile_policies: &'a [ModelPolicyRule],
     settings_policies: &'a [ModelPolicyRule],
 ) -> impl Iterator<Item = (PolicyLayer, usize, &'a ModelPolicyRule)> + 'a {
-    overlay
-        .into_iter()
-        .flat_map(|agent_overlay| {
-            agent_overlay
-                .model_policies
-                .iter()
-                .enumerate()
-                .map(|(index, rule)| (PolicyLayer::Overlay, index, rule))
+    // Overlay->profile ordering (with per-layer indices) is shared with native
+    // emission via the config helper; launch-bundle alone appends settings policies.
+    crate::config::overlay_then_profile_policies(overlay, profile_policies)
+        .map(|(is_overlay, index, rule)| {
+            let layer = if is_overlay {
+                PolicyLayer::Overlay
+            } else {
+                PolicyLayer::Profile
+            };
+            (layer, index, rule)
         })
-        .chain(
-            profile_policies
-                .iter()
-                .enumerate()
-                .map(|(index, rule)| (PolicyLayer::Profile, index, rule)),
-        )
         .chain(
             settings_policies
                 .iter()

--- a/src/build/project/claude.rs
+++ b/src/build/project/claude.rs
@@ -1,0 +1,32 @@
+use crate::build::bundle::{LaunchActions, LaunchBundle, RuntimeContext};
+use crate::error::MarsError;
+
+#[allow(dead_code)]
+pub fn project(
+    _bundle: &LaunchBundle,
+    _context: &RuntimeContext,
+) -> Result<LaunchActions, MarsError> {
+    Err(MarsError::InvalidRequest {
+        message: "launch_actions projection not implemented for this harness yet".to_string(),
+    })
+}
+
+#[allow(dead_code)]
+pub fn project_subprocess(
+    _bundle: &LaunchBundle,
+    _context: &RuntimeContext,
+) -> Result<LaunchActions, MarsError> {
+    Err(MarsError::InvalidRequest {
+        message: "launch_actions projection not implemented for this harness yet".to_string(),
+    })
+}
+
+#[allow(dead_code)]
+pub fn project_streaming(
+    _bundle: &LaunchBundle,
+    _context: &RuntimeContext,
+) -> Result<LaunchActions, MarsError> {
+    Err(MarsError::InvalidRequest {
+        message: "launch_actions projection not implemented for this harness yet".to_string(),
+    })
+}

--- a/src/build/project/claude.rs
+++ b/src/build/project/claude.rs
@@ -1,5 +1,5 @@
 use crate::build::bundle::{LaunchActions, LaunchBundle, RuntimeContext};
-use crate::build::project::{agent_name, approval, effort, empty_actions, model, prompt_file};
+use crate::build::project::{agent_name, approval, effort, model, prompt_file, subprocess_actions};
 use crate::error::MarsError;
 
 const CLAUDE_PARENT_ALLOWED_TOOLS_FLAG: &str = "--meridian-parent-allowed-tools";
@@ -104,9 +104,7 @@ pub fn project(
 
     argv.extend(passthrough_tail);
 
-    let mut actions = empty_actions(argv);
-    actions.files = files;
-    Ok(actions)
+    subprocess_actions(context, argv, files, context.prompt.clone())
 }
 
 fn claude_effort(effort: &str) -> &str {

--- a/src/build/project/claude.rs
+++ b/src/build/project/claude.rs
@@ -22,6 +22,7 @@ pub fn project(
         "--verbose".to_string(),
     ];
 
+    // TODO(launch-actions-parity, launch-bundle-projection): interactive prompt via stdin, not positional arg
     if !context.interactive {
         argv.push("-".to_string());
     }
@@ -43,6 +44,7 @@ pub fn project(
 
     argv.extend(permission_tail(bundle)?);
 
+    // TODO(launch-actions-parity, launch-bundle-projection): no `--agents` native-agent payload emitted
     let mut allowed_tools = Vec::new();
     allowed_tools.extend(bundle.tools.allowed.iter().cloned());
     allowed_tools.extend(parent_allowed_tools);
@@ -104,6 +106,7 @@ pub fn project(
 
     argv.extend(passthrough_tail);
 
+    // TODO(launch-actions-parity, launch-bundle-projection): interactive prompt via stdin, not positional arg
     subprocess_actions(context, argv, files, context.prompt.clone())
 }
 

--- a/src/build/project/claude.rs
+++ b/src/build/project/claude.rs
@@ -1,32 +1,235 @@
 use crate::build::bundle::{LaunchActions, LaunchBundle, RuntimeContext};
+use crate::build::project::{agent_name, approval, effort, empty_actions, model, prompt_file};
 use crate::error::MarsError;
 
-#[allow(dead_code)]
+const CLAUDE_PARENT_ALLOWED_TOOLS_FLAG: &str = "--meridian-parent-allowed-tools";
+const CLAUDE_BUILTIN_AGENT_DENY_TOOLS: &[&str] = &[
+    "Agent(Explore)",
+    "Agent(Plan)",
+    "Agent(General-purpose)",
+    "Agent(general-purpose)",
+];
+
 pub fn project(
-    _bundle: &LaunchBundle,
-    _context: &RuntimeContext,
+    bundle: &LaunchBundle,
+    context: &RuntimeContext,
 ) -> Result<LaunchActions, MarsError> {
-    Err(MarsError::InvalidRequest {
-        message: "launch_actions projection not implemented for this harness yet".to_string(),
-    })
+    let mut argv = vec![
+        "claude".to_string(),
+        "-p".to_string(),
+        "--output-format".to_string(),
+        "stream-json".to_string(),
+        "--verbose".to_string(),
+    ];
+
+    if !context.interactive {
+        argv.push("-".to_string());
+    }
+
+    if let Some(model) = model(bundle) {
+        argv.extend(["--model".to_string(), model.to_string()]);
+    }
+    if let Some(effort) = effort(bundle) {
+        argv.extend(["--effort".to_string(), claude_effort(effort).to_string()]);
+    }
+    if let Some(agent) = agent_name(bundle) {
+        argv.extend(["--agent".to_string(), agent.to_string()]);
+    }
+
+    let (passthrough_tail, parent_allowed_tools) =
+        split_internal_parent_allowed_tools(&context.extra_args);
+    let (passthrough_tail, passthrough_allowed, passthrough_disallowed) =
+        extract_claude_tool_flags(&passthrough_tail);
+
+    argv.extend(permission_tail(bundle)?);
+
+    let mut allowed_tools = Vec::new();
+    allowed_tools.extend(bundle.tools.allowed.iter().cloned());
+    allowed_tools.extend(parent_allowed_tools);
+    allowed_tools.extend(passthrough_allowed);
+
+    let mut disallowed_tools = Vec::new();
+    disallowed_tools.extend(bundle.tools.disallowed.iter().cloned());
+    disallowed_tools.extend(passthrough_disallowed);
+    disallowed_tools.extend(
+        CLAUDE_BUILTIN_AGENT_DENY_TOOLS
+            .iter()
+            .map(|tool| (*tool).to_string()),
+    );
+
+    let mut allowed_tools = dedupe_nonempty(allowed_tools);
+    allowed_tools.retain(|tool| !is_claude_agent_tool(tool));
+    let disallowed_tools = dedupe_nonempty(disallowed_tools);
+    if !disallowed_tools.is_empty() {
+        allowed_tools.retain(|tool| !is_denied_tool(tool, &disallowed_tools));
+    }
+
+    if !allowed_tools.is_empty() {
+        argv.extend(["--allowedTools".to_string(), allowed_tools.join(",")]);
+    }
+    if !disallowed_tools.is_empty() {
+        argv.extend(["--disallowedTools".to_string(), disallowed_tools.join(",")]);
+    }
+
+    for tool in &bundle.tools.mcp {
+        let normalized = tool.trim();
+        if !normalized.is_empty() {
+            argv.extend(["--mcp-config".to_string(), normalized.to_string()]);
+        }
+    }
+
+    let mut files = Vec::new();
+    let system_prompt = bundle.prompt_surface.system_instruction.trim();
+    if !system_prompt.is_empty() {
+        let file = prompt_file(context, bundle.prompt_surface.system_instruction.clone())?;
+        argv.extend(["--append-system-prompt-file".to_string(), file.path.clone()]);
+        files.push(file);
+    }
+
+    if let Some(session_id) = context
+        .session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        argv.extend(["--resume".to_string(), session_id.to_string()]);
+        if context.fork {
+            argv.push("--fork-session".to_string());
+        }
+    }
+
+    for root in &context.workspace_roots {
+        argv.extend(["--add-dir".to_string(), root.to_string()]);
+    }
+
+    argv.extend(passthrough_tail);
+
+    let mut actions = empty_actions(argv);
+    actions.files = files;
+    Ok(actions)
 }
 
-#[allow(dead_code)]
-pub fn project_subprocess(
-    _bundle: &LaunchBundle,
-    _context: &RuntimeContext,
-) -> Result<LaunchActions, MarsError> {
-    Err(MarsError::InvalidRequest {
-        message: "launch_actions projection not implemented for this harness yet".to_string(),
-    })
+fn claude_effort(effort: &str) -> &str {
+    match effort {
+        "xhigh" => "max",
+        other => other,
+    }
 }
 
-#[allow(dead_code)]
-pub fn project_streaming(
-    _bundle: &LaunchBundle,
-    _context: &RuntimeContext,
-) -> Result<LaunchActions, MarsError> {
-    Err(MarsError::InvalidRequest {
-        message: "launch_actions projection not implemented for this harness yet".to_string(),
-    })
+fn permission_tail(bundle: &LaunchBundle) -> Result<Vec<String>, MarsError> {
+    match approval(bundle) {
+        "yolo" | "never" => Ok(vec!["--dangerously-skip-permissions".to_string()]),
+        "auto" => Ok(vec![
+            "--permission-mode".to_string(),
+            "acceptEdits".to_string(),
+        ]),
+        "confirm" => Ok(vec!["--permission-mode".to_string(), "default".to_string()]),
+        "default" => Ok(Vec::new()),
+        other => Err(MarsError::InvalidRequest {
+            message: format!("Claude projection does not support approval mode '{other}'."),
+        }),
+    }
+}
+
+fn split_internal_parent_allowed_tools(extra_args: &[String]) -> (Vec<String>, Vec<String>) {
+    let mut passthrough_tail = Vec::new();
+    let mut parent_allowed_tools = Vec::new();
+    let mut index = 0;
+    while index < extra_args.len() {
+        let token = &extra_args[index];
+        if token == CLAUDE_PARENT_ALLOWED_TOOLS_FLAG {
+            if index + 1 < extra_args.len() {
+                parent_allowed_tools.extend(split_csv_entries(&extra_args[index + 1]));
+                index += 2;
+                continue;
+            }
+            index += 1;
+            continue;
+        }
+        if let Some(value) = token.strip_prefix(&format!("{CLAUDE_PARENT_ALLOWED_TOOLS_FLAG}=")) {
+            parent_allowed_tools.extend(split_csv_entries(value));
+            index += 1;
+            continue;
+        }
+        passthrough_tail.push(token.clone());
+        index += 1;
+    }
+    (passthrough_tail, dedupe_nonempty(parent_allowed_tools))
+}
+
+fn extract_claude_tool_flags(flags: &[String]) -> (Vec<String>, Vec<String>, Vec<String>) {
+    let mut projected = Vec::new();
+    let mut allowed = Vec::new();
+    let mut disallowed = Vec::new();
+    let mut index = 0;
+    while index < flags.len() {
+        let token = &flags[index];
+        if token == "--allowedTools" {
+            if index + 1 < flags.len() {
+                allowed.extend(split_csv_entries(&flags[index + 1]));
+                index += 2;
+                continue;
+            }
+            index += 1;
+            continue;
+        }
+        if let Some(value) = token.strip_prefix("--allowedTools=") {
+            allowed.extend(split_csv_entries(value));
+            index += 1;
+            continue;
+        }
+        if token == "--disallowedTools" {
+            if index + 1 < flags.len() {
+                disallowed.extend(split_csv_entries(&flags[index + 1]));
+                index += 2;
+                continue;
+            }
+            index += 1;
+            continue;
+        }
+        if let Some(value) = token.strip_prefix("--disallowedTools=") {
+            disallowed.extend(split_csv_entries(value));
+            index += 1;
+            continue;
+        }
+        projected.push(token.clone());
+        index += 1;
+    }
+    (
+        projected,
+        dedupe_nonempty(allowed),
+        dedupe_nonempty(disallowed),
+    )
+}
+
+fn split_csv_entries(value: &str) -> Vec<String> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn dedupe_nonempty(values: Vec<String>) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    let mut out = Vec::new();
+    for value in values {
+        let normalized = value.trim();
+        if normalized.is_empty() || !seen.insert(normalized.to_string()) {
+            continue;
+        }
+        out.push(normalized.to_string());
+    }
+    out
+}
+
+fn is_claude_agent_tool(tool: &str) -> bool {
+    tool == "Agent" || tool.starts_with("Agent(")
+}
+
+fn is_denied_tool(tool: &str, denied_tools: &[String]) -> bool {
+    denied_tools
+        .iter()
+        .any(|denied| denied == tool || (denied == "Agent" && is_claude_agent_tool(tool)))
 }

--- a/src/build/project/codex.rs
+++ b/src/build/project/codex.rs
@@ -62,6 +62,7 @@ pub fn project_subprocess(
         argv.extend(["-o".to_string(), report_path.to_string()]);
     }
 
+    // TODO(launch-actions-parity, launch-bundle-projection): subprocess drops base/developer instruction layers (only positional prompt)
     if let Some(prompt) = context.prompt.as_deref() {
         argv.push(prompt.to_string());
     }
@@ -69,6 +70,7 @@ pub fn project_subprocess(
     subprocess_actions(context, argv, Vec::new(), None)
 }
 
+// TODO(launch-actions-parity, launch-bundle-projection): no primary TUI attach command (`codex resume <id> --remote <ws>`)
 pub fn project_streaming(
     bundle: &LaunchBundle,
     context: &RuntimeContext,
@@ -109,6 +111,7 @@ pub fn project_streaming(
     let method = select_thread_method(context);
     let mut params = serde_json::Map::new();
     params.insert("cwd".to_string(), json!(cwd(context)?));
+    // TODO(launch-actions-parity, launch-bundle-projection): streaming sets only developerInstructions, not baseInstructions
     let system_instruction = bundle.prompt_surface.system_instruction.trim();
     if !system_instruction.is_empty() {
         params.insert(

--- a/src/build/project/codex.rs
+++ b/src/build/project/codex.rs
@@ -1,8 +1,10 @@
 use serde_json::json;
 
-use crate::build::bundle::{LaunchActions, LaunchBundle, RuntimeContext};
+use crate::build::bundle::{
+    LaunchActions, LaunchBundle, LaunchProtocol, ProtocolBootstrap, ProtocolTurn, RuntimeContext,
+};
 use crate::build::project::{
-    approval, effort, empty_actions, json_string, mcp_codex_flags, model, sandbox,
+    approval, cwd, effort, json_string, mcp_codex_flags, model, sandbox, subprocess_actions,
 };
 use crate::error::MarsError;
 
@@ -16,14 +18,7 @@ pub fn project_subprocess(
         "--json".to_string(),
     ];
 
-    let final_prompt = final_prompt(bundle, context);
     let session_id = normalized_session_id(context);
-    let guarded_prompt = if context.interactive && session_id.is_none() && !final_prompt.is_empty()
-    {
-        format!("{final_prompt}\n\nDO NOT DO ANYTHING. WAIT FOR USER INPUT.")
-    } else {
-        final_prompt
-    };
 
     if let Some(model) = model(bundle) {
         argv.extend(["--model".to_string(), model.to_string()]);
@@ -67,11 +62,11 @@ pub fn project_subprocess(
         argv.extend(["-o".to_string(), report_path.to_string()]);
     }
 
-    if !guarded_prompt.is_empty() {
-        argv.push(guarded_prompt);
+    if let Some(prompt) = context.prompt.as_deref() {
+        argv.push(prompt.to_string());
     }
 
-    Ok(empty_actions(argv))
+    subprocess_actions(context, argv, Vec::new(), None)
 }
 
 pub fn project_streaming(
@@ -113,26 +108,13 @@ pub fn project_streaming(
 
     let method = select_thread_method(context);
     let mut params = serde_json::Map::new();
-    params.insert(
-        "cwd".to_string(),
-        json!(context.cwd.as_deref().unwrap_or_default()),
-    );
-    if let Some(base) = context
-        .base_instructions
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        params.insert("baseInstructions".to_string(), json!(base));
-    }
-    let developer = context
-        .developer_instructions
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or(bundle.prompt_surface.system_instruction.trim());
-    if !developer.is_empty() {
-        params.insert("developerInstructions".to_string(), json!(developer));
+    params.insert("cwd".to_string(), json!(cwd(context)?));
+    let system_instruction = bundle.prompt_surface.system_instruction.trim();
+    if !system_instruction.is_empty() {
+        params.insert(
+            "developerInstructions".to_string(),
+            json!(system_instruction),
+        );
     }
     if let Some(model) = model(bundle) {
         params.insert("model".to_string(), json!(model));
@@ -156,32 +138,33 @@ pub fn project_streaming(
         params.insert("ephemeral".to_string(), json!(false));
     }
 
-    let mut actions = empty_actions(argv);
-    actions.protocol_payload = Some(json!({
-        "transport": "jsonrpc",
-        "method": method,
-        "params": params,
-    }));
-    Ok(actions)
+    Ok(LaunchActions::Streaming {
+        argv,
+        env: Default::default(),
+        cwd: cwd(context)?,
+        protocol: LaunchProtocol {
+            transport: "jsonrpc".to_string(),
+            bootstrap: ProtocolBootstrap {
+                method: method.to_string(),
+                path: None,
+                params: Some(json!(params)),
+                body: None,
+            },
+            turn: ProtocolTurn {
+                method: "turn/start".to_string(),
+                path_template: None,
+                params_template: Some(json!({
+                    "threadId": "{{thread_id}}",
+                    "input": build_text_user_input(context.prompt.as_deref().unwrap_or_default()),
+                })),
+                body_template: None,
+            },
+        },
+    })
 }
 
-fn final_prompt(bundle: &LaunchBundle, context: &RuntimeContext) -> String {
-    let base = context.base_instructions.as_deref().unwrap_or("");
-    let developer = context
-        .developer_instructions
-        .as_deref()
-        .unwrap_or(bundle.prompt_surface.system_instruction.as_str());
-    let prompt = context
-        .user_turn_content
-        .as_deref()
-        .or(context.prompt.as_deref())
-        .unwrap_or("");
-    [base, developer, prompt]
-        .into_iter()
-        .map(str::trim)
-        .filter(|part| !part.is_empty())
-        .collect::<Vec<_>>()
-        .join("\n\n")
+fn build_text_user_input(text: &str) -> serde_json::Value {
+    json!([{ "type": "text", "text": text }])
 }
 
 fn normalized_session_id(context: &RuntimeContext) -> Option<String> {

--- a/src/build/project/codex.rs
+++ b/src/build/project/codex.rs
@@ -1,0 +1,32 @@
+use crate::build::bundle::{LaunchActions, LaunchBundle, RuntimeContext};
+use crate::error::MarsError;
+
+#[allow(dead_code)]
+pub fn project(
+    _bundle: &LaunchBundle,
+    _context: &RuntimeContext,
+) -> Result<LaunchActions, MarsError> {
+    Err(MarsError::InvalidRequest {
+        message: "launch_actions projection not implemented for this harness yet".to_string(),
+    })
+}
+
+#[allow(dead_code)]
+pub fn project_subprocess(
+    _bundle: &LaunchBundle,
+    _context: &RuntimeContext,
+) -> Result<LaunchActions, MarsError> {
+    Err(MarsError::InvalidRequest {
+        message: "launch_actions projection not implemented for this harness yet".to_string(),
+    })
+}
+
+#[allow(dead_code)]
+pub fn project_streaming(
+    _bundle: &LaunchBundle,
+    _context: &RuntimeContext,
+) -> Result<LaunchActions, MarsError> {
+    Err(MarsError::InvalidRequest {
+        message: "launch_actions projection not implemented for this harness yet".to_string(),
+    })
+}

--- a/src/build/project/codex.rs
+++ b/src/build/project/codex.rs
@@ -1,32 +1,232 @@
+use serde_json::json;
+
 use crate::build::bundle::{LaunchActions, LaunchBundle, RuntimeContext};
+use crate::build::project::{
+    approval, effort, empty_actions, json_string, mcp_codex_flags, model, sandbox,
+};
 use crate::error::MarsError;
 
-#[allow(dead_code)]
-pub fn project(
-    _bundle: &LaunchBundle,
-    _context: &RuntimeContext,
-) -> Result<LaunchActions, MarsError> {
-    Err(MarsError::InvalidRequest {
-        message: "launch_actions projection not implemented for this harness yet".to_string(),
-    })
-}
-
-#[allow(dead_code)]
 pub fn project_subprocess(
-    _bundle: &LaunchBundle,
-    _context: &RuntimeContext,
+    bundle: &LaunchBundle,
+    context: &RuntimeContext,
 ) -> Result<LaunchActions, MarsError> {
-    Err(MarsError::InvalidRequest {
-        message: "launch_actions projection not implemented for this harness yet".to_string(),
-    })
+    let mut argv = vec![
+        "codex".to_string(),
+        "exec".to_string(),
+        "--json".to_string(),
+    ];
+
+    let final_prompt = final_prompt(bundle, context);
+    let session_id = normalized_session_id(context);
+    let guarded_prompt = if context.interactive && session_id.is_none() && !final_prompt.is_empty()
+    {
+        format!("{final_prompt}\n\nDO NOT DO ANYTHING. WAIT FOR USER INPUT.")
+    } else {
+        final_prompt
+    };
+
+    if let Some(model) = model(bundle) {
+        argv.extend(["--model".to_string(), model.to_string()]);
+    }
+    if let Some(effort) = effort(bundle) {
+        argv.extend([
+            "-c".to_string(),
+            format!("model_reasoning_effort={}", json_string(effort)),
+        ]);
+    }
+
+    if let Some(sandbox) = map_codex_sandbox_mode(sandbox(bundle))? {
+        argv.extend(["--sandbox".to_string(), sandbox.to_string()]);
+    }
+    if let Some(approval) = map_codex_approval_policy(approval(bundle))? {
+        argv.extend([
+            "-c".to_string(),
+            format!("approval_policy={}", json_string(approval)),
+        ]);
+    }
+
+    argv.extend(mcp_codex_flags(&bundle.tools.mcp)?);
+
+    if let Some(session_id) = session_id {
+        argv.extend(["resume".to_string(), session_id]);
+    }
+
+    for root in &context.workspace_roots {
+        argv.extend(["--add-dir".to_string(), root.clone()]);
+    }
+
+    argv.extend(context.extra_args.iter().cloned());
+
+    if !context.interactive
+        && let Some(report_path) = context
+            .report_output_path
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+    {
+        argv.extend(["-o".to_string(), report_path.to_string()]);
+    }
+
+    if !guarded_prompt.is_empty() {
+        argv.push(guarded_prompt);
+    }
+
+    Ok(empty_actions(argv))
 }
 
-#[allow(dead_code)]
 pub fn project_streaming(
-    _bundle: &LaunchBundle,
-    _context: &RuntimeContext,
+    bundle: &LaunchBundle,
+    context: &RuntimeContext,
 ) -> Result<LaunchActions, MarsError> {
-    Err(MarsError::InvalidRequest {
-        message: "launch_actions projection not implemented for this harness yet".to_string(),
-    })
+    let (host, port) = crate::build::project::streaming_context(context)?;
+    let mut argv = vec![
+        "codex".to_string(),
+        "app-server".to_string(),
+        "--listen".to_string(),
+        format!("ws://{host}:{port}"),
+    ];
+
+    if let Some(sandbox) = map_codex_sandbox_mode(sandbox(bundle))? {
+        argv.extend([
+            "-c".to_string(),
+            format!("sandbox_mode={}", json_string(sandbox)),
+        ]);
+    }
+    if let Some(approval) = map_codex_approval_policy(approval(bundle))? {
+        argv.extend([
+            "-c".to_string(),
+            format!("approval_policy={}", json_string(approval)),
+        ]);
+    }
+    argv.extend(mcp_codex_flags(&bundle.tools.mcp)?);
+    if !context.workspace_roots.is_empty() {
+        argv.extend([
+            "-c".to_string(),
+            format!(
+                "sandbox_workspace_write.writable_roots={}",
+                serde_json::to_string(&context.workspace_roots)
+                    .expect("JSON serialization cannot fail")
+            ),
+        ]);
+    }
+    argv.extend(context.extra_args.iter().cloned());
+
+    let method = select_thread_method(context);
+    let mut params = serde_json::Map::new();
+    params.insert(
+        "cwd".to_string(),
+        json!(context.cwd.as_deref().unwrap_or_default()),
+    );
+    if let Some(base) = context
+        .base_instructions
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        params.insert("baseInstructions".to_string(), json!(base));
+    }
+    let developer = context
+        .developer_instructions
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(bundle.prompt_surface.system_instruction.trim());
+    if !developer.is_empty() {
+        params.insert("developerInstructions".to_string(), json!(developer));
+    }
+    if let Some(model) = model(bundle) {
+        params.insert("model".to_string(), json!(model));
+    }
+    if let Some(effort) = effort(bundle) {
+        params.insert(
+            "config".to_string(),
+            json!({ "model_reasoning_effort": effort }),
+        );
+    }
+    if let Some(approval) = map_codex_approval_policy(approval(bundle))? {
+        params.insert("approvalPolicy".to_string(), json!(approval));
+    }
+    if let Some(sandbox) = map_codex_sandbox_mode(sandbox(bundle))? {
+        params.insert("sandbox".to_string(), json!(sandbox));
+    }
+    if let Some(session_id) = normalized_session_id(context) {
+        params.insert("threadId".to_string(), json!(session_id));
+    }
+    if method == "thread/fork" {
+        params.insert("ephemeral".to_string(), json!(false));
+    }
+
+    let mut actions = empty_actions(argv);
+    actions.protocol_payload = Some(json!({
+        "transport": "jsonrpc",
+        "method": method,
+        "params": params,
+    }));
+    Ok(actions)
+}
+
+fn final_prompt(bundle: &LaunchBundle, context: &RuntimeContext) -> String {
+    let base = context.base_instructions.as_deref().unwrap_or("");
+    let developer = context
+        .developer_instructions
+        .as_deref()
+        .unwrap_or(bundle.prompt_surface.system_instruction.as_str());
+    let prompt = context
+        .user_turn_content
+        .as_deref()
+        .or(context.prompt.as_deref())
+        .unwrap_or("");
+    [base, developer, prompt]
+        .into_iter()
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn normalized_session_id(context: &RuntimeContext) -> Option<String> {
+    context
+        .session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
+fn select_thread_method(context: &RuntimeContext) -> &'static str {
+    if normalized_session_id(context).is_none() {
+        "thread/start"
+    } else if context.fork {
+        "thread/fork"
+    } else {
+        "thread/resume"
+    }
+}
+
+fn map_codex_approval_policy(mode: &str) -> Result<Option<&'static str>, MarsError> {
+    match mode {
+        "default" => Ok(None),
+        "auto" => Ok(Some("on-request")),
+        "confirm" => Ok(Some("untrusted")),
+        "never" | "yolo" => Ok(Some("never")),
+        other => Err(MarsError::InvalidRequest {
+            message: format!(
+                "Codex cannot express requested approval mode '{other}' on this CLI/protocol version"
+            ),
+        }),
+    }
+}
+
+fn map_codex_sandbox_mode(mode: &str) -> Result<Option<&'static str>, MarsError> {
+    match mode {
+        "default" => Ok(None),
+        "read-only" => Ok(Some("read-only")),
+        "workspace-write" => Ok(Some("workspace-write")),
+        "danger-full-access" => Ok(Some("danger-full-access")),
+        other => Err(MarsError::InvalidRequest {
+            message: format!(
+                "Codex cannot express requested sandbox mode '{other}' on this CLI/protocol version"
+            ),
+        }),
+    }
 }

--- a/src/build/project/cursor.rs
+++ b/src/build/project/cursor.rs
@@ -1,0 +1,86 @@
+use crate::build::bundle::{LaunchActions, LaunchBundle, RuntimeContext};
+use crate::build::project::{approval, empty_actions, model, sandbox};
+use crate::error::MarsError;
+
+pub fn project(
+    bundle: &LaunchBundle,
+    context: &RuntimeContext,
+) -> Result<LaunchActions, MarsError> {
+    if !bundle.tools.mcp.is_empty() {
+        return Err(MarsError::InvalidRequest {
+            message: "Cursor subprocess does not support per-spawn mcp_tools for MVP.".to_string(),
+        });
+    }
+    if context.fork {
+        return Err(MarsError::InvalidRequest {
+            message: "Cursor subprocess continue_fork is not supported for MVP.".to_string(),
+        });
+    }
+    if !context
+        .session_id
+        .as_deref()
+        .unwrap_or("")
+        .trim()
+        .is_empty()
+    {
+        return Err(MarsError::InvalidRequest {
+            message: "Cursor subprocess session resume is not supported for MVP.".to_string(),
+        });
+    }
+    if context.interactive {
+        return Err(MarsError::InvalidRequest {
+            message: "Cursor subprocess interactive mode is not supported for MVP.".to_string(),
+        });
+    }
+
+    let mut argv = vec![
+        "cursor".to_string(),
+        "agent".to_string(),
+        "--print".to_string(),
+        "--output-format".to_string(),
+        "stream-json".to_string(),
+        "--trust".to_string(),
+    ];
+
+    if let Some(model) = model(bundle) {
+        argv.extend(["--model".to_string(), model.to_string()]);
+    }
+
+    match approval(bundle) {
+        "yolo" | "never" => argv.push("--yolo".to_string()),
+        "auto" => argv.push("--force".to_string()),
+        "default" | "confirm" => {}
+        other => {
+            return Err(MarsError::InvalidRequest {
+                message: format!("Cursor projection does not support approval mode '{other}'."),
+            });
+        }
+    }
+
+    match sandbox(bundle) {
+        "default" => {}
+        "read-only" => argv.extend(["--sandbox".to_string(), "enabled".to_string()]),
+        "workspace-write" | "danger-full-access" => {
+            argv.extend(["--sandbox".to_string(), "disabled".to_string()]);
+        }
+        other => {
+            return Err(MarsError::InvalidRequest {
+                message: format!("Cursor projection does not support sandbox mode '{other}'."),
+            });
+        }
+    }
+
+    if let Some(cwd) = context
+        .cwd
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        argv.extend(["--workspace".to_string(), cwd.to_string()]);
+    }
+
+    argv.extend(context.extra_args.iter().cloned());
+    argv.push(context.prompt.clone().unwrap_or_default());
+
+    Ok(empty_actions(argv))
+}

--- a/src/build/project/cursor.rs
+++ b/src/build/project/cursor.rs
@@ -1,5 +1,5 @@
 use crate::build::bundle::{LaunchActions, LaunchBundle, RuntimeContext};
-use crate::build::project::{approval, empty_actions, model, sandbox};
+use crate::build::project::{approval, cwd, model, sandbox, subprocess_actions};
 use crate::error::MarsError;
 
 pub fn project(
@@ -70,17 +70,12 @@ pub fn project(
         }
     }
 
-    if let Some(cwd) = context
-        .cwd
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        argv.extend(["--workspace".to_string(), cwd.to_string()]);
-    }
+    argv.extend(["--workspace".to_string(), cwd(context)?]);
 
     argv.extend(context.extra_args.iter().cloned());
-    argv.push(context.prompt.clone().unwrap_or_default());
+    if let Some(prompt) = context.prompt.as_deref() {
+        argv.push(prompt.to_string());
+    }
 
-    Ok(empty_actions(argv))
+    subprocess_actions(context, argv, Vec::new(), None)
 }

--- a/src/build/project/mod.rs
+++ b/src/build/project/mod.rs
@@ -81,7 +81,6 @@ fn sandbox(bundle: &LaunchBundle) -> &str {
         .unwrap_or("default")
 }
 
-#[allow(dead_code)]
 fn effort(bundle: &LaunchBundle) -> Option<&str> {
     bundle
         .execution_policy
@@ -96,7 +95,6 @@ fn model(bundle: &LaunchBundle) -> Option<&str> {
     if value.is_empty() { None } else { Some(value) }
 }
 
-#[allow(dead_code)]
 fn agent_name(bundle: &LaunchBundle) -> Option<&str> {
     bundle
         .agent
@@ -114,12 +112,10 @@ fn empty_actions(argv: Vec<String>) -> LaunchActions {
     }
 }
 
-#[allow(dead_code)]
 fn json_string(value: &str) -> String {
     serde_json::to_string(value).expect("string serialization cannot fail")
 }
 
-#[allow(dead_code)]
 fn mcp_codex_flags(entries: &[String]) -> Result<Vec<String>, MarsError> {
     let mut flags = Vec::new();
     for raw in entries {
@@ -148,7 +144,6 @@ fn mcp_codex_flags(entries: &[String]) -> Result<Vec<String>, MarsError> {
     Ok(flags)
 }
 
-#[allow(dead_code)]
 fn opencode_workspace_env(context: &RuntimeContext) -> Option<String> {
     if context.workspace_roots.is_empty() {
         return None;
@@ -202,7 +197,6 @@ fn opencode_workspace_env(context: &RuntimeContext) -> Option<String> {
     )
 }
 
-#[allow(dead_code)]
 fn prompt_file(context: &RuntimeContext, content: String) -> Result<LaunchFile, MarsError> {
     let temp_dir = context
         .temp_dir
@@ -217,7 +211,6 @@ fn prompt_file(context: &RuntimeContext, content: String) -> Result<LaunchFile, 
     })
 }
 
-#[allow(dead_code)]
 fn streaming_context(context: &RuntimeContext) -> Result<(&str, u16), MarsError> {
     context
         .streaming

--- a/src/build/project/mod.rs
+++ b/src/build/project/mod.rs
@@ -1,3 +1,20 @@
+//! EXPERIMENTAL per-harness `launch_actions` projection (`mars build launch-bundle --context`).
+//!
+//! Not consumed by meridian-cli (invariant I-2). Meridian owns launch argv/env in its harness
+//! adapters. This module is slated for possible deletion — see work item `launch-bundle-projection` / PR #94.
+//!
+//! Parity TODOs in harness projectors document gaps vs meridian adapters for anyone reviving Phase 2.
+//! A second class of gaps (MERIDIAN_* env protocol, session preflight, permission→flag model) is
+//! intentionally meridian-owned and will never be mars's responsibility.
+//!
+//! To delete the experimental launch_actions projection:
+//! - src/build/project/*            (this module: per-harness projectors + project_launch_actions)
+//! - src/build/bundle.rs            (launch_actions field; LaunchActions/LaunchFile/LaunchProtocol/RuntimeContext/StreamingContext)
+//! - src/build/mod.rs               (runtime_context/transport on request; the `if let Some(context)` gate)
+//! - src/cli/build.rs               (--context/--transport args + RuntimeContext parse + the warning)
+//!
+//! launch_actions is Option (serde-skipped when None), so removal needs no version bump.
+
 use std::collections::BTreeMap;
 
 use serde_json::json;

--- a/src/build/project/mod.rs
+++ b/src/build/project/mod.rs
@@ -1,0 +1,229 @@
+use std::collections::BTreeMap;
+
+use serde_json::json;
+
+use crate::build::bundle::{LaunchActions, LaunchBundle, LaunchFile, RuntimeContext};
+use crate::error::MarsError;
+use crate::harness::registry::{HarnessId, parse as parse_harness};
+
+mod claude;
+mod codex;
+mod cursor;
+mod opencode;
+mod pi;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Transport {
+    Subprocess,
+    Streaming,
+}
+
+impl Transport {
+    pub fn parse(value: &str) -> Result<Self, MarsError> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "subprocess" => Ok(Self::Subprocess),
+            "streaming" => Ok(Self::Streaming),
+            other => Err(MarsError::InvalidRequest {
+                message: format!(
+                    "unsupported launch-bundle transport `{other}`; expected subprocess or streaming"
+                ),
+            }),
+        }
+    }
+}
+
+pub fn project_launch_actions(
+    bundle: &LaunchBundle,
+    context: &RuntimeContext,
+    transport: Transport,
+) -> Result<LaunchActions, MarsError> {
+    let harness = parse_harness(&bundle.routing.harness).ok_or_else(|| {
+        MarsError::Internal(format!(
+            "launch-bundle routing selected unknown harness `{}`",
+            bundle.routing.harness
+        ))
+    })?;
+
+    match (harness, transport) {
+        (HarnessId::Cursor, Transport::Subprocess) => cursor::project(bundle, context),
+        (HarnessId::Claude, Transport::Subprocess) => claude::project(bundle, context),
+        (HarnessId::Codex, Transport::Subprocess) => codex::project_subprocess(bundle, context),
+        (HarnessId::Codex, Transport::Streaming) => codex::project_streaming(bundle, context),
+        (HarnessId::OpenCode, Transport::Subprocess) => {
+            opencode::project_subprocess(bundle, context)
+        }
+        (HarnessId::OpenCode, Transport::Streaming) => opencode::project_streaming(bundle, context),
+        (HarnessId::Pi, Transport::Subprocess) => pi::project(bundle, context),
+        (HarnessId::Claude | HarnessId::Cursor | HarnessId::Pi, Transport::Streaming) => {
+            Err(MarsError::InvalidRequest {
+                message: format!(
+                    "harness `{}` does not support launch_actions transport `streaming`",
+                    bundle.routing.harness
+                ),
+            })
+        }
+    }
+}
+
+fn approval(bundle: &LaunchBundle) -> &str {
+    bundle
+        .execution_policy
+        .approval
+        .as_deref()
+        .unwrap_or("default")
+}
+
+fn sandbox(bundle: &LaunchBundle) -> &str {
+    bundle
+        .execution_policy
+        .sandbox
+        .as_deref()
+        .unwrap_or("default")
+}
+
+#[allow(dead_code)]
+fn effort(bundle: &LaunchBundle) -> Option<&str> {
+    bundle
+        .execution_policy
+        .effort
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn model(bundle: &LaunchBundle) -> Option<&str> {
+    let value = bundle.routing.harness_model.trim();
+    if value.is_empty() { None } else { Some(value) }
+}
+
+#[allow(dead_code)]
+fn agent_name(bundle: &LaunchBundle) -> Option<&str> {
+    bundle
+        .agent
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn empty_actions(argv: Vec<String>) -> LaunchActions {
+    LaunchActions {
+        argv,
+        env: BTreeMap::new(),
+        files: Vec::new(),
+        protocol_payload: None,
+    }
+}
+
+#[allow(dead_code)]
+fn json_string(value: &str) -> String {
+    serde_json::to_string(value).expect("string serialization cannot fail")
+}
+
+#[allow(dead_code)]
+fn mcp_codex_flags(entries: &[String]) -> Result<Vec<String>, MarsError> {
+    let mut flags = Vec::new();
+    for raw in entries {
+        let entry = raw.trim();
+        if entry.is_empty() {
+            continue;
+        }
+        let (name, command) = entry
+            .split_once('=')
+            .ok_or_else(|| MarsError::InvalidRequest {
+                message: format!("Codex mcp_tools entries must be '<name>=<command>'; got {raw:?}"),
+            })?;
+        let name = name.trim();
+        let command = command.trim();
+        if name.is_empty() || command.is_empty() {
+            return Err(MarsError::InvalidRequest {
+                message: format!("Codex mcp_tools entries must be '<name>=<command>'; got {raw:?}"),
+            });
+        }
+        flags.push("-c".to_string());
+        flags.push(format!(
+            "mcp.servers.{name}.command={}",
+            json_string(command)
+        ));
+    }
+    Ok(flags)
+}
+
+#[allow(dead_code)]
+fn opencode_workspace_env(context: &RuntimeContext) -> Option<String> {
+    if context.workspace_roots.is_empty() {
+        return None;
+    }
+
+    let mut merged = match context
+        .opencode_config_content
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .and_then(|value| serde_json::from_str::<serde_json::Value>(value).ok())
+    {
+        Some(serde_json::Value::Object(map)) => map,
+        _ => serde_json::Map::new(),
+    };
+
+    let permission = merged
+        .remove("permission")
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+    let mut permission = permission;
+
+    let external_raw = permission.remove("external_directory");
+    let mut external = match external_raw {
+        Some(serde_json::Value::Object(map)) => map
+            .into_iter()
+            .map(|(key, value)| (key, value.as_str().unwrap_or("").to_string()))
+            .collect::<BTreeMap<_, _>>(),
+        Some(serde_json::Value::Array(values)) => values
+            .into_iter()
+            .map(|value| {
+                (
+                    value.as_str().unwrap_or("").to_string(),
+                    "allow".to_string(),
+                )
+            })
+            .collect::<BTreeMap<_, _>>(),
+        _ => BTreeMap::new(),
+    };
+    external.retain(|path, _| !path.is_empty());
+
+    for root in &context.workspace_roots {
+        external.insert(format!("{root}/**"), "allow".to_string());
+    }
+
+    permission.insert("external_directory".to_string(), json!(external));
+    merged.insert("permission".to_string(), json!(permission));
+    Some(
+        serde_json::to_string(&serde_json::Value::Object(merged))
+            .expect("JSON serialization cannot fail"),
+    )
+}
+
+#[allow(dead_code)]
+fn prompt_file(context: &RuntimeContext, content: String) -> Result<LaunchFile, MarsError> {
+    let temp_dir = context
+        .temp_dir
+        .as_deref()
+        .ok_or_else(|| MarsError::InvalidRequest {
+            message: "launch-bundle --context must include temp_dir for prompt file projection"
+                .to_string(),
+        })?;
+    Ok(LaunchFile {
+        path: format!("{}/prompt.md", temp_dir.trim_end_matches(['/', '\\'])),
+        content,
+    })
+}
+
+#[allow(dead_code)]
+fn streaming_context(context: &RuntimeContext) -> Result<(&str, u16), MarsError> {
+    context
+        .streaming
+        .as_ref()
+        .map(|streaming| (streaming.host.as_str(), streaming.port))
+        .ok_or_else(|| MarsError::InvalidRequest {
+            message: "launch-bundle --transport streaming requires context.streaming".to_string(),
+        })
+}

--- a/src/build/project/mod.rs
+++ b/src/build/project/mod.rs
@@ -103,13 +103,32 @@ fn agent_name(bundle: &LaunchBundle) -> Option<&str> {
         .filter(|value| !value.is_empty())
 }
 
-fn empty_actions(argv: Vec<String>) -> LaunchActions {
-    LaunchActions {
+fn cwd(context: &RuntimeContext) -> Result<String, MarsError> {
+    context
+        .cwd
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+        .ok_or_else(|| MarsError::InvalidRequest {
+            message: "launch-bundle --context must include cwd for launch_actions projection"
+                .to_string(),
+        })
+}
+
+fn subprocess_actions(
+    context: &RuntimeContext,
+    argv: Vec<String>,
+    files: Vec<LaunchFile>,
+    stdin: Option<String>,
+) -> Result<LaunchActions, MarsError> {
+    Ok(LaunchActions::Subprocess {
         argv,
         env: BTreeMap::new(),
-        files: Vec::new(),
-        protocol_payload: None,
-    }
+        cwd: cwd(context)?,
+        files,
+        stdin,
+    })
 }
 
 fn json_string(value: &str) -> String {

--- a/src/build/project/opencode.rs
+++ b/src/build/project/opencode.rs
@@ -1,32 +1,131 @@
+use std::collections::BTreeMap;
+
+use serde_json::json;
+
 use crate::build::bundle::{LaunchActions, LaunchBundle, RuntimeContext};
+use crate::build::project::{
+    effort, empty_actions, model, opencode_workspace_env, streaming_context,
+};
 use crate::error::MarsError;
 
-#[allow(dead_code)]
-pub fn project(
-    _bundle: &LaunchBundle,
-    _context: &RuntimeContext,
-) -> Result<LaunchActions, MarsError> {
-    Err(MarsError::InvalidRequest {
-        message: "launch_actions projection not implemented for this harness yet".to_string(),
-    })
-}
-
-#[allow(dead_code)]
 pub fn project_subprocess(
-    _bundle: &LaunchBundle,
-    _context: &RuntimeContext,
+    bundle: &LaunchBundle,
+    context: &RuntimeContext,
 ) -> Result<LaunchActions, MarsError> {
-    Err(MarsError::InvalidRequest {
-        message: "launch_actions projection not implemented for this harness yet".to_string(),
+    if bundle
+        .tools
+        .mcp
+        .iter()
+        .any(|entry| !entry.trim().is_empty())
+    {
+        return Err(MarsError::InvalidRequest {
+            message: "OpenCode subprocess does not support per-spawn mcp_tools; use streaming transport (opencode serve) for MCP session payloads.".to_string(),
+        });
+    }
+
+    let mut argv = vec!["opencode".to_string(), "run".to_string()];
+    if let Some(model) = model(bundle) {
+        argv.extend(["--model".to_string(), normalize_opencode_model(model)]);
+    }
+    if let Some(effort) = effort(bundle).filter(|_| !context.interactive) {
+        argv.extend(["--variant".to_string(), effort.to_string()]);
+    }
+
+    argv.extend(context.extra_args.iter().cloned());
+
+    if !context.interactive {
+        argv.push("-".to_string());
+    }
+
+    if let Some(session_id) = context
+        .session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        argv.extend(["--session".to_string(), session_id.to_string()]);
+        if context.fork {
+            argv.push("--fork".to_string());
+        }
+    }
+
+    let mut actions = empty_actions(argv);
+    if let Some(config) = opencode_workspace_env(context) {
+        actions
+            .env
+            .insert("OPENCODE_CONFIG_CONTENT".to_string(), config);
+    }
+    Ok(actions)
+}
+
+pub fn project_streaming(
+    bundle: &LaunchBundle,
+    context: &RuntimeContext,
+) -> Result<LaunchActions, MarsError> {
+    if context.fork {
+        return Err(MarsError::InvalidRequest {
+            message: "OpenCode streaming cannot express continue_fork semantics over the current /session API.".to_string(),
+        });
+    }
+    let (host, port) = streaming_context(context)?;
+    let mut argv = vec![
+        "opencode".to_string(),
+        "serve".to_string(),
+        "--hostname".to_string(),
+        host.to_string(),
+        "--port".to_string(),
+        port.to_string(),
+    ];
+    argv.extend(context.extra_args.iter().cloned());
+
+    let mut env = BTreeMap::new();
+    if let Some(config) = opencode_workspace_env(context) {
+        env.insert("OPENCODE_CONFIG_CONTENT".to_string(), config);
+    }
+
+    let mut body = serde_json::Map::new();
+    if let Some(model) = model(bundle) {
+        let normalized = normalize_opencode_model(model);
+        body.insert("model".to_string(), json!(normalized));
+        body.insert("modelID".to_string(), json!(normalized));
+    }
+    if let Some(agent) = crate::build::project::agent_name(bundle) {
+        body.insert("agent".to_string(), json!(agent));
+    }
+    let mcp = bundle
+        .tools
+        .mcp
+        .iter()
+        .map(|entry| entry.trim())
+        .filter(|entry| !entry.is_empty())
+        .collect::<Vec<_>>();
+    if !mcp.is_empty() {
+        body.insert("mcp".to_string(), json!({ "servers": mcp }));
+    }
+
+    Ok(LaunchActions {
+        argv,
+        env,
+        files: Vec::new(),
+        protocol_payload: Some(json!({
+            "transport": "http",
+            "method": "POST",
+            "path": "/session",
+            "body": body,
+        })),
     })
 }
 
-#[allow(dead_code)]
-pub fn project_streaming(
-    _bundle: &LaunchBundle,
-    _context: &RuntimeContext,
-) -> Result<LaunchActions, MarsError> {
-    Err(MarsError::InvalidRequest {
-        message: "launch_actions projection not implemented for this harness yet".to_string(),
-    })
+fn normalize_opencode_model(model: &str) -> String {
+    let normalized = model.trim();
+    let Some((provider, model_name)) = normalized.split_once('/') else {
+        return normalized.to_string();
+    };
+    let provider = provider.trim();
+    let model_name = model_name.trim();
+    if provider.is_empty() || model_name.is_empty() {
+        normalized.to_string()
+    } else {
+        format!("{provider}/{model_name}")
+    }
 }

--- a/src/build/project/opencode.rs
+++ b/src/build/project/opencode.rs
@@ -25,10 +25,13 @@ pub fn project_subprocess(
         });
     }
 
+    // TODO(launch-actions-parity, launch-bundle-projection): subprocess emits no `--agent <name>` flag
+    // TODO(launch-actions-parity, launch-bundle-projection): interactive emits `opencode run`, not managed serve+HTTP attach
     let mut argv = vec!["opencode".to_string(), "run".to_string()];
     if let Some(model) = model(bundle) {
         argv.extend(["--model".to_string(), model.to_string()]);
     }
+    // TODO(launch-actions-parity, launch-bundle-projection): interactive emits `opencode run`, not managed serve+HTTP attach
     if let Some(effort) = effort(bundle).filter(|_| !context.interactive) {
         argv.extend(["--variant".to_string(), effort.to_string()]);
     }
@@ -39,6 +42,7 @@ pub fn project_subprocess(
         argv.push("-".to_string());
     }
 
+    // TODO(launch-actions-parity, launch-bundle-projection): interactive emits `opencode run`, not managed serve+HTTP attach
     if let Some(session_id) = context
         .session_id
         .as_deref()
@@ -60,6 +64,7 @@ pub fn project_subprocess(
     Ok(actions)
 }
 
+// TODO(launch-actions-parity, launch-bundle-projection): streaming has no session resume (always POST /session)
 pub fn project_streaming(
     bundle: &LaunchBundle,
     context: &RuntimeContext,
@@ -85,6 +90,7 @@ pub fn project_streaming(
         env.insert("OPENCODE_CONFIG_CONTENT".to_string(), config);
     }
 
+    // TODO(launch-actions-parity, launch-bundle-projection): streaming bootstrap omits agent/skills
     let mut body = serde_json::Map::new();
     if let Some(model) = model(bundle) {
         body.insert("model".to_string(), json!(model));

--- a/src/build/project/opencode.rs
+++ b/src/build/project/opencode.rs
@@ -1,0 +1,32 @@
+use crate::build::bundle::{LaunchActions, LaunchBundle, RuntimeContext};
+use crate::error::MarsError;
+
+#[allow(dead_code)]
+pub fn project(
+    _bundle: &LaunchBundle,
+    _context: &RuntimeContext,
+) -> Result<LaunchActions, MarsError> {
+    Err(MarsError::InvalidRequest {
+        message: "launch_actions projection not implemented for this harness yet".to_string(),
+    })
+}
+
+#[allow(dead_code)]
+pub fn project_subprocess(
+    _bundle: &LaunchBundle,
+    _context: &RuntimeContext,
+) -> Result<LaunchActions, MarsError> {
+    Err(MarsError::InvalidRequest {
+        message: "launch_actions projection not implemented for this harness yet".to_string(),
+    })
+}
+
+#[allow(dead_code)]
+pub fn project_streaming(
+    _bundle: &LaunchBundle,
+    _context: &RuntimeContext,
+) -> Result<LaunchActions, MarsError> {
+    Err(MarsError::InvalidRequest {
+        message: "launch_actions projection not implemented for this harness yet".to_string(),
+    })
+}

--- a/src/build/project/opencode.rs
+++ b/src/build/project/opencode.rs
@@ -25,7 +25,7 @@ pub fn project_subprocess(
 
     let mut argv = vec!["opencode".to_string(), "run".to_string()];
     if let Some(model) = model(bundle) {
-        argv.extend(["--model".to_string(), normalize_opencode_model(model)]);
+        argv.extend(["--model".to_string(), model.to_string()]);
     }
     if let Some(effort) = effort(bundle).filter(|_| !context.interactive) {
         argv.extend(["--variant".to_string(), effort.to_string()]);
@@ -85,9 +85,8 @@ pub fn project_streaming(
 
     let mut body = serde_json::Map::new();
     if let Some(model) = model(bundle) {
-        let normalized = normalize_opencode_model(model);
-        body.insert("model".to_string(), json!(normalized));
-        body.insert("modelID".to_string(), json!(normalized));
+        body.insert("model".to_string(), json!(model));
+        body.insert("modelID".to_string(), json!(model));
     }
     let mcp = bundle
         .tools
@@ -111,18 +110,4 @@ pub fn project_streaming(
             "body": body,
         })),
     })
-}
-
-fn normalize_opencode_model(model: &str) -> String {
-    let normalized = model.trim();
-    let Some((provider, model_name)) = normalized.split_once('/') else {
-        return normalized.to_string();
-    };
-    let provider = provider.trim();
-    let model_name = model_name.trim();
-    if provider.is_empty() || model_name.is_empty() {
-        normalized.to_string()
-    } else {
-        format!("{provider}/{model_name}")
-    }
 }

--- a/src/build/project/opencode.rs
+++ b/src/build/project/opencode.rs
@@ -2,9 +2,11 @@ use std::collections::BTreeMap;
 
 use serde_json::json;
 
-use crate::build::bundle::{LaunchActions, LaunchBundle, RuntimeContext};
+use crate::build::bundle::{
+    LaunchActions, LaunchBundle, LaunchProtocol, ProtocolBootstrap, ProtocolTurn, RuntimeContext,
+};
 use crate::build::project::{
-    effort, empty_actions, model, opencode_workspace_env, streaming_context,
+    cwd, effort, model, opencode_workspace_env, streaming_context, subprocess_actions,
 };
 use crate::error::MarsError;
 
@@ -49,11 +51,11 @@ pub fn project_subprocess(
         }
     }
 
-    let mut actions = empty_actions(argv);
-    if let Some(config) = opencode_workspace_env(context) {
-        actions
-            .env
-            .insert("OPENCODE_CONFIG_CONTENT".to_string(), config);
+    let mut actions = subprocess_actions(context, argv, Vec::new(), context.prompt.clone())?;
+    if let Some(config) = opencode_workspace_env(context)
+        && let LaunchActions::Subprocess { env, .. } = &mut actions
+    {
+        env.insert("OPENCODE_CONFIG_CONTENT".to_string(), config);
     }
     Ok(actions)
 }
@@ -99,15 +101,34 @@ pub fn project_streaming(
         body.insert("mcp".to_string(), json!({ "servers": mcp }));
     }
 
-    Ok(LaunchActions {
+    let mut turn_body = serde_json::Map::new();
+    turn_body.insert(
+        "parts".to_string(),
+        json!([{ "type": "text", "text": context.prompt.as_deref().unwrap_or_default() }]),
+    );
+    let system_instruction = bundle.prompt_surface.system_instruction.trim();
+    if !system_instruction.is_empty() {
+        turn_body.insert("system".to_string(), json!(system_instruction));
+    }
+
+    Ok(LaunchActions::Streaming {
         argv,
         env,
-        files: Vec::new(),
-        protocol_payload: Some(json!({
-            "transport": "http",
-            "method": "POST",
-            "path": "/session",
-            "body": body,
-        })),
+        cwd: cwd(context)?,
+        protocol: LaunchProtocol {
+            transport: "http".to_string(),
+            bootstrap: ProtocolBootstrap {
+                method: "POST".to_string(),
+                path: Some("/session".to_string()),
+                params: None,
+                body: Some(json!(body)),
+            },
+            turn: ProtocolTurn {
+                method: "POST".to_string(),
+                path_template: Some("/session/{session_id}/prompt_async".to_string()),
+                params_template: None,
+                body_template: Some(json!(turn_body)),
+            },
+        },
     })
 }

--- a/src/build/project/opencode.rs
+++ b/src/build/project/opencode.rs
@@ -89,9 +89,6 @@ pub fn project_streaming(
         body.insert("model".to_string(), json!(normalized));
         body.insert("modelID".to_string(), json!(normalized));
     }
-    if let Some(agent) = crate::build::project::agent_name(bundle) {
-        body.insert("agent".to_string(), json!(agent));
-    }
     let mcp = bundle
         .tools
         .mcp

--- a/src/build/project/pi.rs
+++ b/src/build/project/pi.rs
@@ -1,5 +1,5 @@
 use crate::build::bundle::{LaunchActions, LaunchBundle, RuntimeContext};
-use crate::build::project::{effort, empty_actions, model};
+use crate::build::project::{effort, model, subprocess_actions};
 use crate::error::MarsError;
 
 pub fn project(
@@ -63,7 +63,11 @@ pub fn project(
 
     argv.extend(context.extra_args.iter().cloned());
 
-    Ok(empty_actions(argv))
+    if let Some(prompt) = context.prompt.as_deref() {
+        argv.push(prompt.to_string());
+    }
+
+    subprocess_actions(context, argv, Vec::new(), None)
 }
 
 fn pi_model_arg(model: &str, effort: Option<&str>) -> String {

--- a/src/build/project/pi.rs
+++ b/src/build/project/pi.rs
@@ -1,32 +1,79 @@
 use crate::build::bundle::{LaunchActions, LaunchBundle, RuntimeContext};
+use crate::build::project::{effort, empty_actions, model};
 use crate::error::MarsError;
 
-#[allow(dead_code)]
 pub fn project(
-    _bundle: &LaunchBundle,
-    _context: &RuntimeContext,
+    bundle: &LaunchBundle,
+    context: &RuntimeContext,
 ) -> Result<LaunchActions, MarsError> {
-    Err(MarsError::InvalidRequest {
-        message: "launch_actions projection not implemented for this harness yet".to_string(),
-    })
+    let mut argv = vec!["pi".to_string(), "--mode".to_string(), "rpc".to_string()];
+
+    if let Some(model) = model(bundle) {
+        argv.extend(["--model".to_string(), pi_model_arg(model, effort(bundle))]);
+    }
+
+    let system_prompt = bundle.prompt_surface.system_instruction.trim();
+    if !system_prompt.is_empty() {
+        argv.extend([
+            "--append-system-prompt".to_string(),
+            bundle.prompt_surface.system_instruction.clone(),
+        ]);
+    }
+
+    if let Some(session_id) = context
+        .session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        if context.fork {
+            argv.extend(["--fork".to_string(), session_id.to_string()]);
+        } else {
+            argv.extend(["--session".to_string(), session_id.to_string()]);
+        }
+    }
+
+    if let Some(session_dir) = context
+        .pi_session_dir
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        argv.extend(["--session-dir".to_string(), session_dir.to_string()]);
+    }
+
+    if !context.load_all_pi_extensions {
+        argv.push("--no-extensions".to_string());
+    }
+
+    argv.extend([
+        "--no-skills".to_string(),
+        "--no-context-files".to_string(),
+        "--no-prompt-templates".to_string(),
+    ]);
+
+    for entrypoint in &context.pi_extension_entrypoints {
+        argv.extend(["-e".to_string(), entrypoint.clone()]);
+    }
+
+    argv.extend(context.extra_args.iter().cloned());
+
+    Ok(empty_actions(argv))
 }
 
-#[allow(dead_code)]
-pub fn project_subprocess(
-    _bundle: &LaunchBundle,
-    _context: &RuntimeContext,
-) -> Result<LaunchActions, MarsError> {
-    Err(MarsError::InvalidRequest {
-        message: "launch_actions projection not implemented for this harness yet".to_string(),
-    })
+fn pi_model_arg(model: &str, effort: Option<&str>) -> String {
+    match effort.and_then(effort_to_thinking) {
+        Some(thinking) => format!("{}:{thinking}", model.trim()),
+        None => model.trim().to_string(),
+    }
 }
 
-#[allow(dead_code)]
-pub fn project_streaming(
-    _bundle: &LaunchBundle,
-    _context: &RuntimeContext,
-) -> Result<LaunchActions, MarsError> {
-    Err(MarsError::InvalidRequest {
-        message: "launch_actions projection not implemented for this harness yet".to_string(),
-    })
+fn effort_to_thinking(effort: &str) -> Option<&'static str> {
+    match effort.trim().to_ascii_lowercase().as_str() {
+        "low" => Some("minimal"),
+        "medium" => Some("medium"),
+        "high" => Some("high"),
+        "max" | "xhigh" => Some("xhigh"),
+        _ => None,
+    }
 }

--- a/src/build/project/pi.rs
+++ b/src/build/project/pi.rs
@@ -63,6 +63,7 @@ pub fn project(
 
     argv.extend(context.extra_args.iter().cloned());
 
+    // TODO(launch-actions-parity, launch-bundle-projection): prompt on CLI vs delivered over RPC post-startup
     if let Some(prompt) = context.prompt.as_deref() {
         argv.push(prompt.to_string());
     }

--- a/src/build/project/pi.rs
+++ b/src/build/project/pi.rs
@@ -1,0 +1,32 @@
+use crate::build::bundle::{LaunchActions, LaunchBundle, RuntimeContext};
+use crate::error::MarsError;
+
+#[allow(dead_code)]
+pub fn project(
+    _bundle: &LaunchBundle,
+    _context: &RuntimeContext,
+) -> Result<LaunchActions, MarsError> {
+    Err(MarsError::InvalidRequest {
+        message: "launch_actions projection not implemented for this harness yet".to_string(),
+    })
+}
+
+#[allow(dead_code)]
+pub fn project_subprocess(
+    _bundle: &LaunchBundle,
+    _context: &RuntimeContext,
+) -> Result<LaunchActions, MarsError> {
+    Err(MarsError::InvalidRequest {
+        message: "launch_actions projection not implemented for this harness yet".to_string(),
+    })
+}
+
+#[allow(dead_code)]
+pub fn project_streaming(
+    _bundle: &LaunchBundle,
+    _context: &RuntimeContext,
+) -> Result<LaunchActions, MarsError> {
+    Err(MarsError::InvalidRequest {
+        message: "launch_actions projection not implemented for this harness yet".to_string(),
+    })
+}

--- a/src/build/project/pi.rs
+++ b/src/build/project/pi.rs
@@ -6,6 +6,8 @@ pub fn project(
     bundle: &LaunchBundle,
     context: &RuntimeContext,
 ) -> Result<LaunchActions, MarsError> {
+    reject_managed_flag_collisions(&context.extra_args)?;
+
     let mut argv = vec!["pi".to_string(), "--mode".to_string(), "rpc".to_string()];
 
     if let Some(model) = model(bundle) {
@@ -33,14 +35,17 @@ pub fn project(
         }
     }
 
-    if let Some(session_dir) = context
+    let session_dir = context
         .pi_session_dir
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty())
-    {
-        argv.extend(["--session-dir".to_string(), session_dir.to_string()]);
-    }
+        .ok_or_else(|| MarsError::InvalidRequest {
+            message:
+                "Pi launch_actions require context.pi_session_dir for managed RPC session storage."
+                    .to_string(),
+        })?;
+    argv.extend(["--session-dir".to_string(), session_dir.to_string()]);
 
     if !context.load_all_pi_extensions {
         argv.push("--no-extensions".to_string());
@@ -76,4 +81,34 @@ fn effort_to_thinking(effort: &str) -> Option<&'static str> {
         "max" | "xhigh" => Some("xhigh"),
         _ => None,
     }
+}
+
+fn reject_managed_flag_collisions(extra_args: &[String]) -> Result<(), MarsError> {
+    if has_flag(extra_args, "--mode") {
+        return Err(MarsError::InvalidRequest {
+            message: "Pi harness owns --mode and always launches in RPC mode; remove --mode from passthrough extra_args".to_string(),
+        });
+    }
+    if has_flag(extra_args, "--no-extensions")
+        || has_flag(extra_args, "-e")
+        || has_flag(extra_args, "--extension")
+    {
+        return Err(MarsError::InvalidRequest {
+            message: "Pi harness owns extension loading for RPC launches; remove --no-extensions or -e/--extension from passthrough extra_args".to_string(),
+        });
+    }
+    if has_flag(extra_args, "--session-dir") {
+        return Err(MarsError::InvalidRequest {
+            message: "Pi harness owns --session-dir for Meridian-managed session isolation; remove --session-dir from passthrough extra_args".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn has_flag(args: &[String], flag: &str) -> bool {
+    args.iter().any(|token| {
+        token == flag
+            || token.starts_with(&format!("{flag}="))
+            || (flag == "-e" && token.starts_with("-e") && token != "-e")
+    })
 }

--- a/src/build/prompt.rs
+++ b/src/build/prompt.rs
@@ -1,11 +1,11 @@
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::build::bundle::{AvailableSkill, LoadedSkill, SupplementalDoc};
-use crate::compiler::agents::{AgentMode, ModelPolicyMatchType, parse_agent_content};
+use crate::build::inventory::build_inventory_prompt;
 use crate::compiler::skills::parse_skill_content;
 use crate::compiler::variants::harness_skill_variant_path;
-use crate::error::{ConfigError, MarsError};
+use crate::error::MarsError;
 use crate::frontmatter::{Frontmatter, SkillsSpec};
 
 const REPORT_INSTRUCTION: &str = "# Report\n\n**IMPORTANT - Your final assistant message must be the run report.**\n\nProvide a plain markdown report in your final assistant message.\n\nInclude: what was done, key decisions made, files created/modified, verification results, and any issues or blockers.";
@@ -41,15 +41,6 @@ enum SkillLoadOutcome {
 enum AvailableSkillOutcome {
     Available(AvailableSkill),
     Missing,
-}
-
-#[derive(Debug, Clone)]
-struct ParsedAgentInventory {
-    name: String,
-    description: String,
-    model: Option<String>,
-    fanout: Vec<String>,
-    mode: AgentMode,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -132,7 +123,8 @@ pub fn compile_prompt_surface(
         }
     }
 
-    let inventory_prompt = build_inventory_prompt(mars_dir, subagents_filter, &mut warnings)?;
+    let inventory_prompt =
+        build_inventory_prompt(mars_dir, subagents_filter, harness_id, &mut warnings)?;
     let system_instruction = compose_system_instruction(
         agent_body,
         &supplemental_documents,
@@ -426,208 +418,4 @@ fn compose_system_instruction(
     blocks.push(report_instruction.to_string());
 
     blocks.join("\n\n")
-}
-
-fn build_inventory_prompt(
-    mars_dir: &Path,
-    subagents_filter: &[String],
-    warnings: &mut Vec<String>,
-) -> Result<String, MarsError> {
-    let agents_dir = mars_dir.join("agents");
-    if !agents_dir.is_dir() {
-        return Ok(String::new());
-    }
-
-    let read_dir = match std::fs::read_dir(&agents_dir) {
-        Ok(entries) => entries,
-        Err(err) => {
-            warnings.push(format!(
-                "failed to read agent inventory from {}: {err}",
-                agents_dir.display()
-            ));
-            return Ok(String::new());
-        }
-    };
-
-    let mut agent_paths: Vec<PathBuf> = read_dir
-        .filter_map(Result::ok)
-        .map(|entry| entry.path())
-        .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("md"))
-        .collect();
-    agent_paths.sort();
-
-    let mut primary_agents = Vec::new();
-    let mut subagent_agents = Vec::new();
-
-    for path in agent_paths {
-        match parse_inventory_agent(&path) {
-            Ok((Some(agent), agent_warnings)) => {
-                warnings.extend(agent_warnings);
-                if agent.mode == AgentMode::Primary {
-                    primary_agents.push(agent);
-                } else {
-                    subagent_agents.push(agent);
-                }
-            }
-            Ok((None, agent_warnings)) => warnings.extend(agent_warnings),
-            Err(err) => {
-                return Err(MarsError::Config(ConfigError::Invalid { message: err }));
-            }
-        }
-    }
-
-    if !subagents_filter.is_empty() {
-        primary_agents.retain(|agent| {
-            subagents_filter
-                .iter()
-                .any(|f| f.eq_ignore_ascii_case(&agent.name))
-        });
-        subagent_agents.retain(|agent| {
-            subagents_filter
-                .iter()
-                .any(|f| f.eq_ignore_ascii_case(&agent.name))
-        });
-    }
-
-    if primary_agents.is_empty() && subagent_agents.is_empty() {
-        return Ok(String::new());
-    }
-
-    primary_agents.sort_by(|left, right| left.name.cmp(&right.name));
-    subagent_agents.sort_by(|left, right| left.name.cmp(&right.name));
-
-    let mut lines = vec![
-        "# Meridian Agents".to_string(),
-        "".to_string(),
-        "Installed Meridian agents available at launch time.".to_string(),
-    ];
-
-    if !primary_agents.is_empty() {
-        lines.extend(["".to_string(), "## Primary".to_string()]);
-        for agent in &primary_agents {
-            lines.push(render_inventory_line(agent));
-        }
-    }
-
-    if !subagent_agents.is_empty() {
-        lines.extend(["".to_string(), "## Subagent".to_string()]);
-        for agent in &subagent_agents {
-            lines.push(render_inventory_line(agent));
-        }
-    }
-
-    Ok(lines.join("\n").trim().to_string())
-}
-
-fn parse_inventory_agent(
-    path: &Path,
-) -> Result<(Option<ParsedAgentInventory>, Vec<String>), String> {
-    let content = std::fs::read_to_string(path).map_err(|err| {
-        format!(
-            "failed to read agent inventory file {}: {err}",
-            path.display()
-        )
-    })?;
-
-    let mut parse_diags = Vec::new();
-    let (profile, _frontmatter) =
-        parse_agent_content(&content, &mut parse_diags).map_err(|err| {
-            format!(
-                "failed to parse agent inventory file {}: {err}",
-                path.display()
-            )
-        })?;
-
-    let mut warnings = Vec::new();
-    for diag in parse_diags {
-        if diag.is_error() {
-            return Err(format!(
-                "agent inventory file {} has invalid frontmatter: {}",
-                path.display(),
-                diag.message()
-            ));
-        }
-        warnings.push(format!(
-            "agent inventory parse warning in {}: {}",
-            path.display(),
-            diag.message()
-        ));
-    }
-    if !profile.model_invocable {
-        return Ok((None, warnings));
-    }
-
-    let fallback_name = path
-        .file_stem()
-        .and_then(|stem| stem.to_str())
-        .unwrap_or("unknown-agent")
-        .to_string();
-    let fanout = fallback_model_policies_for_inventory(&profile);
-    let name = profile.name.unwrap_or(fallback_name);
-    let description = profile.description.unwrap_or_default();
-    let mode = profile.mode.clone().unwrap_or(AgentMode::Subagent);
-
-    Ok((
-        Some(ParsedAgentInventory {
-            name,
-            description,
-            model: profile.model,
-            fanout,
-            mode,
-        }),
-        warnings,
-    ))
-}
-
-fn fallback_model_policies_for_inventory(
-    profile: &crate::compiler::agents::AgentProfile,
-) -> Vec<String> {
-    let mut entries = Vec::new();
-    let mut seen = HashSet::new();
-
-    // Limitation: this deduplicates exact fallback labels only. Alias-to-model
-    // canonical dedupe requires alias catalog context not currently loaded here.
-    for policy in &profile.model_policies {
-        if policy.no_fallback {
-            continue;
-        }
-        if !matches!(
-            policy.match_type,
-            ModelPolicyMatchType::Alias | ModelPolicyMatchType::Model
-        ) {
-            continue;
-        }
-        let value = policy.match_value.trim();
-        if value.is_empty() {
-            continue;
-        }
-        if seen.insert(value.to_string()) {
-            entries.push(value.to_string());
-        }
-    }
-
-    entries
-}
-
-fn render_inventory_line(agent: &ParsedAgentInventory) -> String {
-    let description = agent.description.trim();
-    let mut line = if description.is_empty() {
-        format!("- {}", agent.name)
-    } else {
-        format!("- {}: {}", agent.name, description)
-    };
-
-    if let Some(model) = agent.model.as_ref().map(|value| value.trim())
-        && !model.is_empty()
-    {
-        line.push_str(" | Model: ");
-        line.push_str(model);
-    }
-
-    if !agent.fanout.is_empty() {
-        line.push_str(" | Fan-out: ");
-        line.push_str(&agent.fanout.join(", "));
-    }
-
-    line
 }

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -2,6 +2,7 @@
 
 use clap::{ArgAction, ValueEnum};
 
+use crate::build::bundle::RuntimeContext;
 use crate::build::{LaunchBundleRequest, build_launch_bundle};
 use crate::cli::MarsContext;
 use crate::error::MarsError;
@@ -85,6 +86,21 @@ enum SandboxArg {
     DangerFullAccess,
 }
 
+#[derive(Debug, Clone, ValueEnum)]
+enum TransportArg {
+    Subprocess,
+    Streaming,
+}
+
+impl TransportArg {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Subprocess => "subprocess",
+            Self::Streaming => "streaming",
+        }
+    }
+}
+
 impl SandboxArg {
     fn as_str(&self) -> &'static str {
         match self {
@@ -134,6 +150,14 @@ pub struct LaunchBundleArgs {
     /// Skip automatic models-cache refresh; use disk cache only (no probe background refresh).
     #[arg(long, conflicts_with = "refresh_models")]
     pub no_refresh_models: bool,
+
+    /// Runtime launch context JSON used to project concrete launch actions.
+    #[arg(long)]
+    pub context: Option<String>,
+
+    /// Launch transport shape to project when --context is provided.
+    #[arg(long, value_enum, default_value_t = TransportArg::Subprocess)]
+    transport: TransportArg,
 }
 
 pub fn run(args: &BuildArgs, ctx: &MarsContext, _json: bool) -> Result<i32, MarsError> {
@@ -145,6 +169,16 @@ pub fn run(args: &BuildArgs, ctx: &MarsContext, _json: bool) -> Result<i32, Mars
 fn run_launch_bundle(args: &LaunchBundleArgs, ctx: &MarsContext) -> Result<i32, MarsError> {
     let models_refresh =
         crate::models::resolve_models_refresh_control(args.refresh_models, args.no_refresh_models)?;
+    let runtime_context = args
+        .context
+        .as_deref()
+        .map(|raw| {
+            serde_json::from_str::<RuntimeContext>(raw).map_err(|err| MarsError::InvalidRequest {
+                message: format!("invalid launch-bundle --context JSON: {err}"),
+            })
+        })
+        .transpose()?;
+    let transport = crate::build::project::Transport::parse(args.transport.as_str())?;
     let bundle = build_launch_bundle(
         ctx,
         LaunchBundleRequest {
@@ -156,6 +190,8 @@ fn run_launch_bundle(args: &LaunchBundleArgs, ctx: &MarsContext) -> Result<i32, 
             sandbox: args.sandbox.as_ref().map(|s| s.as_str().to_string()),
             extra_skills: args.extra_skills.clone(),
             models_refresh,
+            runtime_context,
+            transport,
         },
     )?;
 

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -152,10 +152,12 @@ pub struct LaunchBundleArgs {
     pub no_refresh_models: bool,
 
     /// Runtime launch context JSON used to project concrete launch actions.
+    /// (EXPERIMENTAL; launch_actions are not consumed by meridian-cli and may be removed — see work item launch-bundle-projection)
     #[arg(long)]
     pub context: Option<String>,
 
     /// Launch transport shape to project when --context is provided.
+    /// (EXPERIMENTAL; only used with --context)
     #[arg(long, value_enum, default_value_t = TransportArg::Subprocess)]
     transport: TransportArg,
 }
@@ -194,6 +196,12 @@ fn run_launch_bundle(args: &LaunchBundleArgs, ctx: &MarsContext) -> Result<i32, 
             transport,
         },
     )?;
+
+    if args.context.is_some() {
+        eprintln!(
+            "warning: --context launch_actions projection is EXPERIMENTAL and not consumed by meridian-cli; meridian builds argv/env in its own harness adapters (invariant I-2). May be removed. See work item launch-bundle-projection / PR #94."
+        );
+    }
 
     println!(
         "{}",

--- a/src/cli/link.rs
+++ b/src/cli/link.rs
@@ -78,7 +78,7 @@ fn link_target(
     let outcomes = lock_items_as_sync_outcomes(&lock);
     let mut diag = DiagnosticCollector::new();
     let agent_copy_spec = crate::compiler::agent_copy::build_agent_copy_spec(
-        effective.settings.agent_copy.as_ref(),
+        effective.settings.meridian_agent_copy(),
         &runtime_targets,
         &mut diag,
     );

--- a/src/cli/link.rs
+++ b/src/cli/link.rs
@@ -198,6 +198,15 @@ fn link_target(
     crate::lock::apply_target_sync_outputs(&mut new_lock, &target_outcomes);
     crate::lock::apply_removed_native_outputs(&mut new_lock, &removed_native_outputs);
     crate::lock::apply_compiled_native_outputs(&mut new_lock, &compiled_native_outputs);
+    if let Err(err) =
+        crate::compiler::write_native_agent_manifest_from_lock(&ctx.project_root, &new_lock)
+    {
+        diag.warn(
+            "native-agent-manifest-write",
+            format!("could not write native agent manifest: {err}"),
+        );
+        diagnostics.extend(diag.drain());
+    }
     crate::lock::write(&ctx.project_root, &new_lock)?;
 
     if settings_changed {

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -169,6 +169,8 @@ pub fn sync_report_json(report: &SyncReport) -> serde_json::Value {
         conflicts: usize,
         kept: usize,
         skipped: usize,
+        native_emitted: usize,
+        native_removed: usize,
         upgrades_available: usize,
         targets: Vec<JsonTargetOutcome>,
         diagnostics: Vec<Diagnostic>,
@@ -219,6 +221,8 @@ pub fn sync_report_json(report: &SyncReport) -> serde_json::Value {
         conflicts,
         kept,
         skipped,
+        native_emitted: report.native_emitted.len(),
+        native_removed: report.native_removed.len(),
         upgrades_available: report.upgrades_available,
         targets,
         diagnostics: report.diagnostics.clone(),
@@ -268,6 +272,15 @@ fn print_sync_report_human(report: &SyncReport, no_upgrade_hint: bool) {
         }
     }
 
+    let native_emitted = report.native_emitted.len();
+    let native_removed = report.native_removed.len();
+    for (target_root, dest_path) in &report.native_removed {
+        print_native_line(&mut stdout, "-", Color::Red, target_root, dest_path);
+    }
+    for (target_root, dest_path) in &report.native_emitted {
+        print_native_line(&mut stdout, "+", Color::Green, target_root, dest_path);
+    }
+
     // Summary line — use "would ..." wording for dry runs
     let _ = writeln!(stdout);
     let dry = is_dry_run(report);
@@ -292,6 +305,20 @@ fn print_sync_report_human(report: &SyncReport, no_upgrade_hint: bool) {
             let _ = writeln!(stdout, "  removed     {removed} orphans");
         }
     }
+    if native_emitted > 0 {
+        if dry {
+            let _ = writeln!(stdout, "  would emit   {native_emitted} native agents");
+        } else {
+            let _ = writeln!(stdout, "  emitted     {native_emitted} native agents");
+        }
+    }
+    if native_removed > 0 {
+        if dry {
+            let _ = writeln!(stdout, "  would remove {native_removed} native agents");
+        } else {
+            let _ = writeln!(stdout, "  removed     {native_removed} native agents");
+        }
+    }
     if kept > 0 {
         let _ = writeln!(stdout, "  kept        {kept} locally modified");
     }
@@ -305,7 +332,14 @@ fn print_sync_report_human(report: &SyncReport, no_upgrade_hint: bool) {
         let _ = stdout.reset();
     }
 
-    if installed == 0 && updated == 0 && removed == 0 && conflicts == 0 && kept == 0 {
+    if installed == 0
+        && updated == 0
+        && removed == 0
+        && conflicts == 0
+        && kept == 0
+        && native_emitted == 0
+        && native_removed == 0
+    {
         let _ = stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)));
         let _ = writeln!(stdout, "  already up to date");
         let _ = stdout.reset();
@@ -351,6 +385,19 @@ fn print_action_line(
     let _ = write!(stdout, "  {prefix} ");
     let _ = stdout.reset();
     let _ = writeln!(stdout, "{} ({})", outcome.dest_path, outcome.item_id.kind);
+}
+
+fn print_native_line(
+    stdout: &mut StandardStream,
+    prefix: &str,
+    color: Color,
+    target_root: &str,
+    dest_path: &str,
+) {
+    let _ = stdout.set_color(ColorSpec::new().set_fg(Some(color)));
+    let _ = write!(stdout, "  {prefix} ");
+    let _ = stdout.reset();
+    let _ = writeln!(stdout, "{target_root}/{dest_path} (native agent)");
 }
 
 /// Print a list of items as a table or JSON.

--- a/src/compiler/AGENTS.md
+++ b/src/compiler/AGENTS.md
@@ -30,7 +30,7 @@ The compiler is the second half of the sync pipeline. It consumes `ReaderIr` and
 - `mod.rs` (304 lines) — orchestration: `compile()` entry point, stages, lock finalization
 - `native_agents.rs` (814 lines) — native harness surface lifecycle: scan, reconcile, compile,
   emit, link-materialize. Extracted from `mod.rs` (was 1522 lines).
-- `agent_copy.rs` — selective emission when `settings.agent_copy` is configured;
+- `agent_copy.rs` — selective emission when `settings.meridian.agent_copy` is configured;
   `agent_qualifies_for_harness()`, `model_resolves_to_harness()`, `QualifiedEmission` enum
 - `agents/` — `AgentProfile` schema parser + per-harness lowering with model alias resolution
 - `skills/` — universal skill schema + native lowering with variant layouts

--- a/src/compiler/agent_copy.rs
+++ b/src/compiler/agent_copy.rs
@@ -83,7 +83,28 @@ pub fn agent_qualifies_for_harness(
     include_fanout: bool,
 ) -> Option<QualifiedEmission> {
     if profile.harness.as_ref() == Some(target_harness) {
-        return Some(QualifiedEmission::DefaultModel);
+        // Honor the declared harness, but only when the model belongs here. An overlay
+        // can pivot the effective model to another harness while `profile.harness`
+        // stays put; pinning that foreign model would emit an incoherent native file.
+        // Clear only when the model *positively* resolves to a different harness — a
+        // bare/unresolvable model id keeps honoring the declared harness (consistent
+        // with the canonical resolver, which also pivots only on a known alias).
+        let resolves_elsewhere = match profile.model.as_deref() {
+            None => false,
+            Some(token) if token.contains('[') => false,
+            // Cursor hosts foreign-provider models via internal slug mapping, so a
+            // model resolving to another native harness is normal there and must never
+            // be treated as foreign — cursor agents only ever qualify via this branch.
+            Some(_) if *target_harness == HarnessKind::Cursor => false,
+            Some(token) => {
+                matches!(model_resolved_harness(token, model_aliases), Some(h) if h != *target_harness)
+            }
+        };
+        if !resolves_elsewhere {
+            return Some(QualifiedEmission::DefaultModel);
+        }
+        // Model resolves to a different harness: fall through (returns None), so EmitAll
+        // clears the model for this harness and EmitSelective skips it.
     }
 
     if let Some(ref model_token) = profile.model
@@ -177,17 +198,18 @@ fn policy_override_harness(policy: &ModelPolicyRule) -> Option<HarnessKind> {
         .and_then(HarnessKind::from_str)
 }
 
-pub fn model_resolves_to_harness(
+/// The native harness a model token resolves to via its alias — an explicit
+/// `harness` field or a provider->native-harness mapping. Returns `None` when the
+/// token is not a known alias, or carries no harness/provider signal (e.g. a bare
+/// model id). This is the shared primitive behind `model_resolves_to_harness`.
+pub fn model_resolved_harness(
     model_token: &str,
-    target_harness: &HarnessKind,
     aliases: &IndexMap<String, ModelAlias>,
-) -> bool {
-    let Some(alias) = aliases.get(model_token) else {
-        return false;
-    };
+) -> Option<HarnessKind> {
+    let alias = aliases.get(model_token)?;
 
     if let Some(ref harness_name) = alias.harness {
-        return HarnessKind::from_str(harness_name).as_ref() == Some(target_harness);
+        return HarnessKind::from_str(harness_name);
     }
 
     let provider = match &alias.spec {
@@ -197,13 +219,17 @@ pub fn model_resolves_to_harness(
         ModelSpec::AutoResolve { provider, .. } => provider.as_deref(),
     };
 
-    if let Some(provider) = provider
-        && let Some(native) = registry::native_harness_for_provider(provider)
-    {
-        return HarnessKind::from_harness_id(native) == *target_harness;
-    }
+    provider
+        .and_then(registry::native_harness_for_provider)
+        .map(HarnessKind::from_harness_id)
+}
 
-    false
+pub fn model_resolves_to_harness(
+    model_token: &str,
+    target_harness: &HarnessKind,
+    aliases: &IndexMap<String, ModelAlias>,
+) -> bool {
+    model_resolved_harness(model_token, aliases).as_ref() == Some(target_harness)
 }
 
 #[cfg(test)]
@@ -436,6 +462,45 @@ mod tests {
                 .iter()
                 .any(|m| m.contains("not in settings.targets")),
             "{messages:?}"
+        );
+    }
+
+    #[test]
+    fn declared_harness_foreign_model_does_not_short_circuit() {
+        let mut profile = empty_profile();
+        profile.harness = Some(HarnessKind::Codex);
+        profile.model = Some("opus".to_string());
+        let mut aliases = IndexMap::new();
+        aliases.insert("opus".to_string(), anthropic_alias());
+        assert!(
+            agent_qualifies_for_harness(&profile, &HarnessKind::Codex, &aliases, false).is_none(),
+            "codex harness with claude-resolving model must not qualify for codex"
+        );
+        assert!(
+            agent_qualifies_for_harness(&profile, &HarnessKind::Claude, &aliases, false).is_some(),
+            "effective model should qualify via model-resolution branch"
+        );
+    }
+
+    #[test]
+    fn declared_harness_matching_model_still_short_circuits() {
+        let mut profile = empty_profile();
+        profile.harness = Some(HarnessKind::Claude);
+        profile.model = Some("opus".to_string());
+        let mut aliases = IndexMap::new();
+        aliases.insert("opus".to_string(), anthropic_alias());
+        assert!(
+            agent_qualifies_for_harness(&profile, &HarnessKind::Claude, &aliases, false).is_some()
+        );
+    }
+
+    #[test]
+    fn declared_harness_no_model_still_short_circuits() {
+        let mut profile = empty_profile();
+        profile.harness = Some(HarnessKind::Claude);
+        assert!(
+            agent_qualifies_for_harness(&profile, &HarnessKind::Claude, &IndexMap::new(), false,)
+                .is_some()
         );
     }
 }

--- a/src/compiler/agent_copy.rs
+++ b/src/compiler/agent_copy.rs
@@ -1,4 +1,4 @@
-//! Selective native agent emission when `settings.agent_copy` is configured.
+//! Selective native agent emission when `settings.meridian.agent_copy` is configured.
 
 use indexmap::IndexMap;
 
@@ -42,7 +42,7 @@ pub fn build_agent_copy_spec(
             diag.warn(
                 "agent-copy-invalid-harness",
                 format!(
-                    "settings.agent_copy.harnesses: unknown harness '{trimmed}'; \
+                    "settings.meridian.agent_copy.harnesses: unknown harness '{trimmed}'; \
                      valid harnesses: {}",
                     registry::names().join(", ")
                 ),
@@ -54,7 +54,7 @@ pub fn build_agent_copy_spec(
             diag.warn(
                 "agent-copy-harness-not-in-targets",
                 format!(
-                    "settings.agent_copy.harnesses: harness '{trimmed}' maps to target \
+                    "settings.meridian.agent_copy.harnesses: harness '{trimmed}' maps to target \
                      `{target}` which is not in settings.targets; add `{target}` to \
                      settings.targets to emit native agents there"
                 ),

--- a/src/compiler/agents/lower.rs
+++ b/src/compiler/agents/lower.rs
@@ -124,11 +124,35 @@ impl<'a> Effective<'a> {
 ///
 /// `harness-overrides.claude` values are merged into top-level fields
 /// before lowering (D42 — compile-time merge).
+/// What model field a lowered native agent should carry. The native compiler is the
+/// sole caller; this replaces a bare `Option<&str>` so "emit no model" is expressible
+/// authoritatively, without mutating the profile to strip its model.
+#[derive(Debug, Clone)]
+pub enum NativeModel {
+    /// Emit the profile's own model verbatim (unpinned alias / fanout token).
+    Inherit,
+    /// Emit this resolved model id.
+    Set(String),
+    /// Emit no model field (agent emitted to a harness its model does not resolve to).
+    Clear,
+}
+
+impl NativeModel {
+    /// The concrete model string to render for `profile`, or `None` for "no model".
+    fn resolve<'a>(&'a self, profile: &'a AgentProfile) -> Option<&'a str> {
+        match self {
+            NativeModel::Inherit => profile.model.as_deref(),
+            NativeModel::Set(model) => Some(model),
+            NativeModel::Clear => None,
+        }
+    }
+}
+
 pub fn lower_to_claude(
     profile: &AgentProfile,
     _fm: &Frontmatter,
     body: &str,
-    model_override: Option<&str>,
+    model_field: &NativeModel,
 ) -> LoweredOutput {
     let eff = Effective::new(profile, &HarnessKind::Claude);
     let mut lossy = Vec::new();
@@ -146,8 +170,8 @@ pub fn lower_to_claude(
     if let Some(desc) = &profile.description {
         yaml.insert(yk("description"), yv(desc));
     }
-    // model — exact (compile-time alias resolution may supply model_override)
-    if let Some(model) = model_override.or(profile.model.as_deref()) {
+    // model — exact (compile-time alias resolution may supply model_field)
+    if let Some(model) = model_field.resolve(profile) {
         yaml.insert(yk("model"), yv(model));
     }
     // skills — exact (Claude reads skills natively from .claude/skills/)
@@ -287,7 +311,7 @@ pub fn lower_to_claude(
 pub fn lower_to_codex(
     profile: &AgentProfile,
     body: &str,
-    model_override: Option<&str>,
+    model_field: &NativeModel,
 ) -> LoweredOutput {
     let eff = Effective::new(profile, &HarnessKind::Codex);
     let mut lossy = Vec::new();
@@ -408,7 +432,7 @@ pub fn lower_to_codex(
     let doc = CodexAgentToml {
         name: profile.name.as_deref(),
         description: profile.description.as_deref(),
-        model: model_override.or(profile.model.as_deref()),
+        model: model_field.resolve(profile),
         model_reasoning_effort: effort_str,
         sandbox_mode: sandbox_str,
         approval_policy,
@@ -440,7 +464,7 @@ fn lower_to_opencode_like(
     body: &str,
     harness: HarnessKind,
     target: &str,
-    model_override: Option<&str>,
+    model_field: &NativeModel,
 ) -> LoweredOutput {
     let eff = Effective::new(profile, &harness);
     let mut lossy = Vec::new();
@@ -455,7 +479,7 @@ fn lower_to_opencode_like(
     if let Some(desc) = &profile.description {
         yaml.insert(yk("description"), yv(desc));
     }
-    if let Some(model) = model_override.or(profile.model.as_deref()) {
+    if let Some(model) = model_field.resolve(profile) {
         yaml.insert(yk("model"), yv(model));
     }
     // mode — approximate (OpenCode has a mode concept: primary/subagent)
@@ -579,14 +603,14 @@ fn lower_to_opencode_like(
 pub fn lower_to_opencode(
     profile: &AgentProfile,
     body: &str,
-    model_override: Option<&str>,
+    model_field: &NativeModel,
 ) -> LoweredOutput {
     lower_to_opencode_like(
         profile,
         body,
         HarnessKind::OpenCode,
         "OpenCode",
-        model_override,
+        model_field,
     )
 }
 
@@ -597,7 +621,7 @@ fn normalize_cursor_description(description: &str) -> String {
 fn lower_to_cursor_with_model(
     profile: &AgentProfile,
     body: &str,
-    model_override: Option<&str>,
+    model_field: &NativeModel,
 ) -> LoweredOutput {
     let eff = Effective::new(profile, &HarnessKind::Cursor);
     let mut lossy = Vec::new();
@@ -613,7 +637,7 @@ fn lower_to_cursor_with_model(
     if let Some(desc) = &profile.description {
         yaml.insert(yk("description"), yv(&normalize_cursor_description(desc)));
     }
-    if let Some(model) = model_override.or(profile.model.as_deref()) {
+    if let Some(model) = model_field.resolve(profile) {
         yaml.insert(yk("model"), yv(model));
     }
     let skills = eff.skills();
@@ -755,11 +779,7 @@ fn lower_to_cursor_with_model(
 /// Pi's format is similar to OpenCode: markdown + YAML frontmatter with a
 /// minimal subset of fields. Per agent-compilation-mapping.md §6, all policy
 /// fields are dropped.
-pub fn lower_to_pi(
-    profile: &AgentProfile,
-    body: &str,
-    model_override: Option<&str>,
-) -> LoweredOutput {
+pub fn lower_to_pi(profile: &AgentProfile, body: &str, model_field: &NativeModel) -> LoweredOutput {
     let mut lossy = Vec::new();
     let target = "Pi";
 
@@ -773,7 +793,7 @@ pub fn lower_to_pi(
     if let Some(desc) = &profile.description {
         yaml.insert(yk("description"), yv(desc));
     }
-    if let Some(model) = model_override.or(profile.model.as_deref()) {
+    if let Some(model) = model_field.resolve(profile) {
         yaml.insert(yk("model"), yv(model));
     }
     // mode — approximate
@@ -898,14 +918,14 @@ pub fn lower_for_harness_with_model(
     profile: &AgentProfile,
     fm: &Frontmatter,
     body: &str,
-    model_override: Option<&str>,
+    model_field: &NativeModel,
 ) -> LoweredOutput {
     match harness {
-        HarnessKind::Claude => lower_to_claude(profile, fm, body, model_override),
-        HarnessKind::Codex => lower_to_codex(profile, body, model_override),
-        HarnessKind::OpenCode => lower_to_opencode(profile, body, model_override),
-        HarnessKind::Cursor => lower_to_cursor_with_model(profile, body, model_override),
-        HarnessKind::Pi => lower_to_pi(profile, body, model_override),
+        HarnessKind::Claude => lower_to_claude(profile, fm, body, model_field),
+        HarnessKind::Codex => lower_to_codex(profile, body, model_field),
+        HarnessKind::OpenCode => lower_to_opencode(profile, body, model_field),
+        HarnessKind::Cursor => lower_to_cursor_with_model(profile, body, model_field),
+        HarnessKind::Pi => lower_to_pi(profile, body, model_field),
     }
 }
 
@@ -927,7 +947,7 @@ mod tests {
         let content = "---\nname: coder\ndescription: Code impl agent\nmodel: gpt55\nharness: claude\nskills: [dev-principles]\ntools: [Bash, Write]\n---\n# Coder\nYou write code.";
         let (profile, fm, _) = profile_from(content);
         let body = fm.body();
-        let out = lower_to_claude(&profile, &fm, body, None);
+        let out = lower_to_claude(&profile, &fm, body, &NativeModel::Inherit);
         let text = String::from_utf8(out.bytes).unwrap();
         assert!(text.contains("name: coder"), "name missing: {text}");
         assert!(
@@ -944,7 +964,7 @@ mod tests {
     fn claude_lowering_drops_approval_sandbox_mode_autocompact() {
         let content = "---\nname: coder\nharness: claude\napproval: auto\nsandbox: read-only\nmode: subagent\nautocompact: 50\nautocompact_pct: 80\n---\n# Body";
         let (profile, fm, _) = profile_from(content);
-        let out = lower_to_claude(&profile, &fm, fm.body(), None);
+        let out = lower_to_claude(&profile, &fm, fm.body(), &NativeModel::Inherit);
         let text = String::from_utf8(out.bytes).unwrap();
         assert!(!text.contains("approval:"), "approval leaked: {text}");
         assert!(!text.contains("sandbox:"), "sandbox leaked: {text}");
@@ -973,7 +993,7 @@ mod tests {
     fn claude_harness_override_applied_before_lowering() {
         let content = "---\nname: r\nharness: claude\nskills: [base-skill]\nharness-overrides:\n  claude:\n    skills: [override-skill]\n---\n# body";
         let (profile, fm, _) = profile_from(content);
-        let out = lower_to_claude(&profile, &fm, fm.body(), None);
+        let out = lower_to_claude(&profile, &fm, fm.body(), &NativeModel::Inherit);
         let text = String::from_utf8(out.bytes).unwrap();
         assert!(
             text.contains("override-skill"),
@@ -989,7 +1009,7 @@ mod tests {
     fn claude_harness_override_replaces_mcp_tools() {
         let content = "---\nname: r\nharness: claude\nmcp-tools: [plugin:base]\nharness-overrides:\n  claude:\n    mcp-tools: [plugin:claude]\n---\n# body";
         let (profile, fm, _) = profile_from(content);
-        let out = lower_to_claude(&profile, &fm, fm.body(), None);
+        let out = lower_to_claude(&profile, &fm, fm.body(), &NativeModel::Inherit);
         let text = String::from_utf8(out.bytes).unwrap();
         assert!(
             text.contains("mcp-tools"),
@@ -1003,7 +1023,7 @@ mod tests {
     fn claude_meridian_only_fields_dropped() {
         let content = "---\nname: r\nharness: claude\nmodel-policies:\n  - match:\n      model: gpt55\n    override:\n      harness: codex\nfanout:\n  - alias: opus\n---\n# body";
         let (profile, fm, _) = profile_from(content);
-        let out = lower_to_claude(&profile, &fm, fm.body(), None);
+        let out = lower_to_claude(&profile, &fm, fm.body(), &NativeModel::Inherit);
         let text = String::from_utf8(out.bytes).unwrap();
         assert!(
             !text.contains("model-policies:"),
@@ -1026,7 +1046,7 @@ mod tests {
     fn codex_lowering_produces_top_level_toml() {
         let content = "---\nname: coder\ndescription: Code agent\nmodel: gpt55\nharness: codex\neffort: high\nsandbox: workspace-write\napproval: auto\n---\n# Coder\nYou code.";
         let (profile, fm, _) = profile_from(content);
-        let out = lower_to_codex(&profile, fm.body(), None);
+        let out = lower_to_codex(&profile, fm.body(), &NativeModel::Inherit);
         let text = String::from_utf8(out.bytes).unwrap();
         assert!(
             !text.contains("[agent]"),
@@ -1063,7 +1083,7 @@ mod tests {
     fn codex_lowering_drops_skills_and_tools() {
         let content = "---\nname: r\nharness: codex\nskills: [review]\ntools: [Bash]\ndisallowed-tools: [Agent]\n---\n# body";
         let (profile, fm, _) = profile_from(content);
-        let out = lower_to_codex(&profile, fm.body(), None);
+        let out = lower_to_codex(&profile, fm.body(), &NativeModel::Inherit);
         let dropped: Vec<_> = out
             .lossy_fields
             .iter()
@@ -1079,7 +1099,7 @@ mod tests {
     fn codex_harness_override_applied() {
         let content = "---\nname: r\nharness: codex\neffort: low\nharness-overrides:\n  codex:\n    effort: high\n    sandbox: workspace-write\n---\n# body";
         let (profile, fm, _) = profile_from(content);
-        let out = lower_to_codex(&profile, fm.body(), None);
+        let out = lower_to_codex(&profile, fm.body(), &NativeModel::Inherit);
         let text = String::from_utf8(out.bytes).unwrap();
         assert!(
             text.contains("model_reasoning_effort = \"high\""),
@@ -1095,7 +1115,7 @@ mod tests {
     fn codex_mcp_lossiness_uses_effective_override() {
         let content = "---\nname: r\nharness: codex\nmcp-tools: [plugin:base]\nharness-overrides:\n  codex:\n    mcp-tools: []\n---\n# body";
         let (profile, fm, _) = profile_from(content);
-        let out = lower_to_codex(&profile, fm.body(), None);
+        let out = lower_to_codex(&profile, fm.body(), &NativeModel::Inherit);
         assert!(
             !out.lossy_fields
                 .iter()
@@ -1112,7 +1132,7 @@ mod tests {
     fn codex_native_config_lossiness_uses_matching_override() {
         let content = "---\nname: r\nharness-overrides:\n  codex:\n    native-config:\n      sandbox_workspace_write.network_access: true\n---\n# body";
         let (profile, fm, _) = profile_from(content);
-        let out = lower_to_codex(&profile, fm.body(), None);
+        let out = lower_to_codex(&profile, fm.body(), &NativeModel::Inherit);
         assert!(
             out.lossy_fields.iter().any(|field| {
                 field.field == "native-config"
@@ -1131,7 +1151,7 @@ mod tests {
     fn codex_lowering_multiline_instructions_are_parseable() {
         let content = "---\nname: explorer\ndescription: \"Line one\\nLine two\"\nharness: codex\napproval: yolo\n---\n# Explore\nUse \"quotes\" and backslashes \\\\\nKeep going.";
         let (profile, fm, _) = profile_from(content);
-        let out = lower_to_codex(&profile, fm.body(), None);
+        let out = lower_to_codex(&profile, fm.body(), &NativeModel::Inherit);
         let text = String::from_utf8(out.bytes).unwrap();
         let parsed: toml::Value = toml::from_str(&text).expect("lowered TOML should parse");
 
@@ -1154,7 +1174,7 @@ mod tests {
     fn opencode_lowering_preserves_name_description_model_mode() {
         let content = "---\nname: r\ndescription: Reviewer\nmodel: gpt55\nmode: primary\nharness: opencode\n---\n# Reviewer\nbody";
         let (profile, fm, _) = profile_from(content);
-        let out = lower_to_opencode(&profile, fm.body(), None);
+        let out = lower_to_opencode(&profile, fm.body(), &NativeModel::Inherit);
         let text = String::from_utf8(out.bytes).unwrap();
         assert!(text.contains("name: r"), "name missing");
         assert!(text.contains("description: Reviewer"), "desc missing");
@@ -1167,7 +1187,7 @@ mod tests {
         let content = "---\nname: r\nharness: cursor\ntools: [Read]\nmcp-tools: [plugin:base]\nharness-overrides:\n  opencode:\n    tools: []\n    mcp-tools: []\n    native-config:\n      opencode.only: true\n  cursor:\n    tools: [Bash]\n    mcp-tools: [plugin:cursor]\n    native-config:\n      cursor.only: true\n---\n# body";
         let (profile, fm, _) = profile_from(content);
 
-        let opencode = lower_to_opencode(&profile, fm.body(), None);
+        let opencode = lower_to_opencode(&profile, fm.body(), &NativeModel::Inherit);
         assert!(
             !opencode
                 .lossy_fields
@@ -1183,7 +1203,7 @@ mod tests {
             "opencode override should clear mcp lossiness",
         );
 
-        let cursor = lower_to_cursor_with_model(&profile, fm.body(), None);
+        let cursor = lower_to_cursor_with_model(&profile, fm.body(), &NativeModel::Inherit);
         assert!(
             cursor
                 .lossy_fields
@@ -1213,7 +1233,7 @@ mod tests {
         let content = "---\nname: cursor-agent\ndescription: |\n  Cursor agent\n  with   lots\t of\n  whitespace\nharness: cursor\n---\n# body";
         let (profile, fm, _) = profile_from(content);
 
-        let out = lower_to_cursor_with_model(&profile, fm.body(), None);
+        let out = lower_to_cursor_with_model(&profile, fm.body(), &NativeModel::Inherit);
         let text = String::from_utf8(out.bytes).unwrap();
 
         assert!(
@@ -1231,7 +1251,7 @@ mod tests {
     fn cursor_sandbox_is_approximate_not_dropped() {
         let content = "---\nname: r\nharness: cursor\nsandbox: read-only\n---\n# body";
         let (profile, fm, _) = profile_from(content);
-        let out = lower_to_cursor_with_model(&profile, fm.body(), None);
+        let out = lower_to_cursor_with_model(&profile, fm.body(), &NativeModel::Inherit);
 
         // sandbox must not appear in the emitted YAML artifact
         let text = String::from_utf8(out.bytes).unwrap();
@@ -1264,7 +1284,7 @@ mod tests {
     fn cursor_approval_is_approximate_not_dropped() {
         let content = "---\nname: r\nharness: cursor\napproval: auto\n---\n# body";
         let (profile, fm, _) = profile_from(content);
-        let out = lower_to_cursor_with_model(&profile, fm.body(), None);
+        let out = lower_to_cursor_with_model(&profile, fm.body(), &NativeModel::Inherit);
 
         // approval must not appear in the emitted YAML artifact
         let text = String::from_utf8(out.bytes).unwrap();
@@ -1299,14 +1319,14 @@ mod tests {
     fn pi_lowering_preserves_name_description_model() {
         let content = "---\nname: pi-agent\ndescription: Pi agent\nmodel: gpt55\nharness: pi\n---\n# Pi\nbody";
         let (profile, fm, _) = profile_from(content);
-        let out = lower_to_pi(&profile, fm.body(), None);
+        let out = lower_to_pi(&profile, fm.body(), &NativeModel::Inherit);
         let text = String::from_utf8(out.bytes).unwrap();
         assert!(text.contains("name: pi-agent"), "name missing");
         assert!(text.contains("description: Pi agent"), "desc missing");
     }
 
     #[test]
-    fn lower_for_harness_with_model_override_emits_pinned_id_for_claude_and_codex() {
+    fn lower_for_harness_with_model_field_emits_pinned_id_for_claude_and_codex() {
         let claude_content = "---\nname: coder\nmodel: gpt55\nharness: claude\n---\n# Coder\nbody";
         let (claude_profile, claude_fm, _) = profile_from(claude_content);
         let claude_out = lower_for_harness_with_model(
@@ -1314,7 +1334,7 @@ mod tests {
             &claude_profile,
             &claude_fm,
             claude_fm.body(),
-            Some("o3"),
+            &NativeModel::Set("o3".to_string()),
         );
         let claude_text = String::from_utf8(claude_out.bytes).unwrap();
         assert!(
@@ -1333,7 +1353,7 @@ mod tests {
             &codex_profile,
             &codex_fm,
             codex_fm.body(),
-            Some("o3"),
+            &NativeModel::Set("o3".to_string()),
         );
         let codex_text = String::from_utf8(codex_out.bytes).unwrap();
         assert!(
@@ -1353,14 +1373,26 @@ mod tests {
         let content = "---\nname: coder\nmodel: gpt55\nharness: claude\n---\n# body";
         let (profile, fm, _) = profile_from(content);
         let body = fm.body().to_string();
-        let out = lower_for_harness_with_model(&HarnessKind::Claude, &profile, &fm, &body, None);
+        let out = lower_for_harness_with_model(
+            &HarnessKind::Claude,
+            &profile,
+            &fm,
+            &body,
+            &NativeModel::Inherit,
+        );
         let text = String::from_utf8(out.bytes).unwrap();
         assert!(text.contains("---"), "not markdown format");
 
         let content2 = "---\nname: coder\nmodel: gpt55\nharness: codex\n---\n# body";
         let (profile2, fm2, _) = profile_from(content2);
         let body2 = fm2.body().to_string();
-        let out2 = lower_for_harness_with_model(&HarnessKind::Codex, &profile2, &fm2, &body2, None);
+        let out2 = lower_for_harness_with_model(
+            &HarnessKind::Codex,
+            &profile2,
+            &fm2,
+            &body2,
+            &NativeModel::Inherit,
+        );
         let text2 = String::from_utf8(out2.bytes).unwrap();
         assert!(text2.contains("name = \"coder\""), "not TOML format");
         assert!(
@@ -1370,8 +1402,13 @@ mod tests {
 
         let content3 = "---\nname: cursor-agent\nmodel: gpt55\nharness: cursor\n---\n# body";
         let (profile3, fm3, _) = profile_from(content3);
-        let out3 =
-            lower_for_harness_with_model(&HarnessKind::Cursor, &profile3, &fm3, fm3.body(), None);
+        let out3 = lower_for_harness_with_model(
+            &HarnessKind::Cursor,
+            &profile3,
+            &fm3,
+            fm3.body(),
+            &NativeModel::Inherit,
+        );
         let text3 = String::from_utf8(out3.bytes).unwrap();
         assert!(
             text3.contains("name: cursor-agent"),

--- a/src/compiler/agents/mod.rs
+++ b/src/compiler/agents/mod.rs
@@ -89,6 +89,14 @@ impl HarnessKind {
             crate::harness::registry::HarnessId::Cursor => Self::Cursor,
         }
     }
+
+    /// Resolve a linked target directory (e.g. `.claude`) to its harness kind.
+    pub fn from_target_dir(target_root: &str) -> Option<Self> {
+        Self::all()
+            .iter()
+            .find(|harness| harness.target_dir() == target_root)
+            .cloned()
+    }
 }
 
 /// Approval policy field.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -73,6 +73,11 @@ pub fn compile(
         agent_copy_spec.as_ref(),
         ctx.meridian_managed,
     );
+    let configured_emit_harnesses: Vec<agents::HarnessKind> = effective_settings
+        .managed_targets()
+        .iter()
+        .filter_map(|t| agents::HarnessKind::from_target_dir(t))
+        .collect();
     let mars_dir = ctx.project_root.join(".mars");
     let model_aliases =
         native_agents::merged_model_aliases_for_native_agents(&applied.planned.targeted.resolved);
@@ -118,6 +123,7 @@ pub fn compile(
             cursor_probe_slugs: &cursor_probe_slugs,
             old_lock: native_ownership_lock,
             harness_scope: None,
+            configured_emit_harnesses: &configured_emit_harnesses,
             options: native_agents::NativeAgentSurfaceCompileOptions {
                 force: request.options.force,
                 collision_hint: crate::surface_ownership::CollisionAdoptHint::SyncForce,

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1,4 +1,4 @@
-/// Selective native agent emission via `settings.agent_copy`.
+/// Selective native agent emission via `settings.meridian.agent_copy`.
 pub mod agent_copy;
 /// Compiler stage — target building, diff, plan, apply, lock finalization.
 ///
@@ -64,7 +64,7 @@ pub fn compile(
     // Phase 3.2 / 3.3: Native agent surfaces — scan once; reconcile + compile after target sync.
     let effective_settings = &applied.planned.targeted.resolved.loaded.effective.settings;
     let agent_copy_spec = agent_copy::build_agent_copy_spec(
-        effective_settings.agent_copy.as_ref(),
+        effective_settings.meridian_agent_copy(),
         &effective_settings.managed_targets(),
         diag,
     );

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -14,6 +14,7 @@ pub mod context;
 pub mod hooks;
 /// MCP server compiler lane: discovery, env-ref validation, collision detection.
 pub mod mcp;
+pub(crate) mod native_agent_manifest;
 mod native_agents;
 /// Skill frontmatter compiler lane: universal schema parsing and native lowering.
 pub mod skills;
@@ -22,6 +23,7 @@ pub mod variants;
 /// Visibility propagation rules for passive vs effectful items (D1/D10).
 pub mod visibility;
 
+pub use native_agent_manifest::write_native_agent_manifest_from_lock;
 pub use native_agents::selective_native_orphan_preserve_paths;
 pub(crate) use native_agents::{
     NativeAgentLinkMaterializeCtx, RemovedNativeOutput, materialize_native_agents_after_link,

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -102,7 +102,6 @@ pub fn compile(
         policy: agent_surface_policy.clone(),
         project_root: &ctx.project_root,
         model_aliases: &model_aliases,
-        agent_overlays: &agent_overlays,
         outcomes,
         old_lock,
         dry_run: request.options.dry_run,
@@ -125,7 +124,6 @@ pub fn compile(
         Some(native_agents::NativeAgentCompileCtx {
             project_root: &ctx.project_root,
             model_aliases: &model_aliases,
-            agent_overlays: &agent_overlays,
             cursor_probe_slugs: &cursor_probe_slugs,
             old_lock: native_ownership_lock,
             harness_scope: None,
@@ -144,6 +142,7 @@ pub fn compile(
         &native_reconcile_ctx,
         &agent_surface_policy,
         &mars_agents,
+        &agent_overlays,
         native_compile_ctx.as_ref(),
         diag,
     );

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -94,10 +94,15 @@ pub fn compile(
 
     let old_lock = &synced.applied.planned.targeted.resolved.loaded.old_lock;
     let outcomes = &synced.applied.applied.outcomes;
+    let loaded = &synced.applied.planned.targeted.resolved.loaded;
+    // Per-agent overlays merged from mars.toml + mars.local.toml (loaded.effective is
+    // EffectiveConfig, which does not carry the overlay map).
+    let agent_overlays = crate::config::merged_agent_overlays(&loaded.config.agents, &loaded.local);
     let native_reconcile_ctx = native_agents::NativeAgentReconcileCtx {
         policy: agent_surface_policy.clone(),
         project_root: &ctx.project_root,
         model_aliases: &model_aliases,
+        agent_overlays: &agent_overlays,
         outcomes,
         old_lock,
         dry_run: request.options.dry_run,
@@ -120,6 +125,7 @@ pub fn compile(
         Some(native_agents::NativeAgentCompileCtx {
             project_root: &ctx.project_root,
             model_aliases: &model_aliases,
+            agent_overlays: &agent_overlays,
             cursor_probe_slugs: &cursor_probe_slugs,
             old_lock: native_ownership_lock,
             harness_scope: None,

--- a/src/compiler/native_agent_manifest.rs
+++ b/src/compiler/native_agent_manifest.rs
@@ -1,0 +1,322 @@
+//! On-disk native agent manifest (`.mars/native-agents.json`) — schema, lock projection, queries.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::compiler::agents::HarnessKind;
+use crate::error::{ConfigError, MarsError};
+use crate::lock::CompiledNativeOutput;
+
+const NATIVE_AGENT_MANIFEST_VERSION: u32 = 1;
+const NATIVE_AGENT_MANIFEST_FILENAME: &str = "native-agents.json";
+
+#[derive(Debug, Serialize, Deserialize)]
+struct NativeAgentManifestFile {
+    version: u32,
+    agents: HashMap<String, Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum NativeAgentManifestRead {
+    Found(HashMap<String, Vec<String>>),
+    Missing,
+    Unreadable,
+}
+
+/// Agent identity for manifest keys — must match inventory partition keys.
+///
+/// Native compile writes to `agents/{logical_name}.{ext}` where logical name is
+/// `profile.name` (falling back to the canonical file stem). Inventory lookup
+/// uses the same identity, so the manifest must derive from the native dest
+/// path, not the canonical `.mars` owner path (which follows on-disk filename).
+fn agent_name_from_native_dest(path: &str) -> Option<String> {
+    let name = path.strip_prefix("agents/")?;
+    let stem = Path::new(name).file_stem()?.to_str()?;
+    if stem.is_empty() {
+        return None;
+    }
+    Some(stem.to_string())
+}
+
+/// Native harness outputs recorded in the lock for agent items (canonical + linked targets).
+fn compiled_native_outputs_from_lock(lock: &crate::lock::LockFile) -> Vec<CompiledNativeOutput> {
+    use crate::lock::{CANONICAL_TARGET_ROOT, ItemKind};
+
+    let mut records = Vec::new();
+    for item in lock.items.values() {
+        if item.kind != ItemKind::Agent {
+            continue;
+        }
+        let Some(owner_canonical_dest_path) = item
+            .outputs
+            .iter()
+            .find(|output| {
+                output.target_root == CANONICAL_TARGET_ROOT
+                    && output.dest_path.as_str().starts_with("agents/")
+            })
+            .map(|output| output.dest_path.to_string())
+        else {
+            continue;
+        };
+        for output in &item.outputs {
+            if output.target_root == CANONICAL_TARGET_ROOT {
+                continue;
+            }
+            if HarnessKind::from_target_dir(&output.target_root).is_none() {
+                continue;
+            }
+            records.push(CompiledNativeOutput {
+                owner_canonical_dest_path: owner_canonical_dest_path.clone(),
+                target_root: output.target_root.clone(),
+                dest_path: output.dest_path.to_string(),
+                installed_checksum: output.installed_checksum.clone(),
+            });
+        }
+    }
+    records
+}
+
+fn manifest_agents_from_records(records: &[CompiledNativeOutput]) -> HashMap<String, Vec<String>> {
+    let mut agents: HashMap<String, Vec<String>> = HashMap::new();
+    for record in records {
+        let Some(agent_name) = agent_name_from_native_dest(&record.dest_path) else {
+            continue;
+        };
+        let Some(harness_kind) = HarnessKind::from_target_dir(&record.target_root) else {
+            continue;
+        };
+        let harness = harness_kind.to_harness_id().as_str().to_string();
+        let harnesses = agents.entry(agent_name).or_default();
+        if !harnesses.iter().any(|existing| existing == &harness) {
+            harnesses.push(harness);
+        }
+    }
+    for harnesses in agents.values_mut() {
+        harnesses.sort();
+    }
+    agents
+}
+
+fn manifest_path(mars_dir: &Path) -> PathBuf {
+    mars_dir.join(NATIVE_AGENT_MANIFEST_FILENAME)
+}
+
+fn read_native_agent_manifest_state(mars_dir: &Path) -> NativeAgentManifestRead {
+    let path = manifest_path(mars_dir);
+    let content = match std::fs::read_to_string(&path) {
+        Ok(content) => content,
+        Err(_) => return NativeAgentManifestRead::Missing,
+    };
+    let parsed: NativeAgentManifestFile = match serde_json::from_str(&content) {
+        Ok(parsed) => parsed,
+        Err(_) => return NativeAgentManifestRead::Unreadable,
+    };
+    if parsed.version != NATIVE_AGENT_MANIFEST_VERSION {
+        return NativeAgentManifestRead::Unreadable;
+    }
+    NativeAgentManifestRead::Found(parsed.agents)
+}
+
+fn write_native_agent_manifest_file(
+    project_root: &Path,
+    manifest: &NativeAgentManifestFile,
+) -> Result<(), MarsError> {
+    let mars_dir = project_root.join(".mars");
+    std::fs::create_dir_all(&mars_dir)?;
+    let path = manifest_path(&mars_dir);
+    let json = serde_json::to_string_pretty(manifest).map_err(|err| {
+        MarsError::Config(ConfigError::Invalid {
+            message: format!("failed to serialize native agent manifest: {err}"),
+        })
+    })?;
+    crate::fs::atomic_write(&path, json.as_bytes())
+}
+
+/// Write `.mars/native-agents.json` from the authoritative lock native-output set.
+pub fn write_native_agent_manifest_from_lock(
+    project_root: &Path,
+    lock: &crate::lock::LockFile,
+) -> Result<(), MarsError> {
+    let manifest = NativeAgentManifestFile {
+        version: NATIVE_AGENT_MANIFEST_VERSION,
+        agents: manifest_agents_from_records(&compiled_native_outputs_from_lock(lock)),
+    };
+    write_native_agent_manifest_file(project_root, &manifest)
+}
+
+/// Read `.mars/native-agents.json` for inventory rendering and diagnostics.
+pub fn read_native_agent_manifest(mars_dir: &Path) -> HashMap<String, Vec<String>> {
+    match read_native_agent_manifest_state(mars_dir) {
+        NativeAgentManifestRead::Found(agents) => agents,
+        NativeAgentManifestRead::Missing | NativeAgentManifestRead::Unreadable => HashMap::new(),
+    }
+}
+
+/// Whether `agent_name` is materialized natively for `harness` (HarnessId snake_case string).
+pub fn agent_is_native_for_harness(
+    manifest: &HashMap<String, Vec<String>>,
+    agent_name: &str,
+    harness: &str,
+) -> bool {
+    manifest
+        .get(agent_name)
+        .is_some_and(|harnesses| harnesses.iter().any(|entry| entry == harness))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compiler::agents::HarnessKind;
+    use crate::lock::{ItemKind, LockFile, LockedItemV2, OutputRecord};
+    use tempfile::TempDir;
+
+    fn lock_with_agent_outputs(
+        agent_key: &str,
+        canonical_dest: &str,
+        native_targets: &[(&str, &str)],
+    ) -> LockFile {
+        let mut lock = LockFile::empty();
+        let mut outputs = vec![OutputRecord {
+            target_root: ".mars".to_string(),
+            dest_path: canonical_dest.into(),
+            installed_checksum: "sha256:src".into(),
+        }];
+        for (target_root, dest_path) in native_targets {
+            outputs.push(OutputRecord {
+                target_root: (*target_root).to_string(),
+                dest_path: (*dest_path).into(),
+                installed_checksum: "sha256:native".into(),
+            });
+        }
+        lock.items.insert(
+            agent_key.to_string(),
+            LockedItemV2 {
+                source: "test".into(),
+                kind: ItemKind::Agent,
+                version: None,
+                source_checksum: "sha256:src".into(),
+                outputs,
+            },
+        );
+        lock
+    }
+
+    #[test]
+    fn manifest_round_trips_through_read() {
+        let dir = TempDir::new().unwrap();
+        let lock = lock_with_agent_outputs(
+            "agent/coder",
+            "agents/coder.md",
+            &[
+                (HarnessKind::Claude.target_dir(), "agents/coder.md"),
+                (HarnessKind::Codex.target_dir(), "agents/coder.toml"),
+            ],
+        );
+        let lock = {
+            let mut lock = lock;
+            lock.items.insert(
+                "agent/frontend-coder".to_string(),
+                LockedItemV2 {
+                    source: "test".into(),
+                    kind: ItemKind::Agent,
+                    version: None,
+                    source_checksum: "sha256:src".into(),
+                    outputs: vec![
+                        OutputRecord {
+                            target_root: ".mars".to_string(),
+                            dest_path: "agents/frontend-coder.md".into(),
+                            installed_checksum: "sha256:src".into(),
+                        },
+                        OutputRecord {
+                            target_root: HarnessKind::Claude.target_dir().to_string(),
+                            dest_path: "agents/frontend-coder.md".into(),
+                            installed_checksum: "sha256:native".into(),
+                        },
+                    ],
+                },
+            );
+            lock
+        };
+
+        write_native_agent_manifest_from_lock(dir.path(), &lock).unwrap();
+
+        let manifest = read_native_agent_manifest(&dir.path().join(".mars"));
+        let coder_harnesses: Option<Vec<&str>> = manifest
+            .get("coder")
+            .map(|v| v.iter().map(String::as_str).collect());
+        assert_eq!(
+            coder_harnesses.as_deref(),
+            Some(["claude", "codex"].as_slice())
+        );
+        let frontend_harnesses: Option<Vec<&str>> = manifest
+            .get("frontend-coder")
+            .map(|v| v.iter().map(String::as_str).collect());
+        assert_eq!(frontend_harnesses.as_deref(), Some(["claude"].as_slice()));
+    }
+
+    #[test]
+    fn manifest_from_lock_reflects_authoritative_lock_not_stale_file() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join(".mars")).unwrap();
+        std::fs::write(
+            dir.path().join(".mars").join("native-agents.json"),
+            r#"{"version":1,"agents":{"coder":["codex"]}}"#,
+        )
+        .unwrap();
+
+        let lock = lock_with_agent_outputs(
+            "agent/coder",
+            "agents/coder.md",
+            &[(HarnessKind::Claude.target_dir(), "agents/coder.md")],
+        );
+
+        write_native_agent_manifest_from_lock(dir.path(), &lock).unwrap();
+
+        let manifest = read_native_agent_manifest(&dir.path().join(".mars"));
+        let coder_harnesses: Option<Vec<&str>> = manifest
+            .get("coder")
+            .map(|v| v.iter().map(String::as_str).collect());
+        assert_eq!(coder_harnesses.as_deref(), Some(["claude"].as_slice()));
+        assert!(
+            !manifest
+                .get("coder")
+                .is_some_and(|h| h.iter().any(|harness| harness == "codex")),
+            "stale codex entry must be replaced by lock projection"
+        );
+    }
+
+    #[test]
+    fn manifest_uses_logical_name_from_native_dest_not_canonical_filename() {
+        let dir = TempDir::new().unwrap();
+        let lock = lock_with_agent_outputs(
+            "agent/my-file",
+            "agents/my-file.md",
+            &[(HarnessKind::Claude.target_dir(), "agents/logical-name.md")],
+        );
+
+        write_native_agent_manifest_from_lock(dir.path(), &lock).unwrap();
+
+        let manifest = read_native_agent_manifest(&dir.path().join(".mars"));
+        let logical_harnesses: Option<Vec<&str>> = manifest
+            .get("logical-name")
+            .map(|v| v.iter().map(String::as_str).collect());
+        assert_eq!(logical_harnesses.as_deref(), Some(["claude"].as_slice()));
+        assert!(
+            !manifest.contains_key("my-file"),
+            "manifest must not key by canonical filename when native dest uses profile name"
+        );
+    }
+
+    #[test]
+    fn agent_is_native_for_harness_matches_manifest_membership() {
+        let mut manifest = HashMap::new();
+        manifest.insert("coder".to_string(), vec!["claude".to_string()]);
+        assert!(agent_is_native_for_harness(&manifest, "coder", "claude"));
+        assert!(!agent_is_native_for_harness(&manifest, "coder", "codex"));
+        assert!(!agent_is_native_for_harness(
+            &manifest, "explorer", "claude"
+        ));
+    }
+}

--- a/src/compiler/native_agents.rs
+++ b/src/compiler/native_agents.rs
@@ -20,6 +20,9 @@ pub(crate) struct NativeAgentReconcileCtx<'a> {
     pub policy: AgentSurfacePolicy,
     pub project_root: &'a Path,
     pub model_aliases: &'a IndexMap<String, ModelAlias>,
+    /// Per-agent overlays (mars.toml `[agents.<name>]`) keyed by agent name; supplies
+    /// `overlay.model` / `overlay.model_policies` to native qualification (not `overlay.harness`).
+    pub agent_overlays: &'a indexmap::IndexMap<String, crate::config::AgentOverlay>,
     pub outcomes: &'a [ActionOutcome],
     pub old_lock: &'a crate::lock::LockFile,
     pub dry_run: bool,
@@ -37,6 +40,9 @@ pub(crate) struct NativeAgentSurfaceCompileOptions {
 pub(crate) struct NativeAgentCompileCtx<'a> {
     pub project_root: &'a Path,
     pub model_aliases: &'a IndexMap<String, ModelAlias>,
+    /// Per-agent overlays (mars.toml `[agents.<name>]`) keyed by agent name; supplies
+    /// `overlay.model` / `overlay.model_policies` to native qualification (not `overlay.harness`).
+    pub agent_overlays: &'a indexmap::IndexMap<String, crate::config::AgentOverlay>,
     pub cursor_probe_slugs: &'a [String],
     pub old_lock: &'a crate::lock::LockFile,
     pub harness_scope: Option<&'a [crate::compiler::agents::HarnessKind]>,
@@ -284,10 +290,14 @@ fn reconcile_selective_native_agent_surfaces(
 ) -> Vec<RemovedNativeOutput> {
     let mut removed = Vec::new();
     for agent in mars_agents {
+        // Overlay-aware qualification keeps reconcile consistent with emission: an
+        // overlay model that resolves to a harness must not be pruned.
+        let overlay = ctx.agent_overlays.get(&agent.agent_name);
+        let effective_profile = effective_native_profile(&agent.profile, overlay);
         for harness in harnesses {
             let qualifies = spec.harnesses.contains(harness)
                 && agent_copy::agent_qualifies_for_harness(
-                    &agent.profile,
+                    &effective_profile,
                     harness,
                     ctx.model_aliases,
                     spec.include_fanout,
@@ -366,16 +376,20 @@ pub(crate) fn compile_native_agents(
     let mut records = Vec::new();
 
     for agent in mars_agents {
-        for (harness, directive) in qualifying_emissions(agent, policy, ctx, diag) {
+        // Merge per-agent overlay (model + model_policies) over the profile before
+        // qualification and emission; overlay.harness is intentionally ignored.
+        let overlay = ctx.agent_overlays.get(&agent.agent_name);
+        let effective_profile = effective_native_profile(&agent.profile, overlay);
+        for (harness, directive) in qualifying_emissions(&effective_profile, policy, ctx, diag) {
             // `Clear` emits to a harness the agent's model does not resolve to;
-            // strip the profile model so lowering writes no model field.
+            // strip the model so lowering writes no model field.
             let cleared_profile;
             let (profile, model_override): (&crate::compiler::agents::AgentProfile, Option<&str>) =
                 match &directive {
-                    NativeModelDirective::Resolved(model) => (&agent.profile, model.as_deref()),
+                    NativeModelDirective::Resolved(model) => (&effective_profile, model.as_deref()),
                     NativeModelDirective::Clear => {
                         cleared_profile = {
-                            let mut p = agent.profile.clone();
+                            let mut p = effective_profile.clone();
                             p.model = None;
                             p
                         };
@@ -402,6 +416,29 @@ pub(crate) fn compile_native_agents(
     records
 }
 
+/// Merge a per-agent overlay's model selection over the canonical profile for native
+/// emission: `overlay.model` wins over `profile.model`, and overlay policies take
+/// precedence over profile policies (shared with launch-bundle via the config helpers).
+/// `overlay.harness` is intentionally ignored — native coverage is configured-target
+/// driven, not overlay-routed.
+fn effective_native_profile(
+    profile: &crate::compiler::agents::AgentProfile,
+    overlay: Option<&crate::config::AgentOverlay>,
+) -> crate::compiler::agents::AgentProfile {
+    let Some(overlay) = overlay else {
+        return profile.clone();
+    };
+    let mut effective = profile.clone();
+    effective.model =
+        crate::config::overlay_then_profile_model(Some(overlay), profile.model.as_deref())
+            .map(|model| model.to_string());
+    effective.model_policies =
+        crate::config::overlay_then_profile_policies(Some(overlay), &profile.model_policies)
+            .map(|(_, _, rule)| rule.clone())
+            .collect();
+    effective
+}
+
 /// What model field a native emission should carry.
 ///
 /// `Option<String>` alone is two-state ("pin this id" vs "fall back to the
@@ -418,7 +455,7 @@ enum NativeModelDirective {
 }
 
 fn qualifying_emissions(
-    agent: &MarsCanonicalAgent,
+    profile: &crate::compiler::agents::AgentProfile,
     policy: &AgentSurfacePolicy,
     ctx: &NativeAgentCompileCtx<'_>,
     diag: &mut DiagnosticCollector,
@@ -439,14 +476,14 @@ fn qualifying_emissions(
                     continue;
                 }
                 let directive = match agent_copy::agent_qualifies_for_harness(
-                    &agent.profile,
+                    profile,
                     harness,
                     ctx.model_aliases,
                     true,
                 ) {
                     Some(emission) => NativeModelDirective::Resolved(model_override_for_emission(
                         harness,
-                        &agent.profile,
+                        profile,
                         &emission,
                         ctx.model_aliases,
                         ctx.cursor_probe_slugs,
@@ -465,7 +502,7 @@ fn qualifying_emissions(
                     continue;
                 }
                 let Some(emission) = agent_copy::agent_qualifies_for_harness(
-                    &agent.profile,
+                    profile,
                     harness,
                     ctx.model_aliases,
                     spec.include_fanout,
@@ -474,7 +511,7 @@ fn qualifying_emissions(
                 };
                 let directive = NativeModelDirective::Resolved(model_override_for_emission(
                     harness,
-                    &agent.profile,
+                    profile,
                     &emission,
                     ctx.model_aliases,
                     ctx.cursor_probe_slugs,
@@ -808,6 +845,9 @@ pub(crate) fn materialize_native_agents_after_link(
         input.local,
         diag,
     );
+    // Per-agent overlays merged from mars.toml + mars.local.toml (link path lacks the
+    // project-level effective.agents map the sync path carries).
+    let agent_overlays = crate::config::merged_agent_overlays(&input.config.agents, input.local);
     let harness_scope = Some(link_harness_scope.as_slice());
     let configured_emit_harnesses: Vec<_> = input
         .managed_targets
@@ -818,6 +858,7 @@ pub(crate) fn materialize_native_agents_after_link(
         policy: policy.clone(),
         project_root: &input.mars_ctx.project_root,
         model_aliases: &model_aliases,
+        agent_overlays: &agent_overlays,
         outcomes: &[],
         old_lock: input.old_lock,
         dry_run: false,
@@ -832,6 +873,7 @@ pub(crate) fn materialize_native_agents_after_link(
         Some(NativeAgentCompileCtx {
             project_root: &input.mars_ctx.project_root,
             model_aliases: &model_aliases,
+            agent_overlays: &agent_overlays,
             cursor_probe_slugs: &cached_cursor_probe_slugs_for_native_agents(),
             old_lock: &ownership_lock,
             harness_scope,

--- a/src/compiler/native_agents.rs
+++ b/src/compiler/native_agents.rs
@@ -734,7 +734,7 @@ pub(crate) fn materialize_native_agents_after_link(
     if !input
         .managed_targets
         .iter()
-        .any(|target| HarnessKind::all().iter().any(|h| h.target_dir() == target))
+        .any(|target| HarnessKind::from_target_dir(target).is_some())
     {
         return (Vec::new(), Vec::new());
     }
@@ -742,12 +742,7 @@ pub(crate) fn materialize_native_agents_after_link(
     let link_harness_scope: Vec<_> = input
         .target_outcomes
         .iter()
-        .filter_map(|outcome| {
-            HarnessKind::all()
-                .iter()
-                .find(|harness| harness.target_dir() == outcome.target)
-                .cloned()
-        })
+        .filter_map(|outcome| HarnessKind::from_target_dir(&outcome.target))
         .collect();
     if link_harness_scope.is_empty() {
         return (Vec::new(), Vec::new());
@@ -801,13 +796,14 @@ pub(crate) fn materialize_native_agents_after_link(
             },
         })
     };
-    run_native_agent_post_sync_lifecycle(
+    let (compiled_native_outputs, removed_native_outputs) = run_native_agent_post_sync_lifecycle(
         &reconcile_ctx,
         &policy,
         &mars_agents,
         compile_ctx.as_ref(),
         diag,
-    )
+    );
+    (compiled_native_outputs, removed_native_outputs)
 }
 
 #[cfg(test)]

--- a/src/compiler/native_agents.rs
+++ b/src/compiler/native_agents.rs
@@ -749,7 +749,7 @@ pub(crate) fn materialize_native_agents_after_link(
     }
 
     let agent_copy_spec = agent_copy::build_agent_copy_spec(
-        input.effective.settings.agent_copy.as_ref(),
+        input.effective.settings.meridian_agent_copy(),
         input.managed_targets,
         diag,
     );

--- a/src/compiler/native_agents.rs
+++ b/src/compiler/native_agents.rs
@@ -20,9 +20,6 @@ pub(crate) struct NativeAgentReconcileCtx<'a> {
     pub policy: AgentSurfacePolicy,
     pub project_root: &'a Path,
     pub model_aliases: &'a IndexMap<String, ModelAlias>,
-    /// Per-agent overlays (mars.toml `[agents.<name>]`) keyed by agent name; supplies
-    /// `overlay.model` / `overlay.model_policies` to native qualification (not `overlay.harness`).
-    pub agent_overlays: &'a indexmap::IndexMap<String, crate::config::AgentOverlay>,
     pub outcomes: &'a [ActionOutcome],
     pub old_lock: &'a crate::lock::LockFile,
     pub dry_run: bool,
@@ -40,9 +37,6 @@ pub(crate) struct NativeAgentSurfaceCompileOptions {
 pub(crate) struct NativeAgentCompileCtx<'a> {
     pub project_root: &'a Path,
     pub model_aliases: &'a IndexMap<String, ModelAlias>,
-    /// Per-agent overlays (mars.toml `[agents.<name>]`) keyed by agent name; supplies
-    /// `overlay.model` / `overlay.model_policies` to native qualification (not `overlay.harness`).
-    pub agent_overlays: &'a indexmap::IndexMap<String, crate::config::AgentOverlay>,
     pub cursor_probe_slugs: &'a [String],
     pub old_lock: &'a crate::lock::LockFile,
     pub harness_scope: Option<&'a [crate::compiler::agents::HarnessKind]>,
@@ -290,14 +284,12 @@ fn reconcile_selective_native_agent_surfaces(
 ) -> Vec<RemovedNativeOutput> {
     let mut removed = Vec::new();
     for agent in mars_agents {
-        // Overlay-aware qualification keeps reconcile consistent with emission: an
-        // overlay model that resolves to a harness must not be pruned.
-        let overlay = ctx.agent_overlays.get(&agent.agent_name);
-        let effective_profile = effective_native_profile(&agent.profile, overlay);
+        // `agent.profile` is already overlay-resolved (see the lifecycle), so reconcile
+        // and emission qualify against identical effective profiles.
         for harness in harnesses {
             let qualifies = spec.harnesses.contains(harness)
                 && agent_copy::agent_qualifies_for_harness(
-                    &effective_profile,
+                    &agent.profile,
                     harness,
                     ctx.model_aliases,
                     spec.include_fanout,
@@ -375,18 +367,17 @@ pub(crate) fn compile_native_agents(
     };
     let mut records = Vec::new();
 
+    // `mars_agents` carry already overlay-resolved profiles (resolved once in
+    // run_native_agent_post_sync_lifecycle for both reconcile and compile).
     for agent in mars_agents {
-        // Merge per-agent overlay (model + model_policies) over the profile before
-        // qualification and emission; overlay.harness is intentionally ignored.
-        let overlay = ctx.agent_overlays.get(&agent.agent_name);
-        let effective_profile = effective_native_profile(&agent.profile, overlay);
-        for (harness, directive) in qualifying_emissions(&effective_profile, policy, ctx, diag) {
+        let effective_profile = &agent.profile;
+        for (harness, directive) in qualifying_emissions(effective_profile, policy, ctx, diag) {
             // `Clear` emits to a harness the agent's model does not resolve to;
             // strip the model so lowering writes no model field.
             let cleared_profile;
             let (profile, model_override): (&crate::compiler::agents::AgentProfile, Option<&str>) =
                 match &directive {
-                    NativeModelDirective::Resolved(model) => (&effective_profile, model.as_deref()),
+                    NativeModelDirective::Resolved(model) => (effective_profile, model.as_deref()),
                     NativeModelDirective::Clear => {
                         cleared_profile = {
                             let mut p = effective_profile.clone();
@@ -791,15 +782,41 @@ pub(crate) fn run_native_agent_post_sync_lifecycle(
     reconcile_ctx: &NativeAgentReconcileCtx<'_>,
     policy: &AgentSurfacePolicy,
     mars_agents: &[MarsCanonicalAgent],
+    agent_overlays: &indexmap::IndexMap<String, crate::config::AgentOverlay>,
     compile_ctx: Option<&NativeAgentCompileCtx<'_>>,
     diag: &mut DiagnosticCollector,
 ) -> (Vec<CompiledNativeOutput>, Vec<RemovedNativeOutput>) {
-    let removed_native_outputs = reconcile_native_agent_surfaces(reconcile_ctx, mars_agents, diag);
+    // Resolve per-agent overlays into effective profiles ONCE here, so reconcile and
+    // compile qualify against identical state without each re-deriving it (and without
+    // threading the overlay map through their contexts).
+    let resolved = resolve_native_agent_profiles(mars_agents, agent_overlays);
+    let removed_native_outputs = reconcile_native_agent_surfaces(reconcile_ctx, &resolved, diag);
     let compiled_native_outputs = match compile_ctx {
         None => Vec::new(),
-        Some(ctx) => compile_native_agents(ctx, policy, mars_agents, diag),
+        Some(ctx) => compile_native_agents(ctx, policy, &resolved, diag),
     };
     (compiled_native_outputs, removed_native_outputs)
+}
+
+/// Apply each agent's overlay (`overlay.model` / `overlay.model_policies`) over its
+/// canonical profile, yielding agents whose `profile` is the effective native profile.
+/// Single source of overlay merging for the native lifecycle.
+fn resolve_native_agent_profiles(
+    mars_agents: &[MarsCanonicalAgent],
+    agent_overlays: &indexmap::IndexMap<String, crate::config::AgentOverlay>,
+) -> Vec<MarsCanonicalAgent> {
+    mars_agents
+        .iter()
+        .map(|agent| MarsCanonicalAgent {
+            agent_name: agent.agent_name.clone(),
+            canonical_dest_path: agent.canonical_dest_path.clone(),
+            profile: effective_native_profile(
+                &agent.profile,
+                agent_overlays.get(&agent.agent_name),
+            ),
+            fm: agent.fm.clone(),
+        })
+        .collect()
 }
 
 /// Reconcile and compile native harness agents after `mars link` (same path as sync).
@@ -858,7 +875,6 @@ pub(crate) fn materialize_native_agents_after_link(
         policy: policy.clone(),
         project_root: &input.mars_ctx.project_root,
         model_aliases: &model_aliases,
-        agent_overlays: &agent_overlays,
         outcomes: &[],
         old_lock: input.old_lock,
         dry_run: false,
@@ -873,7 +889,6 @@ pub(crate) fn materialize_native_agents_after_link(
         Some(NativeAgentCompileCtx {
             project_root: &input.mars_ctx.project_root,
             model_aliases: &model_aliases,
-            agent_overlays: &agent_overlays,
             cursor_probe_slugs: &cached_cursor_probe_slugs_for_native_agents(),
             old_lock: &ownership_lock,
             harness_scope,
@@ -889,6 +904,7 @@ pub(crate) fn materialize_native_agents_after_link(
         &reconcile_ctx,
         &policy,
         &mars_agents,
+        &agent_overlays,
         compile_ctx.as_ref(),
         diag,
     );

--- a/src/compiler/native_agents.rs
+++ b/src/compiler/native_agents.rs
@@ -51,7 +51,7 @@ struct NativeAgentEmit<'a> {
     body: &'a str,
     agent_name: &'a str,
     canonical_dest_path: &'a str,
-    model_override: Option<&'a str>,
+    model: &'a crate::compiler::agents::lower::NativeModel,
 }
 
 struct NativeAgentEmitCtx<'a> {
@@ -371,31 +371,16 @@ pub(crate) fn compile_native_agents(
     // run_native_agent_post_sync_lifecycle for both reconcile and compile).
     for agent in mars_agents {
         let effective_profile = &agent.profile;
-        for (harness, directive) in qualifying_emissions(effective_profile, policy, ctx, diag) {
-            // `Clear` emits to a harness the agent's model does not resolve to;
-            // strip the model so lowering writes no model field.
-            let cleared_profile;
-            let (profile, model_override): (&crate::compiler::agents::AgentProfile, Option<&str>) =
-                match &directive {
-                    NativeModelDirective::Resolved(model) => (effective_profile, model.as_deref()),
-                    NativeModelDirective::Clear => {
-                        cleared_profile = {
-                            let mut p = effective_profile.clone();
-                            p.model = None;
-                            p
-                        };
-                        (&cleared_profile, None)
-                    }
-                };
+        for (harness, model) in qualifying_emissions(effective_profile, policy, ctx, diag) {
             emit_lowered_native_agent(
                 &NativeAgentEmit {
                     harness: &harness,
-                    profile,
+                    profile: effective_profile,
                     fm: &agent.fm,
                     body: agent.fm.body(),
                     agent_name: &agent.agent_name,
                     canonical_dest_path: &agent.canonical_dest_path,
-                    model_override,
+                    model: &model,
                 },
                 &emit_ctx,
                 diag,
@@ -430,19 +415,16 @@ fn effective_native_profile(
     effective
 }
 
-/// What model field a native emission should carry.
-///
-/// `Option<String>` alone is two-state ("pin this id" vs "fall back to the
-/// profile's own model"); full-coverage `EmitAll` needs a third state that
-/// clears the model entirely when an agent is emitted to a harness whose model
-/// it does not resolve to.
-#[derive(Debug, Clone)]
-enum NativeModelDirective {
-    /// Qualified emission: pin `Some(id)`, or `None` to emit the profile's own
-    /// model verbatim (e.g. an unpinned alias or a fanout token).
-    Resolved(Option<String>),
-    /// Full-coverage emission to a non-resolving harness: emit no model field.
-    Clear,
+/// Map a resolved model override (`Some(id)` to pin, `None` to inherit the profile's
+/// own model) to the lowering boundary's [`crate::compiler::agents::lower::NativeModel`].
+fn native_model_from_override(
+    model_override: Option<String>,
+) -> crate::compiler::agents::lower::NativeModel {
+    use crate::compiler::agents::lower::NativeModel;
+    match model_override {
+        Some(id) => NativeModel::Set(id),
+        None => NativeModel::Inherit,
+    }
 }
 
 fn qualifying_emissions(
@@ -450,7 +432,10 @@ fn qualifying_emissions(
     policy: &AgentSurfacePolicy,
     ctx: &NativeAgentCompileCtx<'_>,
     diag: &mut DiagnosticCollector,
-) -> Vec<(crate::compiler::agents::HarnessKind, NativeModelDirective)> {
+) -> Vec<(
+    crate::compiler::agents::HarnessKind,
+    crate::compiler::agents::lower::NativeModel,
+)> {
     use crate::compiler::agents::HarnessKind;
 
     let in_scope = |harness: &HarnessKind| {
@@ -466,13 +451,13 @@ fn qualifying_emissions(
                 if !in_scope(harness) {
                     continue;
                 }
-                let directive = match agent_copy::agent_qualifies_for_harness(
+                let model = match agent_copy::agent_qualifies_for_harness(
                     profile,
                     harness,
                     ctx.model_aliases,
                     true,
                 ) {
-                    Some(emission) => NativeModelDirective::Resolved(model_override_for_emission(
+                    Some(emission) => native_model_from_override(model_override_for_emission(
                         harness,
                         profile,
                         &emission,
@@ -480,9 +465,9 @@ fn qualifying_emissions(
                         ctx.cursor_probe_slugs,
                         diag,
                     )),
-                    None => NativeModelDirective::Clear,
+                    None => crate::compiler::agents::lower::NativeModel::Clear,
                 };
-                emissions.push((harness.clone(), directive));
+                emissions.push((harness.clone(), model));
             }
             emissions
         }
@@ -500,7 +485,7 @@ fn qualifying_emissions(
                 ) else {
                     continue;
                 };
-                let directive = NativeModelDirective::Resolved(model_override_for_emission(
+                let model = native_model_from_override(model_override_for_emission(
                     harness,
                     profile,
                     &emission,
@@ -508,7 +493,7 @@ fn qualifying_emissions(
                     ctx.cursor_probe_slugs,
                     diag,
                 ));
-                emissions.push((harness.clone(), directive));
+                emissions.push((harness.clone(), model));
             }
             emissions
         }
@@ -529,7 +514,7 @@ fn emit_lowered_native_agent(
         agent.profile,
         agent.fm,
         agent.body,
-        agent.model_override,
+        agent.model,
     );
 
     for lf in &lowered.lossy_fields {

--- a/src/compiler/native_agents.rs
+++ b/src/compiler/native_agents.rs
@@ -40,6 +40,7 @@ pub(crate) struct NativeAgentCompileCtx<'a> {
     pub cursor_probe_slugs: &'a [String],
     pub old_lock: &'a crate::lock::LockFile,
     pub harness_scope: Option<&'a [crate::compiler::agents::HarnessKind]>,
+    pub configured_emit_harnesses: &'a [crate::compiler::agents::HarnessKind],
     pub options: NativeAgentSurfaceCompileOptions,
 }
 
@@ -365,16 +366,31 @@ pub(crate) fn compile_native_agents(
     let mut records = Vec::new();
 
     for agent in mars_agents {
-        for (harness, model_override) in qualifying_emissions(agent, policy, ctx, diag) {
+        for (harness, directive) in qualifying_emissions(agent, policy, ctx, diag) {
+            // `Clear` emits to a harness the agent's model does not resolve to;
+            // strip the profile model so lowering writes no model field.
+            let cleared_profile;
+            let (profile, model_override): (&crate::compiler::agents::AgentProfile, Option<&str>) =
+                match &directive {
+                    NativeModelDirective::Resolved(model) => (&agent.profile, model.as_deref()),
+                    NativeModelDirective::Clear => {
+                        cleared_profile = {
+                            let mut p = agent.profile.clone();
+                            p.model = None;
+                            p
+                        };
+                        (&cleared_profile, None)
+                    }
+                };
             emit_lowered_native_agent(
                 &NativeAgentEmit {
                     harness: &harness,
-                    profile: &agent.profile,
+                    profile,
                     fm: &agent.fm,
                     body: agent.fm.body(),
                     agent_name: &agent.agent_name,
                     canonical_dest_path: &agent.canonical_dest_path,
-                    model_override: model_override.as_deref(),
+                    model_override,
                 },
                 &emit_ctx,
                 diag,
@@ -386,12 +402,27 @@ pub(crate) fn compile_native_agents(
     records
 }
 
+/// What model field a native emission should carry.
+///
+/// `Option<String>` alone is two-state ("pin this id" vs "fall back to the
+/// profile's own model"); full-coverage `EmitAll` needs a third state that
+/// clears the model entirely when an agent is emitted to a harness whose model
+/// it does not resolve to.
+#[derive(Debug, Clone)]
+enum NativeModelDirective {
+    /// Qualified emission: pin `Some(id)`, or `None` to emit the profile's own
+    /// model verbatim (e.g. an unpinned alias or a fanout token).
+    Resolved(Option<String>),
+    /// Full-coverage emission to a non-resolving harness: emit no model field.
+    Clear,
+}
+
 fn qualifying_emissions(
     agent: &MarsCanonicalAgent,
     policy: &AgentSurfacePolicy,
     ctx: &NativeAgentCompileCtx<'_>,
     diag: &mut DiagnosticCollector,
-) -> Vec<(crate::compiler::agents::HarnessKind, Option<String>)> {
+) -> Vec<(crate::compiler::agents::HarnessKind, NativeModelDirective)> {
     use crate::compiler::agents::HarnessKind;
 
     let in_scope = |harness: &HarnessKind| {
@@ -402,20 +433,30 @@ fn qualifying_emissions(
     match policy {
         AgentSurfacePolicy::SuppressAll => Vec::new(),
         AgentSurfacePolicy::EmitAll => {
-            let Some(harness) = agent.profile.harness.as_ref() else {
-                return Vec::new();
-            };
-            if !in_scope(harness) {
-                return Vec::new();
+            let mut emissions = Vec::new();
+            for harness in ctx.configured_emit_harnesses {
+                if !in_scope(harness) {
+                    continue;
+                }
+                let directive = match agent_copy::agent_qualifies_for_harness(
+                    &agent.profile,
+                    harness,
+                    ctx.model_aliases,
+                    true,
+                ) {
+                    Some(emission) => NativeModelDirective::Resolved(model_override_for_emission(
+                        harness,
+                        &agent.profile,
+                        &emission,
+                        ctx.model_aliases,
+                        ctx.cursor_probe_slugs,
+                        diag,
+                    )),
+                    None => NativeModelDirective::Clear,
+                };
+                emissions.push((harness.clone(), directive));
             }
-            let model_override = native_model_override_for_harness(
-                harness,
-                &agent.profile,
-                ctx.model_aliases,
-                ctx.cursor_probe_slugs,
-                diag,
-            );
-            vec![(harness.clone(), model_override)]
+            emissions
         }
         AgentSurfacePolicy::EmitSelective(spec) => {
             let mut emissions = Vec::new();
@@ -431,15 +472,15 @@ fn qualifying_emissions(
                 ) else {
                     continue;
                 };
-                let model_override = model_override_for_emission(
+                let directive = NativeModelDirective::Resolved(model_override_for_emission(
                     harness,
                     &agent.profile,
                     &emission,
                     ctx.model_aliases,
                     ctx.cursor_probe_slugs,
                     diag,
-                );
-                emissions.push((harness.clone(), model_override));
+                ));
+                emissions.push((harness.clone(), directive));
             }
             emissions
         }
@@ -768,6 +809,11 @@ pub(crate) fn materialize_native_agents_after_link(
         diag,
     );
     let harness_scope = Some(link_harness_scope.as_slice());
+    let configured_emit_harnesses: Vec<_> = input
+        .managed_targets
+        .iter()
+        .filter_map(|t| HarnessKind::from_target_dir(t))
+        .collect();
     let reconcile_ctx = NativeAgentReconcileCtx {
         policy: policy.clone(),
         project_root: &input.mars_ctx.project_root,
@@ -789,6 +835,7 @@ pub(crate) fn materialize_native_agents_after_link(
             cursor_probe_slugs: &cached_cursor_probe_slugs_for_native_agents(),
             old_lock: &ownership_lock,
             harness_scope,
+            configured_emit_harnesses: &configured_emit_harnesses,
             options: NativeAgentSurfaceCompileOptions {
                 force: input.force,
                 collision_hint: crate::surface_ownership::CollisionAdoptHint::LinkForce,

--- a/src/compiler/native_agents/tests.rs
+++ b/src/compiler/native_agents/tests.rs
@@ -174,7 +174,6 @@ fn link_suppress_all_reconciles_selective_native_target() {
             policy: AgentSurfacePolicy::SuppressAll,
             project_root: dir.path(),
             model_aliases: &IndexMap::new(),
-            agent_overlays: &IndexMap::new(),
             outcomes: &[],
             old_lock: &lock,
             dry_run: false,
@@ -239,7 +238,6 @@ fn reconcile_selective_removes_native_when_agent_stops_qualifying() {
             policy: AgentSurfacePolicy::EmitSelective(spec),
             project_root: dir.path(),
             model_aliases: &aliases,
-            agent_overlays: &IndexMap::new(),
             outcomes: &[],
             old_lock: &lock,
             dry_run: false,
@@ -320,7 +318,6 @@ fn reconcile_selective_keeps_lock_when_native_remove_fails() {
             policy: AgentSurfacePolicy::EmitSelective(spec),
             project_root: dir.path(),
             model_aliases: &aliases,
-            agent_overlays: &IndexMap::new(),
             outcomes: &[],
             old_lock: &lock,
             dry_run: false,
@@ -363,11 +360,9 @@ fn compile_emit_all_agents(
     aliases: &IndexMap<String, ModelAlias>,
 ) -> Vec<CompiledNativeOutput> {
     let mut diag = DiagnosticCollector::new();
-    let empty_overlays: IndexMap<String, crate::config::AgentOverlay> = IndexMap::new();
     let ctx = NativeAgentCompileCtx {
         project_root: dir,
         model_aliases: aliases,
-        agent_overlays: &empty_overlays,
         cursor_probe_slugs: &[],
         old_lock: &LockFile::empty(),
         harness_scope: None,
@@ -527,7 +522,6 @@ fn compile_emit_all_with_overlays(
     let ctx = NativeAgentCompileCtx {
         project_root: dir,
         model_aliases: aliases,
-        agent_overlays: overlays,
         cursor_probe_slugs: &[],
         old_lock: &LockFile::empty(),
         harness_scope: None,
@@ -538,7 +532,9 @@ fn compile_emit_all_with_overlays(
             dry_run: false,
         },
     };
-    compile_native_agents(&ctx, &AgentSurfacePolicy::EmitAll, agents, &mut diag)
+    // Mirror the lifecycle: resolve overlays before compile (compile no longer merges).
+    let resolved = resolve_native_agent_profiles(agents, overlays);
+    compile_native_agents(&ctx, &AgentSurfacePolicy::EmitAll, &resolved, &mut diag)
 }
 
 #[test]

--- a/src/compiler/native_agents/tests.rs
+++ b/src/compiler/native_agents/tests.rs
@@ -112,14 +112,16 @@ fn non_cursor_native_model_mapping_handles_pinned_raw_and_unpinned_aliases() {
 
 fn lock_with_target_outputs(targets: &[&str], dest: &str, checksum: &str) -> LockFile {
     let mut lock = LockFile::empty();
-    let outputs = targets
-        .iter()
-        .map(|target| OutputRecord {
-            target_root: (*target).to_string(),
-            dest_path: dest.into(),
-            installed_checksum: checksum.into(),
-        })
-        .collect();
+    let mut outputs: Vec<OutputRecord> = vec![OutputRecord {
+        target_root: ".mars".to_string(),
+        dest_path: dest.into(),
+        installed_checksum: checksum.into(),
+    }];
+    outputs.extend(targets.iter().map(|target| OutputRecord {
+        target_root: (*target).to_string(),
+        dest_path: dest.into(),
+        installed_checksum: checksum.into(),
+    }));
     lock.items.insert(
         "agent/coder".to_string(),
         LockedItemV2 {

--- a/src/compiler/native_agents/tests.rs
+++ b/src/compiler/native_agents/tests.rs
@@ -4,6 +4,7 @@ use crate::diagnostic::DiagnosticCollector;
 use crate::lock::{ItemKind, LockFile, LockedItemV2, OutputRecord};
 use crate::models::{ModelAlias, ModelSpec};
 use indexmap::IndexMap;
+use std::path::Path;
 use tempfile::TempDir;
 
 fn profile_with_model(model: &str, harness: HarnessKind) -> crate::compiler::agents::AgentProfile {
@@ -336,5 +337,176 @@ fn reconcile_selective_keeps_lock_when_native_remove_fails() {
     assert!(
         diag.drain().iter().any(|d| d.code == "native-agent-remove"),
         "failed delete should warn"
+    );
+}
+
+fn parse_mars_agent(content: &str, stem: &str) -> MarsCanonicalAgent {
+    let mut agent_diags = Vec::new();
+    let (profile, fm) =
+        crate::compiler::agents::parse_agent_content(content, &mut agent_diags).unwrap();
+    let agent_name = profile.name.clone().unwrap_or_else(|| stem.to_string());
+    MarsCanonicalAgent {
+        agent_name,
+        canonical_dest_path: format!("agents/{stem}.md"),
+        profile,
+        fm,
+    }
+}
+
+fn compile_emit_all_agents(
+    dir: &Path,
+    configured_harnesses: &[HarnessKind],
+    agents: &[MarsCanonicalAgent],
+    aliases: &IndexMap<String, ModelAlias>,
+) -> Vec<CompiledNativeOutput> {
+    let mut diag = DiagnosticCollector::new();
+    let ctx = NativeAgentCompileCtx {
+        project_root: dir,
+        model_aliases: aliases,
+        cursor_probe_slugs: &[],
+        old_lock: &LockFile::empty(),
+        harness_scope: None,
+        configured_emit_harnesses: configured_harnesses,
+        options: NativeAgentSurfaceCompileOptions {
+            force: false,
+            collision_hint: crate::surface_ownership::CollisionAdoptHint::SyncForce,
+            dry_run: false,
+        },
+    };
+    compile_native_agents(&ctx, &AgentSurfacePolicy::EmitAll, agents, &mut diag)
+}
+
+#[test]
+fn emit_all_emits_every_agent_to_single_configured_claude_target() {
+    let dir = TempDir::new().unwrap();
+    std::fs::create_dir_all(dir.path().join(".claude/agents")).unwrap();
+
+    let mut aliases = IndexMap::new();
+    aliases.insert(
+        "opus".to_string(),
+        pinned_alias_with_harness("claude-opus-4-6", "claude", None),
+    );
+
+    let pinned = parse_mars_agent(
+        "---\nname: pinned-coder\nmodel: opus\n---\n# Pinned\n",
+        "pinned-coder",
+    );
+    let model_less = parse_mars_agent(
+        "---\nname: bare-agent\nmodel: gpt-5.3-codex\n---\n# Bare\n",
+        "bare-agent",
+    );
+    let agents = [pinned, model_less];
+
+    let records = compile_emit_all_agents(dir.path(), &[HarnessKind::Claude], &agents, &aliases);
+    assert_eq!(records.len(), 2);
+    assert!(records.iter().all(|r| r.target_root == ".claude"));
+
+    let pinned_native =
+        std::fs::read_to_string(dir.path().join(".claude/agents/pinned-coder.md")).unwrap();
+    assert!(
+        pinned_native.contains("model: claude-opus-4-6"),
+        "resolved claude model should be pinned: {pinned_native}"
+    );
+
+    let bare_native =
+        std::fs::read_to_string(dir.path().join(".claude/agents/bare-agent.md")).unwrap();
+    assert!(
+        !bare_native.contains("model:"),
+        "non-claude model should emit model-less under claude: {bare_native}"
+    );
+}
+
+#[test]
+fn emit_all_emits_to_every_configured_target() {
+    let dir = TempDir::new().unwrap();
+    std::fs::create_dir_all(dir.path().join(".claude/agents")).unwrap();
+    std::fs::create_dir_all(dir.path().join(".codex/agents")).unwrap();
+
+    let agent = parse_mars_agent("---\nname: worker\nmodel: opus\n---\n# Worker\n", "worker");
+    let mut aliases = IndexMap::new();
+    aliases.insert(
+        "opus".to_string(),
+        ModelAlias {
+            harness: None,
+            description: None,
+            default_effort: None,
+            autocompact: None,
+            autocompact_pct: None,
+            spec: ModelSpec::Pinned {
+                model: "claude-opus-4-6".to_string(),
+                provider: Some("anthropic".to_string()),
+            },
+        },
+    );
+
+    let records = compile_emit_all_agents(
+        dir.path(),
+        &[HarnessKind::Claude, HarnessKind::Codex],
+        std::slice::from_ref(&agent),
+        &aliases,
+    );
+    assert_eq!(records.len(), 2);
+    assert!(dir.path().join(".claude/agents/worker.md").exists());
+    assert!(dir.path().join(".codex/agents/worker.toml").exists());
+}
+
+#[test]
+fn emit_all_with_empty_configured_targets_emits_nothing() {
+    let dir = TempDir::new().unwrap();
+    let agent = parse_mars_agent(
+        "---\nname: worker\nharness: claude\n---\n# Worker\n",
+        "worker",
+    );
+
+    let records = compile_emit_all_agents(
+        dir.path(),
+        &[],
+        std::slice::from_ref(&agent),
+        &IndexMap::new(),
+    );
+    assert!(records.is_empty());
+    assert!(!dir.path().join(".claude/agents/worker.md").exists());
+}
+
+#[test]
+fn emit_all_ignores_authored_harness_pin_for_coverage() {
+    let dir = TempDir::new().unwrap();
+    std::fs::create_dir_all(dir.path().join(".claude/agents")).unwrap();
+
+    let agent = parse_mars_agent(
+        "---\nname: product-lead\nharness: codex\nmodel: opus\n---\n# Lead\n",
+        "product-lead",
+    );
+    let mut aliases = IndexMap::new();
+    aliases.insert(
+        "opus".to_string(),
+        ModelAlias {
+            harness: None,
+            description: None,
+            default_effort: None,
+            autocompact: None,
+            autocompact_pct: None,
+            spec: ModelSpec::Pinned {
+                model: "claude-opus-4-6".to_string(),
+                provider: Some("anthropic".to_string()),
+            },
+        },
+    );
+
+    let records = compile_emit_all_agents(
+        dir.path(),
+        &[HarnessKind::Claude],
+        std::slice::from_ref(&agent),
+        &aliases,
+    );
+    assert_eq!(records.len(), 1);
+    assert!(dir.path().join(".claude/agents/product-lead.md").exists());
+    assert!(!dir.path().join(".codex/agents/product-lead.toml").exists());
+
+    let native =
+        std::fs::read_to_string(dir.path().join(".claude/agents/product-lead.md")).unwrap();
+    assert!(
+        native.contains("model: claude-opus-4-6"),
+        "authored codex pin should not block claude emission; model resolves via alias: {native}"
     );
 }

--- a/src/compiler/native_agents/tests.rs
+++ b/src/compiler/native_agents/tests.rs
@@ -627,6 +627,134 @@ fn emit_all_consumes_overlay_model_policies() {
 }
 
 #[test]
+fn emit_all_overlay_cross_harness_clears_foreign_declared_harness() {
+    let dir = TempDir::new().unwrap();
+    std::fs::create_dir_all(dir.path().join(".claude/agents")).unwrap();
+    std::fs::create_dir_all(dir.path().join(".codex/agents")).unwrap();
+
+    let mut aliases = IndexMap::new();
+    aliases.insert(
+        "opus".to_string(),
+        pinned_alias_with_harness("claude-opus-4-6", "claude", None),
+    );
+    aliases.insert(
+        "codex-model".to_string(),
+        pinned_alias_with_harness("gpt-5.3-codex", "codex", None),
+    );
+
+    let agent = parse_mars_agent(
+        "---\nname: worker\nharness: codex\nmodel: codex-model\n---\n# Worker\n",
+        "worker",
+    );
+    let mut overlays: IndexMap<String, crate::config::AgentOverlay> = IndexMap::new();
+    overlays.insert(
+        "worker".to_string(),
+        crate::config::AgentOverlay {
+            model: Some("opus".to_string()),
+            ..Default::default()
+        },
+    );
+
+    let records = compile_emit_all_with_overlays(
+        dir.path(),
+        &[HarnessKind::Claude, HarnessKind::Codex],
+        std::slice::from_ref(&agent),
+        &aliases,
+        &overlays,
+    );
+    assert_eq!(records.len(), 2);
+    assert!(dir.path().join(".claude/agents/worker.md").exists());
+    assert!(dir.path().join(".codex/agents/worker.toml").exists());
+
+    let codex_native =
+        std::fs::read_to_string(dir.path().join(".codex/agents/worker.toml")).unwrap();
+    assert!(
+        !codex_native.contains("model"),
+        "overlay claude model must not leak into declared codex harness: {codex_native}"
+    );
+
+    let claude_native =
+        std::fs::read_to_string(dir.path().join(".claude/agents/worker.md")).unwrap();
+    assert!(
+        claude_native.contains("model: claude-opus-4-6"),
+        "claude harness should carry the overlay opus model: {claude_native}"
+    );
+}
+
+#[test]
+fn emit_all_hand_authored_cross_harness_clears_foreign_model() {
+    let dir = TempDir::new().unwrap();
+    std::fs::create_dir_all(dir.path().join(".claude/agents")).unwrap();
+
+    let mut aliases = IndexMap::new();
+    aliases.insert(
+        "codex-model".to_string(),
+        pinned_alias_with_harness("gpt-5.3-codex", "codex", None),
+    );
+
+    let agent = parse_mars_agent(
+        "---\nname: worker\nharness: claude\nmodel: codex-model\n---\n# Worker\n",
+        "worker",
+    );
+
+    let records = compile_emit_all_agents(
+        dir.path(),
+        &[HarnessKind::Claude],
+        std::slice::from_ref(&agent),
+        &aliases,
+    );
+    assert_eq!(records.len(), 1);
+    let native = std::fs::read_to_string(dir.path().join(".claude/agents/worker.md")).unwrap();
+    assert!(
+        !native.contains("model:"),
+        "declared claude harness with codex model must emit model-less: {native}"
+    );
+}
+
+#[test]
+fn emit_all_declared_harness_matching_model_still_pins() {
+    let dir = TempDir::new().unwrap();
+    std::fs::create_dir_all(dir.path().join(".claude/agents")).unwrap();
+
+    let mut aliases = IndexMap::new();
+    aliases.insert(
+        "opus".to_string(),
+        pinned_alias_with_harness("claude-opus-4-6", "claude", None),
+    );
+
+    let pinned = parse_mars_agent(
+        "---\nname: pinned-worker\nharness: claude\nmodel: opus\n---\n# Pinned\n",
+        "pinned-worker",
+    );
+    let model_less = parse_mars_agent(
+        "---\nname: bare-worker\nharness: claude\n---\n# Bare\n",
+        "bare-worker",
+    );
+
+    let records = compile_emit_all_agents(
+        dir.path(),
+        &[HarnessKind::Claude],
+        &[pinned, model_less],
+        &aliases,
+    );
+    assert_eq!(records.len(), 2);
+
+    let pinned_native =
+        std::fs::read_to_string(dir.path().join(".claude/agents/pinned-worker.md")).unwrap();
+    assert!(
+        pinned_native.contains("model: claude-opus-4-6"),
+        "matching harness+model should still pin: {pinned_native}"
+    );
+
+    let bare_native =
+        std::fs::read_to_string(dir.path().join(".claude/agents/bare-worker.md")).unwrap();
+    assert!(
+        !bare_native.contains("model:"),
+        "declared harness without model should emit model-less: {bare_native}"
+    );
+}
+
+#[test]
 fn emit_all_ignores_overlay_harness_for_model_resolution() {
     let dir = TempDir::new().unwrap();
     std::fs::create_dir_all(dir.path().join(".claude/agents")).unwrap();

--- a/src/compiler/native_agents/tests.rs
+++ b/src/compiler/native_agents/tests.rs
@@ -174,6 +174,7 @@ fn link_suppress_all_reconciles_selective_native_target() {
             policy: AgentSurfacePolicy::SuppressAll,
             project_root: dir.path(),
             model_aliases: &IndexMap::new(),
+            agent_overlays: &IndexMap::new(),
             outcomes: &[],
             old_lock: &lock,
             dry_run: false,
@@ -238,6 +239,7 @@ fn reconcile_selective_removes_native_when_agent_stops_qualifying() {
             policy: AgentSurfacePolicy::EmitSelective(spec),
             project_root: dir.path(),
             model_aliases: &aliases,
+            agent_overlays: &IndexMap::new(),
             outcomes: &[],
             old_lock: &lock,
             dry_run: false,
@@ -318,6 +320,7 @@ fn reconcile_selective_keeps_lock_when_native_remove_fails() {
             policy: AgentSurfacePolicy::EmitSelective(spec),
             project_root: dir.path(),
             model_aliases: &aliases,
+            agent_overlays: &IndexMap::new(),
             outcomes: &[],
             old_lock: &lock,
             dry_run: false,
@@ -360,9 +363,11 @@ fn compile_emit_all_agents(
     aliases: &IndexMap<String, ModelAlias>,
 ) -> Vec<CompiledNativeOutput> {
     let mut diag = DiagnosticCollector::new();
+    let empty_overlays: IndexMap<String, crate::config::AgentOverlay> = IndexMap::new();
     let ctx = NativeAgentCompileCtx {
         project_root: dir,
         model_aliases: aliases,
+        agent_overlays: &empty_overlays,
         cursor_probe_slugs: &[],
         old_lock: &LockFile::empty(),
         harness_scope: None,
@@ -508,5 +513,150 @@ fn emit_all_ignores_authored_harness_pin_for_coverage() {
     assert!(
         native.contains("model: claude-opus-4-6"),
         "authored codex pin should not block claude emission; model resolves via alias: {native}"
+    );
+}
+
+fn compile_emit_all_with_overlays(
+    dir: &Path,
+    configured_harnesses: &[HarnessKind],
+    agents: &[MarsCanonicalAgent],
+    aliases: &IndexMap<String, ModelAlias>,
+    overlays: &IndexMap<String, crate::config::AgentOverlay>,
+) -> Vec<CompiledNativeOutput> {
+    let mut diag = DiagnosticCollector::new();
+    let ctx = NativeAgentCompileCtx {
+        project_root: dir,
+        model_aliases: aliases,
+        agent_overlays: overlays,
+        cursor_probe_slugs: &[],
+        old_lock: &LockFile::empty(),
+        harness_scope: None,
+        configured_emit_harnesses: configured_harnesses,
+        options: NativeAgentSurfaceCompileOptions {
+            force: false,
+            collision_hint: crate::surface_ownership::CollisionAdoptHint::SyncForce,
+            dry_run: false,
+        },
+    };
+    compile_native_agents(&ctx, &AgentSurfacePolicy::EmitAll, agents, &mut diag)
+}
+
+#[test]
+fn emit_all_consumes_overlay_model_over_profile_model() {
+    let dir = TempDir::new().unwrap();
+    std::fs::create_dir_all(dir.path().join(".claude/agents")).unwrap();
+
+    let mut aliases = IndexMap::new();
+    aliases.insert(
+        "opus".to_string(),
+        pinned_alias_with_harness("claude-opus-4-6", "claude", None),
+    );
+
+    // profile.model is a codex token that does not resolve to claude.
+    let agent = parse_mars_agent(
+        "---\nname: worker\nmodel: gpt-5.3-codex\n---\n# Worker\n",
+        "worker",
+    );
+    let mut overlays: IndexMap<String, crate::config::AgentOverlay> = IndexMap::new();
+    overlays.insert(
+        "worker".to_string(),
+        crate::config::AgentOverlay {
+            model: Some("opus".to_string()),
+            ..Default::default()
+        },
+    );
+
+    let records = compile_emit_all_with_overlays(
+        dir.path(),
+        &[HarnessKind::Claude],
+        std::slice::from_ref(&agent),
+        &aliases,
+        &overlays,
+    );
+    assert_eq!(records.len(), 1);
+    let native = std::fs::read_to_string(dir.path().join(".claude/agents/worker.md")).unwrap();
+    assert!(
+        native.contains("model: claude-opus-4-6"),
+        "overlay.model must re-pin the claude native copy: {native}"
+    );
+}
+
+#[test]
+fn emit_all_consumes_overlay_model_policies() {
+    let dir = TempDir::new().unwrap();
+    std::fs::create_dir_all(dir.path().join(".claude/agents")).unwrap();
+
+    let mut aliases = IndexMap::new();
+    aliases.insert(
+        "opus".to_string(),
+        pinned_alias_with_harness("claude-opus-4-6", "claude", None),
+    );
+
+    // profile has no claude-resolving model; an overlay model-policy supplies one.
+    let agent = parse_mars_agent(
+        "---\nname: worker\nmodel: gpt-5.3-codex\n---\n# Worker\n",
+        "worker",
+    );
+    let mut overlays: IndexMap<String, crate::config::AgentOverlay> = IndexMap::new();
+    overlays.insert(
+        "worker".to_string(),
+        crate::config::AgentOverlay {
+            model_policies: vec![crate::config::ModelPolicyRule {
+                match_type: crate::config::ModelPolicyMatchType::Alias,
+                match_value: "opus".to_string(),
+                no_fallback: false,
+                overrides: serde_yaml::Mapping::new(),
+            }],
+            ..Default::default()
+        },
+    );
+
+    let records = compile_emit_all_with_overlays(
+        dir.path(),
+        &[HarnessKind::Claude],
+        std::slice::from_ref(&agent),
+        &aliases,
+        &overlays,
+    );
+    assert_eq!(records.len(), 1);
+    let native = std::fs::read_to_string(dir.path().join(".claude/agents/worker.md")).unwrap();
+    assert!(
+        native.contains("model: claude-opus-4-6"),
+        "overlay model-policy must supply the claude native model: {native}"
+    );
+}
+
+#[test]
+fn emit_all_ignores_overlay_harness_for_model_resolution() {
+    let dir = TempDir::new().unwrap();
+    std::fs::create_dir_all(dir.path().join(".claude/agents")).unwrap();
+
+    let aliases = IndexMap::new();
+    // profile.model is a codex token; overlay.harness alone must not make it qualify.
+    let agent = parse_mars_agent(
+        "---\nname: worker\nmodel: gpt-5.3-codex\n---\n# Worker\n",
+        "worker",
+    );
+    let mut overlays: IndexMap<String, crate::config::AgentOverlay> = IndexMap::new();
+    overlays.insert(
+        "worker".to_string(),
+        crate::config::AgentOverlay {
+            harness: Some("claude".to_string()),
+            ..Default::default()
+        },
+    );
+
+    let records = compile_emit_all_with_overlays(
+        dir.path(),
+        &[HarnessKind::Claude],
+        std::slice::from_ref(&agent),
+        &aliases,
+        &overlays,
+    );
+    assert_eq!(records.len(), 1);
+    let native = std::fs::read_to_string(dir.path().join(".claude/agents/worker.md")).unwrap();
+    assert!(
+        !native.contains("model:"),
+        "overlay.harness must be ignored; the codex model must not leak under claude: {native}"
     );
 }

--- a/src/config/layering.rs
+++ b/src/config/layering.rs
@@ -43,7 +43,7 @@ impl LocalSettings {
             && self.harness_order.is_none()
             && self.provider_order.is_none()
             && self.agent_emission.is_none()
-            && self.agent_copy.is_none()
+            && self.meridian.is_empty()
             && self.model_policies.is_none()
     }
 
@@ -80,8 +80,8 @@ impl LocalSettings {
         if let Some(value) = &self.agent_emission {
             merged.agent_emission = Some(value.clone());
         }
-        if let Some(value) = &self.agent_copy {
-            merged.agent_copy = Some(value.clone());
+        if let Some(value) = &self.meridian.agent_copy {
+            merged.meridian.agent_copy = Some(value.clone());
         }
         if let Some(value) = &self.model_policies {
             merged.model_policies = value.clone();

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -792,6 +792,44 @@ pub fn merged_agent_overlays(
     overlay_agent_overlays_replace_by_key(base, local)
 }
 
+/// Base model precedence for the overlay+profile layer shared by native emission
+/// and launch-bundle: `overlay.model` wins over `profile.model`. Settings-level
+/// defaults (e.g. `settings.default_model`) are layered on by launch-bundle only.
+pub fn overlay_then_profile_model<'a>(
+    overlay: Option<&'a AgentOverlay>,
+    profile_model: Option<&'a str>,
+) -> Option<&'a str> {
+    overlay
+        .and_then(|entry| entry.model.as_deref())
+        .or(profile_model)
+}
+
+/// Model-policy precedence for the overlay+profile layer: overlay policies first,
+/// then profile policies. Each item carries `is_overlay` (its source layer) and the
+/// index within that layer's own list, so callers can index back into the originating
+/// slice. Launch-bundle appends `settings.model_policies` after this iterator; native
+/// emission consumes it directly (settings policies stay launch-bundle/spawn-only).
+pub fn overlay_then_profile_policies<'a>(
+    overlay: Option<&'a AgentOverlay>,
+    profile_policies: &'a [ModelPolicyRule],
+) -> impl Iterator<Item = (bool, usize, &'a ModelPolicyRule)> + 'a {
+    overlay
+        .into_iter()
+        .flat_map(|entry| {
+            entry
+                .model_policies
+                .iter()
+                .enumerate()
+                .map(|(index, rule)| (true, index, rule))
+        })
+        .chain(
+            profile_policies
+                .iter()
+                .enumerate()
+                .map(|(index, rule)| (false, index, rule)),
+        )
+}
+
 pub fn load_config_with_local(root: &Path) -> Result<(Config, LocalConfig), MarsError> {
     let config = load(root)?;
     let local = load_local(root)?;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -451,8 +451,8 @@ pub struct LocalSettings {
     pub provider_order: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_emission: Option<AgentEmission>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub agent_copy: Option<AgentCopyConfig>,
+    #[serde(default, skip_serializing_if = "MeridianSettings::is_empty")]
+    pub meridian: MeridianSettings,
     #[serde(default, rename = "model-policies")]
     pub model_policies: Option<Vec<ModelPolicyRule>>,
 }
@@ -524,8 +524,8 @@ pub struct Settings {
     /// `MERIDIAN_MANAGED=1`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_emission: Option<AgentEmission>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub agent_copy: Option<AgentCopyConfig>,
+    #[serde(default, skip_serializing_if = "MeridianSettings::is_empty")]
+    pub meridian: MeridianSettings,
     #[serde(
         default,
         rename = "model-policies",
@@ -542,6 +542,20 @@ pub struct AgentCopyConfig {
     pub harnesses: Vec<String>,
     #[serde(default)]
     pub include_fanout: bool,
+}
+
+/// Meridian-managed settings nested under `[settings.meridian]`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct MeridianSettings {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_copy: Option<AgentCopyConfig>,
+}
+
+impl MeridianSettings {
+    pub fn is_empty(&self) -> bool {
+        self.agent_copy.is_none()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -565,7 +579,7 @@ impl Default for Settings {
             harness_order: None,
             provider_order: None,
             agent_emission: None,
-            agent_copy: None,
+            meridian: MeridianSettings::default(),
             model_policies: Vec::new(),
         }
     }
@@ -598,6 +612,11 @@ impl Settings {
             .into_iter()
             .map(|harness| harness.to_string())
             .collect()
+    }
+
+    /// Selective native agent copy config from `[settings.meridian.agent_copy]`.
+    pub fn meridian_agent_copy(&self) -> Option<&AgentCopyConfig> {
+        self.meridian.agent_copy.as_ref()
     }
 }
 
@@ -1179,11 +1198,11 @@ fn validate_save_roundtrip(original: &Config, reparsed: &Config) -> Result<(), M
         }
         .into());
     }
-    if reparsed.settings.agent_copy != original.settings.agent_copy {
+    if reparsed.settings.meridian.agent_copy != original.settings.meridian.agent_copy {
         return Err(ConfigError::Invalid {
             message: format!(
-                "refusing to save config: settings.agent_copy changed during roundtrip ({:?} -> {:?})",
-                original.settings.agent_copy, reparsed.settings.agent_copy
+                "refusing to save config: settings.meridian.agent_copy changed during roundtrip ({:?} -> {:?})",
+                original.settings.meridian.agent_copy, reparsed.settings.meridian.agent_copy
             ),
         }
         .into());
@@ -2859,13 +2878,17 @@ models_cache_ttl_hours = 48
 [settings]
 targets = [".claude"]
 
-[settings.agent_copy]
+[settings.meridian.agent_copy]
 harnesses = ["claude"]
 include_fanout = true
 "#,
         )
         .unwrap();
-        let agent_copy = config.settings.agent_copy.expect("agent_copy should parse");
+        let agent_copy = config
+            .settings
+            .meridian_agent_copy()
+            .expect("agent_copy should parse")
+            .clone();
         assert_eq!(agent_copy.harnesses, vec!["claude".to_string()]);
         assert!(agent_copy.include_fanout);
     }

--- a/src/lock/mod.rs
+++ b/src/lock/mod.rs
@@ -956,6 +956,22 @@ pub struct CompiledNativeOutput {
     pub installed_checksum: ContentHash,
 }
 
+/// Whether a freshly compiled native output is new or content-changed vs the
+/// previous lock at the same `(target_root, dest_path)`. Lets the sync summary
+/// count only real emissions — steady-state re-emits don't inflate the count.
+pub fn native_output_is_new_or_changed(old: &LockFile, out: &CompiledNativeOutput) -> bool {
+    for item in old.items.values() {
+        for output in &item.outputs {
+            if output.target_root == out.target_root
+                && crate::target::dest_paths_equivalent(output.dest_path.as_str(), &out.dest_path)
+            {
+                return output.installed_checksum != out.installed_checksum;
+            }
+        }
+    }
+    true
+}
+
 /// Drop native harness output records removed by native agent reconcile.
 pub fn apply_removed_native_outputs(lock: &mut LockFile, records: &[(String, String)]) {
     for (target_root, dest_path) in records {

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -44,6 +44,13 @@ pub struct SyncReport {
     pub target_outcomes: Vec<crate::target_sync::TargetSyncOutcome>,
     /// Whether this was a dry run (`--diff`). Affects output wording only.
     pub dry_run: bool,
+    /// Native harness agent outputs emitted this run that are new or content-changed
+    /// vs the previous lock, as `(target_root, dest_path)`. Surfaced so native
+    /// emission is not silent in the summary.
+    pub native_emitted: Vec<(String, String)>,
+    /// Native harness agent outputs removed this run, as `(target_root, dest_path)`.
+    /// Surfaced so SuppressAll / selective prunes are not reported as "up to date".
+    pub native_removed: Vec<(String, String)>,
 }
 
 impl SyncReport {
@@ -586,6 +593,15 @@ pub(crate) fn finalize(
     let project_root = &ctx.project_root;
     let old_lock = &state.applied.planned.targeted.resolved.loaded.old_lock;
     let graph = &state.applied.planned.targeted.resolved.graph;
+    // Native-agent surface deltas for the summary: removals are unambiguous; emits
+    // are filtered to new/changed outputs so steady-state re-emits stay quiet.
+    let native_removed: Vec<(String, String)> = state.removed_native_outputs.clone();
+    let native_emitted: Vec<(String, String)> = state
+        .compiled_native_outputs
+        .iter()
+        .filter(|out| crate::lock::native_output_is_new_or_changed(old_lock, out))
+        .map(|out| (out.target_root.clone(), out.dest_path.clone()))
+        .collect();
 
     // Write lock file (D21 — regardless of target sync outcome).
     if !request.options.dry_run {
@@ -696,6 +712,8 @@ pub(crate) fn finalize(
         upgrades_available,
         target_outcomes: state.target_outcomes,
         dry_run: request.options.dry_run,
+        native_emitted,
+        native_removed,
     })
 }
 

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -611,6 +611,14 @@ pub(crate) fn finalize(
             old_lock,
             &state.removed_native_outputs,
         );
+        if let Err(err) =
+            crate::compiler::write_native_agent_manifest_from_lock(project_root, &new_lock)
+        {
+            diag.warn(
+                "native-agent-manifest-write",
+                format!("could not write native agent manifest: {err}"),
+            );
+        }
         crate::lock::write(project_root, &new_lock)?;
 
         // Best-effort models cache refresh: ensure the catalog covers any

--- a/tests/agent_copy.rs
+++ b/tests/agent_copy.rs
@@ -743,3 +743,55 @@ targets = [".claude"]
         "shared mars.toml must not persist mars.local.toml-only targets"
     );
 }
+
+#[test]
+fn standalone_overlay_model_does_not_leak_into_declared_codex_harness() {
+    // E2E regression (thermo-nuclear review): a per-agent overlay model that resolves
+    // to a different harness than the agent's authored `harness:` must not be pinned
+    // into the declared-harness native file. Here `explorer` is authored harness=codex
+    // but overlaid to a claude-resolving model; under standalone EmitAll the `.codex`
+    // copy must be model-less while the `.claude` copy carries the overlay model.
+    let dir = TempDir::new().unwrap();
+    let source = create_source(&dir, "src", &[("explorer", CODEX_ONLY_AGENT)], &[]);
+    let project = dir.child("project");
+    project.create_dir_all().unwrap();
+    project
+        .child("mars.toml")
+        .write_str(&format!(
+            r#"
+[settings]
+targets = [".claude", ".codex"]
+
+[models.opus]
+model = "claude-opus-4-6"
+provider = "anthropic"
+
+[agents.explorer]
+model = "opus"
+
+[dependencies.src]
+path = "{}"
+"#,
+            source.display().to_string().replace('\\', "/")
+        ))
+        .unwrap();
+    // Standalone (MERIDIAN_MANAGED unset) -> EmitAll: every agent to every target.
+    sync_project(&project, None);
+
+    let claude = claude_native_content(&project, "explorer");
+    assert!(
+        claude.contains("model: claude-opus-4-6"),
+        ".claude copy should carry the overlay (claude-resolving) model: {claude}"
+    );
+
+    let codex_path = project.path().join(".codex/agents/explorer.toml");
+    assert!(
+        codex_path.exists(),
+        ".codex copy should still be emitted under EmitAll"
+    );
+    let codex = fs::read_to_string(&codex_path).unwrap();
+    assert!(
+        !codex.contains("model = "),
+        "overlay claude model must NOT leak into the declared codex harness file: {codex}"
+    );
+}

--- a/tests/agent_copy.rs
+++ b/tests/agent_copy.rs
@@ -172,7 +172,7 @@ fn agent_copy_mixed_selective_only_qualifying_emitted() {
 [settings]
 targets = [".claude"]
 
-[settings.agent_copy]
+[settings.meridian.agent_copy]
 harnesses = ["claude"]
 
 [dependencies.src]
@@ -207,7 +207,7 @@ fn agent_copy_first_qualifying_policy_wins() {
 [settings]
 targets = [".claude"]
 
-[settings.agent_copy]
+[settings.meridian.agent_copy]
 harnesses = ["claude"]
 include_fanout = true
 
@@ -251,7 +251,7 @@ fn agent_copy_link_fails_on_handwritten_native_collision() {
 [settings]
 targets = []
 
-[settings.agent_copy]
+[settings.meridian.agent_copy]
 harnesses = ["claude"]
 
 [dependencies.src]
@@ -300,7 +300,7 @@ fn agent_copy_model_binding_qualifies_without_profile_harness() {
 [settings]
 targets = [".claude"]
 
-[settings.agent_copy]
+[settings.meridian.agent_copy]
 harnesses = ["claude"]
 
 [models.opus]
@@ -333,7 +333,7 @@ fn agent_copy_steady_state_survives_consecutive_syncs() {
 [settings]
 targets = [".claude"]
 
-[settings.agent_copy]
+[settings.meridian.agent_copy]
 harnesses = ["claude"]
 "#,
         CLAUDE_HARNESS_AGENT,
@@ -373,7 +373,7 @@ fn agent_copy_stale_native_removed_when_config_cleared() {
 [settings]
 targets = [".claude"]
 
-[settings.agent_copy]
+[settings.meridian.agent_copy]
 harnesses = ["claude"]
 "#,
         CLAUDE_HARNESS_AGENT,
@@ -462,7 +462,7 @@ fn agent_copy_link_materializes_selective_native_agents() {
 [settings]
 targets = []
 
-[settings.agent_copy]
+[settings.meridian.agent_copy]
 harnesses = ["claude"]
 
 [dependencies.src]
@@ -528,7 +528,7 @@ model: gpt-5.3-codex
 [settings]
 targets = []
 
-[settings.agent_copy]
+[settings.meridian.agent_copy]
 harnesses = ["codex"]
 
 [dependencies.src]
@@ -573,7 +573,7 @@ fn link_scopes_native_agent_materialization_to_requested_target() {
 [settings]
 targets = []
 
-[settings.agent_copy]
+[settings.meridian.agent_copy]
 harnesses = ["claude", "opencode"]
 "#,
         Some("1"),
@@ -672,7 +672,7 @@ fn agent_copy_sync_diff_does_not_materialize_native_or_lock() {
 [settings]
 targets = [".claude"]
 
-[settings.agent_copy]
+[settings.meridian.agent_copy]
 harnesses = ["claude"]
 
 [dependencies.src]

--- a/tests/agent_emission.rs
+++ b/tests/agent_emission.rs
@@ -171,3 +171,74 @@ fn switching_between_standalone_and_meridian_managed_converges() {
         "returning to standalone sync should re-emit native harness agent"
     );
 }
+
+fn sync_capture(project: &assert_fs::fixture::ChildPath, meridian_managed: Option<&str>) -> String {
+    let mut cmd = mars();
+    cmd.args(["sync", "--root", project.path().to_str().unwrap()]);
+    match meridian_managed {
+        Some(value) => {
+            cmd.env("MERIDIAN_MANAGED", value);
+        }
+        None => {
+            cmd.env_remove("MERIDIAN_MANAGED");
+        }
+    }
+    let output = cmd.output().expect("sync runs");
+    assert!(output.status.success(), "sync should succeed");
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+#[test]
+fn sync_summary_reports_native_emit_and_prune() {
+    // Regression (observability gap): the sync summary must surface native-agent
+    // emission and removal instead of reporting "already up to date".
+    let dir = TempDir::new().unwrap();
+    let project = create_emission_project(&dir);
+
+    // Standalone EmitAll: first sync emits the native agent -> summary says "emitted".
+    let standalone = sync_capture(&project, None);
+    assert!(
+        standalone.contains("emitted") && standalone.contains("native agent"),
+        "standalone sync should report native emission, got:\n{standalone}"
+    );
+    assert!(
+        !standalone.contains("already up to date"),
+        "a sync that emits native agents is not up to date:\n{standalone}"
+    );
+
+    // MERIDIAN_MANAGED auto + no agent_copy -> SuppressAll prunes the native agent.
+    let managed = sync_capture(&project, Some("1"));
+    assert!(
+        managed.contains("removed") && managed.contains("native agent"),
+        "managed prune should report native removal, got:\n{managed}"
+    );
+    assert!(
+        !managed.contains("already up to date"),
+        "a sync that prunes native agents must NOT say up to date:\n{managed}"
+    );
+
+    // Steady state: nothing left to prune or emit -> genuinely up to date.
+    let steady = sync_capture(&project, Some("1"));
+    assert!(
+        steady.contains("already up to date"),
+        "steady-state managed sync should be up to date, got:\n{steady}"
+    );
+    assert!(
+        !steady.contains("native agent"),
+        "steady state should not list native agent changes:\n{steady}"
+    );
+}
+
+fn create_emission_project(dir: &TempDir) -> assert_fs::fixture::ChildPath {
+    let source = create_source(dir, "src", &[("coder", CLAUDE_AGENT)], &[]);
+    let project = dir.child("project");
+    project.create_dir_all().unwrap();
+    project
+        .child("mars.toml")
+        .write_str(&format!(
+            "[settings]\ntargets = [\".claude\"]\n\n[dependencies.src]\npath = \"{}\"\n",
+            source.display().to_string().replace('\\', "/")
+        ))
+        .unwrap();
+    project
+}

--- a/tests/agent_emission.rs
+++ b/tests/agent_emission.rs
@@ -85,7 +85,7 @@ fn sync_project(project: &assert_fs::fixture::ChildPath, meridian_managed: Optio
 #[test]
 fn default_auto_standalone_emits_native_agent() {
     let dir = TempDir::new().unwrap();
-    let project = setup_project(&dir, None, None);
+    let project = setup_project(&dir, Some("[settings]\ntargets = [\".claude\"]\n"), None);
 
     assert_canonical_agent_exists(&project);
     assert!(
@@ -111,7 +111,7 @@ fn always_meridian_managed_still_emits_native_agent() {
     let dir = TempDir::new().unwrap();
     let project = setup_project(
         &dir,
-        Some("[settings]\nagent_emission = \"always\"\n"),
+        Some("[settings]\nagent_emission = \"always\"\ntargets = [\".claude\"]\n"),
         Some("1"),
     );
 
@@ -137,7 +137,7 @@ fn never_suppresses_native_agent() {
 #[test]
 fn standalone_sync_is_idempotent() {
     let dir = TempDir::new().unwrap();
-    let project = setup_project(&dir, None, None);
+    let project = setup_project(&dir, Some("[settings]\ntargets = [\".claude\"]\n"), None);
 
     sync_project(&project, None);
 
@@ -151,7 +151,7 @@ fn standalone_sync_is_idempotent() {
 #[test]
 fn switching_between_standalone_and_meridian_managed_converges() {
     let dir = TempDir::new().unwrap();
-    let project = setup_project(&dir, None, None);
+    let project = setup_project(&dir, Some("[settings]\ntargets = [\".claude\"]\n"), None);
     assert!(
         native_agent_path(&project).exists(),
         "standalone sync should emit native harness agent"

--- a/tests/launch_bundle.rs
+++ b/tests/launch_bundle.rs
@@ -59,6 +59,16 @@ fn build_launch_bundle_projects_pi_launch_actions() {
 }
 
 #[test]
+fn build_launch_bundle_projects_codex_streaming_launch_actions() {
+    launch_actions::build_launch_bundle_projects_codex_streaming_launch_actions();
+}
+
+#[test]
+fn build_launch_bundle_projects_opencode_streaming_launch_actions() {
+    launch_actions::build_launch_bundle_projects_opencode_streaming_launch_actions();
+}
+
+#[test]
 fn build_launch_bundle_outputs_schema_and_slot_placeholders() {
     schema::build_launch_bundle_outputs_schema_and_slot_placeholders();
 }

--- a/tests/launch_bundle.rs
+++ b/tests/launch_bundle.rs
@@ -39,6 +39,11 @@ fn build_launch_bundle_projects_cursor_launch_actions() {
 }
 
 #[test]
+fn build_launch_bundle_projects_claude_launch_actions() {
+    launch_actions::build_launch_bundle_projects_claude_launch_actions();
+}
+
+#[test]
 fn build_launch_bundle_outputs_schema_and_slot_placeholders() {
     schema::build_launch_bundle_outputs_schema_and_slot_placeholders();
 }

--- a/tests/launch_bundle.rs
+++ b/tests/launch_bundle.rs
@@ -44,6 +44,21 @@ fn build_launch_bundle_projects_claude_launch_actions() {
 }
 
 #[test]
+fn build_launch_bundle_projects_codex_subprocess_launch_actions() {
+    launch_actions::build_launch_bundle_projects_codex_subprocess_launch_actions();
+}
+
+#[test]
+fn build_launch_bundle_projects_opencode_subprocess_launch_actions() {
+    launch_actions::build_launch_bundle_projects_opencode_subprocess_launch_actions();
+}
+
+#[test]
+fn build_launch_bundle_projects_pi_launch_actions() {
+    launch_actions::build_launch_bundle_projects_pi_launch_actions();
+}
+
+#[test]
 fn build_launch_bundle_outputs_schema_and_slot_placeholders() {
     schema::build_launch_bundle_outputs_schema_and_slot_placeholders();
 }

--- a/tests/launch_bundle.rs
+++ b/tests/launch_bundle.rs
@@ -12,6 +12,8 @@ mod cursor;
 mod errors;
 #[path = "launch_bundle/execution_policy.rs"]
 mod execution_policy;
+#[path = "launch_bundle/launch_actions.rs"]
+mod launch_actions;
 #[path = "launch_bundle/native_config.rs"]
 mod native_config;
 #[path = "launch_bundle/prompt_surface.rs"]
@@ -25,6 +27,16 @@ mod tool_policy;
 
 // Keep root-level #[test] wrappers so discovered test names stay historically stable
 // while test bodies remain organized in contract-focused modules.
+
+#[test]
+fn build_launch_bundle_omits_launch_actions_without_context() {
+    launch_actions::build_launch_bundle_omits_launch_actions_without_context();
+}
+
+#[test]
+fn build_launch_bundle_projects_cursor_launch_actions() {
+    launch_actions::build_launch_bundle_projects_cursor_launch_actions();
+}
 
 #[test]
 fn build_launch_bundle_outputs_schema_and_slot_placeholders() {

--- a/tests/launch_bundle/launch_actions.rs
+++ b/tests/launch_bundle/launch_actions.rs
@@ -540,7 +540,6 @@ Code."#;
             "body": {
                 "model": "openai/gpt-5",
                 "modelID": "openai/gpt-5",
-                "agent": "reviewer",
                 "mcp": {"servers": ["server-one"]}
             }
         })

--- a/tests/launch_bundle/launch_actions.rs
+++ b/tests/launch_bundle/launch_actions.rs
@@ -71,6 +71,14 @@ Review code changes."#;
     let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
 
     assert_eq!(
+        bundle["launch_actions"]["kind"].as_str(),
+        Some("subprocess")
+    );
+    assert_eq!(
+        bundle["launch_actions"]["cwd"].as_str(),
+        Some("/work/project")
+    );
+    assert_eq!(
         bundle["launch_actions"]["argv"],
         serde_json::json!([
             "cursor",
@@ -92,7 +100,7 @@ Review code changes."#;
     );
     assert_eq!(bundle["launch_actions"]["env"], serde_json::json!({}));
     assert_eq!(bundle["launch_actions"]["files"], serde_json::json!([]));
-    assert!(bundle["launch_actions"]["protocol_payload"].is_null());
+    assert!(bundle["launch_actions"]["stdin"].is_null());
 }
 
 pub(crate) fn build_launch_bundle_projects_claude_launch_actions() {
@@ -141,6 +149,18 @@ Review code changes."#;
     let output = cmd.assert().success().get_output().clone();
     let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
 
+    assert_eq!(
+        bundle["launch_actions"]["kind"].as_str(),
+        Some("subprocess")
+    );
+    assert_eq!(
+        bundle["launch_actions"]["cwd"].as_str(),
+        Some("/work/project")
+    );
+    assert_eq!(
+        bundle["launch_actions"]["stdin"].as_str(),
+        Some("ignored by claude argv")
+    );
     assert_eq!(
         bundle["launch_actions"]["argv"],
         serde_json::json!([
@@ -214,8 +234,6 @@ Code."#;
         "opencode_config_content": null,
         "pi_extension_entrypoints": [],
         "prompt": "USER",
-        "base_instructions": "BASE",
-        "developer_instructions": "DEV",
         "report_output_path": "/tmp/report.md"
     });
 
@@ -233,6 +251,14 @@ Code."#;
     let output = cmd.assert().success().get_output().clone();
     let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
 
+    assert_eq!(
+        bundle["launch_actions"]["kind"].as_str(),
+        Some("subprocess")
+    );
+    assert_eq!(
+        bundle["launch_actions"]["cwd"].as_str(),
+        Some("/work/project")
+    );
     assert_eq!(
         bundle["launch_actions"]["argv"],
         serde_json::json!([
@@ -256,9 +282,10 @@ Code."#;
             "--foo",
             "-o",
             "/tmp/report.md",
-            "BASE\n\nDEV\n\nUSER"
+            "USER"
         ])
     );
+    assert!(bundle["launch_actions"]["stdin"].is_null());
 }
 
 pub(crate) fn build_launch_bundle_projects_opencode_subprocess_launch_actions() {
@@ -303,6 +330,14 @@ Code."#;
     let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
 
     assert_eq!(
+        bundle["launch_actions"]["kind"].as_str(),
+        Some("subprocess")
+    );
+    assert_eq!(
+        bundle["launch_actions"]["cwd"].as_str(),
+        Some("/work/project")
+    );
+    assert_eq!(
         bundle["launch_actions"]["argv"],
         serde_json::json!([
             "opencode",
@@ -324,6 +359,7 @@ Code."#;
             "{\"permission\":{\"external_directory\":{\"/extra/root/**\":\"allow\",\"/parent\":\"allow\"}}}"
         )
     );
+    assert_eq!(bundle["launch_actions"]["stdin"].as_str(), Some("USER"));
 }
 
 pub(crate) fn build_launch_bundle_projects_pi_launch_actions() {
@@ -369,6 +405,14 @@ Code."#;
     let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
     let argv = bundle["launch_actions"]["argv"].as_array().unwrap();
 
+    assert_eq!(
+        bundle["launch_actions"]["kind"].as_str(),
+        Some("subprocess")
+    );
+    assert_eq!(
+        bundle["launch_actions"]["cwd"].as_str(),
+        Some("/work/project")
+    );
     assert_eq!(argv[0].as_str(), Some("pi"));
     assert_eq!(argv[1].as_str(), Some("--mode"));
     assert_eq!(argv[2].as_str(), Some("rpc"));
@@ -384,6 +428,7 @@ Code."#;
         argv.iter()
             .any(|value| value.as_str() == Some("/tmp/pi-sessions"))
     );
+    assert_eq!(argv.last().and_then(|value| value.as_str()), Some("USER"));
 }
 
 pub(crate) fn build_launch_bundle_projects_codex_streaming_launch_actions() {
@@ -413,9 +458,7 @@ Code."#;
         "extra_args": ["--foo"],
         "opencode_config_content": null,
         "pi_extension_entrypoints": [],
-        "prompt": "USER",
-        "base_instructions": "BASE",
-        "developer_instructions": "DEV"
+        "prompt": "USER"
     });
 
     let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
@@ -434,6 +477,11 @@ Code."#;
     let output = cmd.assert().success().get_output().clone();
     let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
 
+    assert_eq!(bundle["launch_actions"]["kind"].as_str(), Some("streaming"));
+    assert_eq!(
+        bundle["launch_actions"]["cwd"].as_str(),
+        Some("/work/project")
+    );
     assert_eq!(
         bundle["launch_actions"]["argv"],
         serde_json::json!([
@@ -453,20 +501,28 @@ Code."#;
         ])
     );
     assert_eq!(
-        bundle["launch_actions"]["protocol_payload"],
+        bundle["launch_actions"]["protocol"],
         serde_json::json!({
             "transport": "jsonrpc",
-            "method": "thread/fork",
-            "params": {
-                "cwd": "/work/project",
-                "baseInstructions": "BASE",
-                "developerInstructions": "DEV",
-                "model": "gpt-5",
-                "config": {"model_reasoning_effort": "high"},
-                "approvalPolicy": "never",
-                "sandbox": "danger-full-access",
-                "threadId": "thread-1",
-                "ephemeral": false
+            "bootstrap": {
+                "method": "thread/fork",
+                "params": {
+                    "cwd": "/work/project",
+                    "developerInstructions": bundle["prompt_surface"]["system_instruction"],
+                    "model": "gpt-5",
+                    "config": {"model_reasoning_effort": "high"},
+                    "approvalPolicy": "never",
+                    "sandbox": "danger-full-access",
+                    "threadId": "thread-1",
+                    "ephemeral": false
+                }
+            },
+            "turn": {
+                "method": "turn/start",
+                "params_template": {
+                    "threadId": "{{thread_id}}",
+                    "input": [{"type": "text", "text": "USER"}]
+                }
             }
         })
     );
@@ -515,6 +571,11 @@ Code."#;
     let output = cmd.assert().success().get_output().clone();
     let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
 
+    assert_eq!(bundle["launch_actions"]["kind"].as_str(), Some("streaming"));
+    assert_eq!(
+        bundle["launch_actions"]["cwd"].as_str(),
+        Some("/work/project")
+    );
     assert_eq!(
         bundle["launch_actions"]["argv"],
         serde_json::json!([
@@ -532,15 +593,25 @@ Code."#;
         Some("{\"permission\":{\"external_directory\":{\"/extra/root/**\":\"allow\"}}}")
     );
     assert_eq!(
-        bundle["launch_actions"]["protocol_payload"],
+        bundle["launch_actions"]["protocol"],
         serde_json::json!({
             "transport": "http",
-            "method": "POST",
-            "path": "/session",
-            "body": {
-                "model": "openai/gpt-5",
-                "modelID": "openai/gpt-5",
-                "mcp": {"servers": ["server-one"]}
+            "bootstrap": {
+                "method": "POST",
+                "path": "/session",
+                "body": {
+                    "model": "openai/gpt-5",
+                    "modelID": "openai/gpt-5",
+                    "mcp": {"servers": ["server-one"]}
+                }
+            },
+            "turn": {
+                "method": "POST",
+                "path_template": "/session/{session_id}/prompt_async",
+                "body_template": {
+                    "parts": [{"type": "text", "text": "USER"}],
+                    "system": bundle["prompt_surface"]["system_instruction"]
+                }
             }
         })
     );

--- a/tests/launch_bundle/launch_actions.rs
+++ b/tests/launch_bundle/launch_actions.rs
@@ -94,3 +94,94 @@ Review code changes."#;
     assert_eq!(bundle["launch_actions"]["files"], serde_json::json!([]));
     assert!(bundle["launch_actions"]["protocol_payload"].is_null());
 }
+
+pub(crate) fn build_launch_bundle_projects_claude_launch_actions() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = install_fake_harnesses(temp.path(), &["claude"]);
+    let agent_content = r#"---
+name: reviewer
+model: claude-opus-4-6
+harness: claude
+effort: xhigh
+approval: auto
+tools: [Bash, Write, Agent]
+disallowed-tools: [Write]
+mcp-tools: [plugin:context7:context7]
+---
+Review code changes."#;
+
+    let (server, project_root) =
+        setup_bundle_project(&temp, "bundle-source", agent_content, &[], "");
+
+    let context = serde_json::json!({
+        "cwd": "/work/project",
+        "temp_dir": "/tmp/mars-spawn",
+        "streaming": null,
+        "session_id": "session-123",
+        "fork": true,
+        "workspace_roots": ["/extra/root"],
+        "interactive": false,
+        "extra_args": ["--meridian-parent-allowed-tools", "Read,Write", "--allowedTools", "Grep", "--passthrough"],
+        "opencode_config_content": null,
+        "pi_extension_entrypoints": [],
+        "prompt": "ignored by claude argv"
+    });
+
+    let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
+    cmd.args([
+        "build",
+        "launch-bundle",
+        "--agent",
+        "reviewer",
+        "--context",
+        &context.to_string(),
+    ]);
+    cmd.env("PATH", replace_path_with(&bin_dir));
+
+    let output = cmd.assert().success().get_output().clone();
+    let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert_eq!(
+        bundle["launch_actions"]["argv"],
+        serde_json::json!([
+            "claude",
+            "-p",
+            "--output-format",
+            "stream-json",
+            "--verbose",
+            "-",
+            "--model",
+            "claude-opus-4-6",
+            "--effort",
+            "max",
+            "--agent",
+            "reviewer",
+            "--permission-mode",
+            "acceptEdits",
+            "--allowedTools",
+            "Bash,Read,Grep",
+            "--disallowedTools",
+            "Write,Agent(Explore),Agent(Plan),Agent(General-purpose),Agent(general-purpose)",
+            "--mcp-config",
+            "plugin:context7:context7",
+            "--append-system-prompt-file",
+            "/tmp/mars-spawn/prompt.md",
+            "--resume",
+            "session-123",
+            "--fork-session",
+            "--add-dir",
+            "/extra/root",
+            "--passthrough"
+        ])
+    );
+    assert_eq!(
+        bundle["launch_actions"]["files"][0]["path"].as_str(),
+        Some("/tmp/mars-spawn/prompt.md")
+    );
+    assert!(
+        bundle["launch_actions"]["files"][0]["content"]
+            .as_str()
+            .unwrap()
+            .contains("Review code changes.")
+    );
+}

--- a/tests/launch_bundle/launch_actions.rs
+++ b/tests/launch_bundle/launch_actions.rs
@@ -385,3 +385,164 @@ Code."#;
             .any(|value| value.as_str() == Some("/tmp/pi-sessions"))
     );
 }
+
+pub(crate) fn build_launch_bundle_projects_codex_streaming_launch_actions() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = install_fake_harnesses(temp.path(), &["codex"]);
+    let agent_content = r#"---
+name: coder
+model: gpt-5
+effort: high
+harness: codex
+approval: never
+sandbox: danger-full-access
+mcp-tools: ["fs=npx filesystem-server"]
+---
+Code."#;
+
+    let (server, project_root) =
+        setup_bundle_project(&temp, "bundle-source", agent_content, &[], "");
+    let context = serde_json::json!({
+        "cwd": "/work/project",
+        "temp_dir": "/tmp/mars-spawn",
+        "streaming": {"host": "127.0.0.1", "port": 9876},
+        "session_id": "thread-1",
+        "fork": true,
+        "workspace_roots": ["/extra/root"],
+        "interactive": false,
+        "extra_args": ["--foo"],
+        "opencode_config_content": null,
+        "pi_extension_entrypoints": [],
+        "prompt": "USER",
+        "base_instructions": "BASE",
+        "developer_instructions": "DEV"
+    });
+
+    let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
+    cmd.args([
+        "build",
+        "launch-bundle",
+        "--agent",
+        "reviewer",
+        "--transport",
+        "streaming",
+        "--context",
+        &context.to_string(),
+    ]);
+    cmd.env("PATH", replace_path_with(&bin_dir));
+
+    let output = cmd.assert().success().get_output().clone();
+    let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert_eq!(
+        bundle["launch_actions"]["argv"],
+        serde_json::json!([
+            "codex",
+            "app-server",
+            "--listen",
+            "ws://127.0.0.1:9876",
+            "-c",
+            "sandbox_mode=\"danger-full-access\"",
+            "-c",
+            "approval_policy=\"never\"",
+            "-c",
+            "mcp.servers.fs.command=\"npx filesystem-server\"",
+            "-c",
+            "sandbox_workspace_write.writable_roots=[\"/extra/root\"]",
+            "--foo"
+        ])
+    );
+    assert_eq!(
+        bundle["launch_actions"]["protocol_payload"],
+        serde_json::json!({
+            "transport": "jsonrpc",
+            "method": "thread/fork",
+            "params": {
+                "cwd": "/work/project",
+                "baseInstructions": "BASE",
+                "developerInstructions": "DEV",
+                "model": "gpt-5",
+                "config": {"model_reasoning_effort": "high"},
+                "approvalPolicy": "never",
+                "sandbox": "danger-full-access",
+                "threadId": "thread-1",
+                "ephemeral": false
+            }
+        })
+    );
+}
+
+pub(crate) fn build_launch_bundle_projects_opencode_streaming_launch_actions() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = install_fake_harnesses(temp.path(), &["opencode"]);
+    let agent_content = r#"---
+name: coder
+model: openai/gpt-5
+harness: opencode
+mcp-tools: [server-one]
+---
+Code."#;
+
+    let (server, project_root) =
+        setup_bundle_project(&temp, "bundle-source", agent_content, &[], "");
+    let context = serde_json::json!({
+        "cwd": "/work/project",
+        "temp_dir": "/tmp/mars-spawn",
+        "streaming": {"host": "127.0.0.1", "port": 9877},
+        "session_id": null,
+        "fork": false,
+        "workspace_roots": ["/extra/root"],
+        "interactive": false,
+        "extra_args": ["--foo"],
+        "opencode_config_content": null,
+        "pi_extension_entrypoints": [],
+        "prompt": "USER"
+    });
+
+    let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
+    cmd.args([
+        "build",
+        "launch-bundle",
+        "--agent",
+        "reviewer",
+        "--transport",
+        "streaming",
+        "--context",
+        &context.to_string(),
+    ]);
+    cmd.env("PATH", replace_path_with(&bin_dir));
+
+    let output = cmd.assert().success().get_output().clone();
+    let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert_eq!(
+        bundle["launch_actions"]["argv"],
+        serde_json::json!([
+            "opencode",
+            "serve",
+            "--hostname",
+            "127.0.0.1",
+            "--port",
+            "9877",
+            "--foo"
+        ])
+    );
+    assert_eq!(
+        bundle["launch_actions"]["env"]["OPENCODE_CONFIG_CONTENT"].as_str(),
+        Some("{\"permission\":{\"external_directory\":{\"/extra/root/**\":\"allow\"}}}")
+    );
+    assert_eq!(
+        bundle["launch_actions"]["protocol_payload"],
+        serde_json::json!({
+            "transport": "http",
+            "method": "POST",
+            "path": "/session",
+            "body": {
+                "model": "openai/gpt-5",
+                "modelID": "openai/gpt-5",
+                "agent": "reviewer",
+                "mcp": {"servers": ["server-one"]}
+            }
+        })
+    );
+}

--- a/tests/launch_bundle/launch_actions.rs
+++ b/tests/launch_bundle/launch_actions.rs
@@ -185,3 +185,203 @@ Review code changes."#;
             .contains("Review code changes.")
     );
 }
+
+pub(crate) fn build_launch_bundle_projects_codex_subprocess_launch_actions() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = install_fake_harnesses(temp.path(), &["codex"]);
+    let agent_content = r#"---
+name: coder
+model: gpt-5
+harness: codex
+effort: high
+approval: auto
+sandbox: workspace-write
+mcp-tools: ["fs=npx filesystem-server"]
+---
+Code."#;
+
+    let (server, project_root) =
+        setup_bundle_project(&temp, "bundle-source", agent_content, &[], "");
+    let context = serde_json::json!({
+        "cwd": "/work/project",
+        "temp_dir": "/tmp/mars-spawn",
+        "streaming": null,
+        "session_id": "codex-thread",
+        "fork": false,
+        "workspace_roots": ["/extra/root"],
+        "interactive": false,
+        "extra_args": ["--foo"],
+        "opencode_config_content": null,
+        "pi_extension_entrypoints": [],
+        "prompt": "USER",
+        "base_instructions": "BASE",
+        "developer_instructions": "DEV",
+        "report_output_path": "/tmp/report.md"
+    });
+
+    let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
+    cmd.args([
+        "build",
+        "launch-bundle",
+        "--agent",
+        "reviewer",
+        "--context",
+        &context.to_string(),
+    ]);
+    cmd.env("PATH", replace_path_with(&bin_dir));
+
+    let output = cmd.assert().success().get_output().clone();
+    let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert_eq!(
+        bundle["launch_actions"]["argv"],
+        serde_json::json!([
+            "codex",
+            "exec",
+            "--json",
+            "--model",
+            "gpt-5",
+            "-c",
+            "model_reasoning_effort=\"high\"",
+            "--sandbox",
+            "workspace-write",
+            "-c",
+            "approval_policy=\"on-request\"",
+            "-c",
+            "mcp.servers.fs.command=\"npx filesystem-server\"",
+            "resume",
+            "codex-thread",
+            "--add-dir",
+            "/extra/root",
+            "--foo",
+            "-o",
+            "/tmp/report.md",
+            "BASE\n\nDEV\n\nUSER"
+        ])
+    );
+}
+
+pub(crate) fn build_launch_bundle_projects_opencode_subprocess_launch_actions() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = install_fake_harnesses(temp.path(), &["opencode"]);
+    let agent_content = r#"---
+name: coder
+model: openai/gpt-5
+harness: opencode
+effort: high
+---
+Code."#;
+
+    let (server, project_root) =
+        setup_bundle_project(&temp, "bundle-source", agent_content, &[], "");
+    let context = serde_json::json!({
+        "cwd": "/work/project",
+        "temp_dir": "/tmp/mars-spawn",
+        "streaming": null,
+        "session_id": "opencode-session",
+        "fork": true,
+        "workspace_roots": ["/extra/root"],
+        "interactive": false,
+        "extra_args": ["--foo"],
+        "opencode_config_content": "{\"permission\":{\"external_directory\":[\"/parent\"]}}",
+        "pi_extension_entrypoints": [],
+        "prompt": "USER"
+    });
+
+    let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
+    cmd.args([
+        "build",
+        "launch-bundle",
+        "--agent",
+        "reviewer",
+        "--context",
+        &context.to_string(),
+    ]);
+    cmd.env("PATH", replace_path_with(&bin_dir));
+
+    let output = cmd.assert().success().get_output().clone();
+    let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert_eq!(
+        bundle["launch_actions"]["argv"],
+        serde_json::json!([
+            "opencode",
+            "run",
+            "--model",
+            "openai/gpt-5",
+            "--variant",
+            "high",
+            "--foo",
+            "-",
+            "--session",
+            "opencode-session",
+            "--fork"
+        ])
+    );
+    assert_eq!(
+        bundle["launch_actions"]["env"]["OPENCODE_CONFIG_CONTENT"].as_str(),
+        Some(
+            "{\"permission\":{\"external_directory\":{\"/extra/root/**\":\"allow\",\"/parent\":\"allow\"}}}"
+        )
+    );
+}
+
+pub(crate) fn build_launch_bundle_projects_pi_launch_actions() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = install_fake_harnesses(temp.path(), &["pi"]);
+    let agent_content = r#"---
+name: coder
+model: openai-codex/gpt-5.4-mini
+harness: pi
+effort: xhigh
+---
+Code."#;
+
+    let (server, project_root) =
+        setup_bundle_project(&temp, "bundle-source", agent_content, &[], "");
+    let context = serde_json::json!({
+        "cwd": "/work/project",
+        "temp_dir": "/tmp/mars-spawn",
+        "streaming": null,
+        "session_id": "pi-session",
+        "fork": false,
+        "workspace_roots": [],
+        "interactive": false,
+        "extra_args": ["--foo"],
+        "opencode_config_content": null,
+        "pi_extension_entrypoints": ["/ext/managed-bash/index.js", "/ext/spawn-watch/index.js"],
+        "prompt": "USER",
+        "pi_session_dir": "/tmp/pi-sessions"
+    });
+
+    let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
+    cmd.args([
+        "build",
+        "launch-bundle",
+        "--agent",
+        "reviewer",
+        "--context",
+        &context.to_string(),
+    ]);
+    cmd.env("PATH", replace_path_with(&bin_dir));
+
+    let output = cmd.assert().success().get_output().clone();
+    let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let argv = bundle["launch_actions"]["argv"].as_array().unwrap();
+
+    assert_eq!(argv[0].as_str(), Some("pi"));
+    assert_eq!(argv[1].as_str(), Some("--mode"));
+    assert_eq!(argv[2].as_str(), Some("rpc"));
+    assert!(
+        argv.iter()
+            .any(|value| value.as_str() == Some("openai-codex/gpt-5.4-mini:xhigh"))
+    );
+    assert!(
+        argv.iter()
+            .any(|value| value.as_str() == Some("/ext/managed-bash/index.js"))
+    );
+    assert!(
+        argv.iter()
+            .any(|value| value.as_str() == Some("/tmp/pi-sessions"))
+    );
+}

--- a/tests/launch_bundle/launch_actions.rs
+++ b/tests/launch_bundle/launch_actions.rs
@@ -1,0 +1,96 @@
+use super::common::{install_fake_harnesses, replace_path_with, setup_bundle_project};
+use crate::test_common::{API_PATH, mars_cmd};
+use assert_fs::TempDir;
+use serde_json::Value;
+
+pub(crate) fn build_launch_bundle_omits_launch_actions_without_context() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = install_fake_harnesses(temp.path(), &["cursor"]);
+    let agent_content = r#"---
+name: reviewer
+model: claude-opus-4-6
+harness: cursor
+---
+Review code changes."#;
+
+    let (server, project_root) =
+        setup_bundle_project(&temp, "bundle-source", agent_content, &[], "");
+
+    let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
+    cmd.args(["build", "launch-bundle", "--agent", "reviewer"]);
+    cmd.env("PATH", replace_path_with(&bin_dir));
+
+    let output = cmd.assert().success().get_output().clone();
+    let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert_eq!(bundle["version"].as_u64(), Some(4));
+    assert!(bundle.get("launch_actions").is_none());
+}
+
+pub(crate) fn build_launch_bundle_projects_cursor_launch_actions() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = install_fake_harnesses(temp.path(), &["cursor"]);
+    let agent_content = r#"---
+name: reviewer
+model: claude-opus-4-6
+harness: cursor
+approval: auto
+sandbox: read-only
+---
+Review code changes."#;
+
+    let (server, project_root) =
+        setup_bundle_project(&temp, "bundle-source", agent_content, &[], "");
+
+    let context = serde_json::json!({
+        "cwd": "/work/project",
+        "temp_dir": "/tmp/mars-spawn",
+        "streaming": null,
+        "session_id": null,
+        "fork": false,
+        "workspace_roots": ["/ignored-extra-root"],
+        "interactive": false,
+        "extra_args": ["--foo"],
+        "opencode_config_content": null,
+        "pi_extension_entrypoints": [],
+        "prompt": "Review this change"
+    });
+
+    let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
+    cmd.args([
+        "build",
+        "launch-bundle",
+        "--agent",
+        "reviewer",
+        "--context",
+        &context.to_string(),
+    ]);
+    cmd.env("PATH", replace_path_with(&bin_dir));
+
+    let output = cmd.assert().success().get_output().clone();
+    let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert_eq!(
+        bundle["launch_actions"]["argv"],
+        serde_json::json!([
+            "cursor",
+            "agent",
+            "--print",
+            "--output-format",
+            "stream-json",
+            "--trust",
+            "--model",
+            "claude-opus-4-6",
+            "--force",
+            "--sandbox",
+            "enabled",
+            "--workspace",
+            "/work/project",
+            "--foo",
+            "Review this change"
+        ])
+    );
+    assert_eq!(bundle["launch_actions"]["env"], serde_json::json!({}));
+    assert_eq!(bundle["launch_actions"]["files"], serde_json::json!([]));
+    assert!(bundle["launch_actions"]["protocol_payload"].is_null());
+}

--- a/tests/launch_bundle/launch_actions.rs
+++ b/tests/launch_bundle/launch_actions.rs
@@ -3,6 +3,30 @@ use crate::test_common::{API_PATH, mars_cmd};
 use assert_fs::TempDir;
 use serde_json::Value;
 
+/// Default launch context; tests override only the fields they care about.
+fn context_json(overrides: Value) -> Value {
+    let mut base = serde_json::json!({
+        "cwd": "/work/project",
+        "temp_dir": "/tmp/mars-spawn",
+        "streaming": null,
+        "session_id": null,
+        "fork": false,
+        "workspace_roots": [],
+        "interactive": false,
+        "extra_args": ["--foo"],
+        "opencode_config_content": null,
+        "pi_extension_entrypoints": [],
+        "prompt": "USER"
+    });
+    let base_map = base.as_object_mut().unwrap();
+    if let Value::Object(over) = overrides {
+        for (k, v) in over {
+            base_map.insert(k, v);
+        }
+    }
+    base
+}
+
 pub(crate) fn build_launch_bundle_omits_launch_actions_without_context() {
     let temp = TempDir::new().unwrap();
     let bin_dir = install_fake_harnesses(temp.path(), &["cursor"]);
@@ -42,19 +66,10 @@ Review code changes."#;
     let (server, project_root) =
         setup_bundle_project(&temp, "bundle-source", agent_content, &[], "");
 
-    let context = serde_json::json!({
-        "cwd": "/work/project",
-        "temp_dir": "/tmp/mars-spawn",
-        "streaming": null,
-        "session_id": null,
-        "fork": false,
+    let context = context_json(serde_json::json!({
         "workspace_roots": ["/ignored-extra-root"],
-        "interactive": false,
-        "extra_args": ["--foo"],
-        "opencode_config_content": null,
-        "pi_extension_entrypoints": [],
         "prompt": "Review this change"
-    });
+    }));
 
     let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
     cmd.args([
@@ -121,19 +136,13 @@ Review code changes."#;
     let (server, project_root) =
         setup_bundle_project(&temp, "bundle-source", agent_content, &[], "");
 
-    let context = serde_json::json!({
-        "cwd": "/work/project",
-        "temp_dir": "/tmp/mars-spawn",
-        "streaming": null,
+    let context = context_json(serde_json::json!({
         "session_id": "session-123",
         "fork": true,
         "workspace_roots": ["/extra/root"],
-        "interactive": false,
         "extra_args": ["--meridian-parent-allowed-tools", "Read,Write", "--allowedTools", "Grep", "--passthrough"],
-        "opencode_config_content": null,
-        "pi_extension_entrypoints": [],
         "prompt": "ignored by claude argv"
-    });
+    }));
 
     let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
     cmd.args([
@@ -210,7 +219,7 @@ pub(crate) fn build_launch_bundle_projects_codex_subprocess_launch_actions() {
     let temp = TempDir::new().unwrap();
     let bin_dir = install_fake_harnesses(temp.path(), &["codex"]);
     let agent_content = r#"---
-name: coder
+name: reviewer
 model: gpt-5
 harness: codex
 effort: high
@@ -222,20 +231,11 @@ Code."#;
 
     let (server, project_root) =
         setup_bundle_project(&temp, "bundle-source", agent_content, &[], "");
-    let context = serde_json::json!({
-        "cwd": "/work/project",
-        "temp_dir": "/tmp/mars-spawn",
-        "streaming": null,
+    let context = context_json(serde_json::json!({
         "session_id": "codex-thread",
-        "fork": false,
         "workspace_roots": ["/extra/root"],
-        "interactive": false,
-        "extra_args": ["--foo"],
-        "opencode_config_content": null,
-        "pi_extension_entrypoints": [],
-        "prompt": "USER",
         "report_output_path": "/tmp/report.md"
-    });
+    }));
 
     let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
     cmd.args([
@@ -292,7 +292,7 @@ pub(crate) fn build_launch_bundle_projects_opencode_subprocess_launch_actions() 
     let temp = TempDir::new().unwrap();
     let bin_dir = install_fake_harnesses(temp.path(), &["opencode"]);
     let agent_content = r#"---
-name: coder
+name: reviewer
 model: openai/gpt-5
 harness: opencode
 effort: high
@@ -301,19 +301,12 @@ Code."#;
 
     let (server, project_root) =
         setup_bundle_project(&temp, "bundle-source", agent_content, &[], "");
-    let context = serde_json::json!({
-        "cwd": "/work/project",
-        "temp_dir": "/tmp/mars-spawn",
-        "streaming": null,
+    let context = context_json(serde_json::json!({
         "session_id": "opencode-session",
         "fork": true,
         "workspace_roots": ["/extra/root"],
-        "interactive": false,
-        "extra_args": ["--foo"],
-        "opencode_config_content": "{\"permission\":{\"external_directory\":[\"/parent\"]}}",
-        "pi_extension_entrypoints": [],
-        "prompt": "USER"
-    });
+        "opencode_config_content": "{\"permission\":{\"external_directory\":[\"/parent\"]}}"
+    }));
 
     let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
     cmd.args([
@@ -366,7 +359,7 @@ pub(crate) fn build_launch_bundle_projects_pi_launch_actions() {
     let temp = TempDir::new().unwrap();
     let bin_dir = install_fake_harnesses(temp.path(), &["pi"]);
     let agent_content = r#"---
-name: coder
+name: reviewer
 model: openai-codex/gpt-5.4-mini
 harness: pi
 effort: xhigh
@@ -375,20 +368,12 @@ Code."#;
 
     let (server, project_root) =
         setup_bundle_project(&temp, "bundle-source", agent_content, &[], "");
-    let context = serde_json::json!({
-        "cwd": "/work/project",
-        "temp_dir": "/tmp/mars-spawn",
-        "streaming": null,
+    let context = context_json(serde_json::json!({
         "session_id": "pi-session",
-        "fork": false,
         "workspace_roots": [],
-        "interactive": false,
-        "extra_args": ["--foo"],
-        "opencode_config_content": null,
         "pi_extension_entrypoints": ["/ext/managed-bash/index.js", "/ext/spawn-watch/index.js"],
-        "prompt": "USER",
         "pi_session_dir": "/tmp/pi-sessions"
-    });
+    }));
 
     let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
     cmd.args([
@@ -435,7 +420,7 @@ pub(crate) fn build_launch_bundle_projects_codex_streaming_launch_actions() {
     let temp = TempDir::new().unwrap();
     let bin_dir = install_fake_harnesses(temp.path(), &["codex"]);
     let agent_content = r#"---
-name: coder
+name: reviewer
 model: gpt-5
 effort: high
 harness: codex
@@ -447,19 +432,12 @@ Code."#;
 
     let (server, project_root) =
         setup_bundle_project(&temp, "bundle-source", agent_content, &[], "");
-    let context = serde_json::json!({
-        "cwd": "/work/project",
-        "temp_dir": "/tmp/mars-spawn",
+    let context = context_json(serde_json::json!({
         "streaming": {"host": "127.0.0.1", "port": 9876},
         "session_id": "thread-1",
         "fork": true,
-        "workspace_roots": ["/extra/root"],
-        "interactive": false,
-        "extra_args": ["--foo"],
-        "opencode_config_content": null,
-        "pi_extension_entrypoints": [],
-        "prompt": "USER"
-    });
+        "workspace_roots": ["/extra/root"]
+    }));
 
     let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
     cmd.args([
@@ -532,7 +510,7 @@ pub(crate) fn build_launch_bundle_projects_opencode_streaming_launch_actions() {
     let temp = TempDir::new().unwrap();
     let bin_dir = install_fake_harnesses(temp.path(), &["opencode"]);
     let agent_content = r#"---
-name: coder
+name: reviewer
 model: openai/gpt-5
 harness: opencode
 mcp-tools: [server-one]
@@ -541,19 +519,10 @@ Code."#;
 
     let (server, project_root) =
         setup_bundle_project(&temp, "bundle-source", agent_content, &[], "");
-    let context = serde_json::json!({
-        "cwd": "/work/project",
-        "temp_dir": "/tmp/mars-spawn",
+    let context = context_json(serde_json::json!({
         "streaming": {"host": "127.0.0.1", "port": 9877},
-        "session_id": null,
-        "fork": false,
-        "workspace_roots": ["/extra/root"],
-        "interactive": false,
-        "extra_args": ["--foo"],
-        "opencode_config_content": null,
-        "pi_extension_entrypoints": [],
-        "prompt": "USER"
-    });
+        "workspace_roots": ["/extra/root"]
+    }));
 
     let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
     cmd.args([

--- a/tests/launch_bundle/prompt_surface.rs
+++ b/tests/launch_bundle/prompt_surface.rs
@@ -326,10 +326,14 @@ Plan work."#;
     assert!(inventory_prompt.contains("# Meridian Agents"));
     assert!(inventory_prompt.contains("## Primary"));
     assert!(inventory_prompt.contains("## Subagent"));
-    assert!(inventory_prompt.contains("- planner: Plan tasks | Model: openai/gpt-5"));
     assert!(
-        inventory_prompt.contains("- reviewer: Review implementation | Model: claude-opus-4-6")
+        inventory_prompt
+            .contains("- `meridian spawn -a planner`: Plan tasks | Model: openai/gpt-5")
     );
+    assert!(inventory_prompt.contains(
+        "- `meridian spawn -a reviewer`: Review implementation | Model: claude-opus-4-6"
+    ));
+    assert!(inventory_prompt.contains("Write prompts to `/tmp/<name>.md`."));
 
     let system_instruction = bundle["prompt_surface"]["system_instruction"]
         .as_str()
@@ -476,7 +480,7 @@ Hidden work."#;
     let inventory_prompt = bundle["prompt_surface"]["inventory_prompt"]
         .as_str()
         .expect("inventory_prompt should be string");
-    assert!(inventory_prompt.contains("reviewer: Review implementation"));
+    assert!(inventory_prompt.contains("`meridian spawn -a reviewer`: Review implementation"));
     assert!(inventory_prompt.contains("Fan-out: gpt55, gpt-5"));
     assert!(!inventory_prompt.contains("hidden-worker"));
 }
@@ -579,9 +583,11 @@ Review code changes."#;
         "# Skill: reference_a\n\n",
         "Reference body.\n\n",
         "# Meridian Agents\n\n",
-        "Installed Meridian agents available at launch time.\n\n",
+        "Write prompts to `/tmp/<name>.md`.\n",
+        "Use `--bg` + `meridian spawn wait` for parallel work.\n",
+        "Use `/handoff` when passing control back to the user.\n\n",
         "## Subagent\n",
-        "- reviewer: Review implementation | Model: claude-opus-4-6\n\n",
+        "- `meridian spawn -a reviewer`: Review implementation | Model: claude-opus-4-6\n\n",
         "# Report\n\n",
         "**IMPORTANT - Your final assistant message must be the run report.**\n\n",
         "Provide a plain markdown report in your final assistant message.\n\n",

--- a/tests/launch_bundle/prompt_surface.rs
+++ b/tests/launch_bundle/prompt_surface.rs
@@ -333,7 +333,6 @@ Plan work."#;
     assert!(inventory_prompt.contains(
         "- `meridian spawn -a reviewer`: Review implementation | Model: claude-opus-4-6"
     ));
-    assert!(inventory_prompt.contains("Write prompts to `/tmp/<name>.md`."));
 
     let system_instruction = bundle["prompt_surface"]["system_instruction"]
         .as_str()
@@ -575,23 +574,39 @@ Review code changes."#;
         .as_str()
         .expect("system instruction should be string");
 
-    let expected = concat!(
-        "# Agent Profile\n\n",
-        "Review code changes.\n\n",
-        "# Skill: principle_a\n\n",
-        "Principle body.\n\n",
-        "# Skill: reference_a\n\n",
-        "Reference body.\n\n",
-        "# Meridian Agents\n\n",
-        "Write prompts to `/tmp/<name>.md`.\n",
-        "Use `--bg` + `meridian spawn wait` for parallel work.\n",
-        "Use `/handoff` when passing control back to the user.\n\n",
-        "## Subagent\n",
-        "- `meridian spawn -a reviewer`: Review implementation | Model: claude-opus-4-6\n\n",
-        "# Report\n\n",
-        "**IMPORTANT - Your final assistant message must be the run report.**\n\n",
-        "Provide a plain markdown report in your final assistant message.\n\n",
-        "Include: what was done, key decisions made, files created/modified, verification results, and any issues or blockers."
+    // Assert structure (headings, spawn format, report contract), not prose copy.
+    assert!(system_instruction.contains("# Agent Profile"));
+    assert!(system_instruction.contains("Review code changes."));
+    assert!(system_instruction.contains("# Skill: principle_a"));
+    assert!(system_instruction.contains("Principle body."));
+    assert!(system_instruction.contains("# Skill: reference_a"));
+    assert!(system_instruction.contains("Reference body."));
+    assert!(system_instruction.contains("# Meridian Agents"));
+    assert!(system_instruction.contains("## Subagent"));
+    assert!(system_instruction.contains(
+        "- `meridian spawn -a reviewer`: Review implementation | Model: claude-opus-4-6"
+    ));
+    assert!(system_instruction.contains("# Report"));
+    assert!(
+        system_instruction
+            .contains("**IMPORTANT - Your final assistant message must be the run report.**")
     );
-    assert_eq!(system_instruction, expected);
+
+    let profile_index = system_instruction
+        .find("# Agent Profile")
+        .expect("profile section");
+    let principle_index = system_instruction
+        .find("# Skill: principle_a")
+        .expect("principle skill");
+    let reference_index = system_instruction
+        .find("# Skill: reference_a")
+        .expect("reference skill");
+    let inventory_index = system_instruction
+        .find("# Meridian Agents")
+        .expect("inventory section");
+    let report_index = system_instruction.find("# Report").expect("report section");
+    assert!(profile_index < principle_index);
+    assert!(principle_index < reference_index);
+    assert!(reference_index < inventory_index);
+    assert!(inventory_index < report_index);
 }

--- a/tests/launch_bundle/schema.rs
+++ b/tests/launch_bundle/schema.rs
@@ -56,7 +56,7 @@ Review code changes.
 
     let bundle: Value = serde_json::from_str(&stdout).expect("launch-bundle should emit JSON");
 
-    assert_eq!(bundle["version"].as_u64(), Some(3));
+    assert_eq!(bundle["version"].as_u64(), Some(4));
     assert_eq!(bundle["agent"].as_str(), Some("reviewer"));
     assert_eq!(
         bundle["agent_body"].as_str(),
@@ -130,7 +130,7 @@ Review code changes."#;
     let output = cmd.assert().success().get_output().clone();
     let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
 
-    assert_eq!(bundle["version"].as_u64(), Some(3));
+    assert_eq!(bundle["version"].as_u64(), Some(4));
     assert!(bundle["agent"].is_null());
     assert_field_absent_or_null(&bundle, "agent_body");
     assert_eq!(

--- a/tests/sync_behavior.rs
+++ b/tests/sync_behavior.rs
@@ -650,6 +650,12 @@ path = "{}"
             .exists()
     );
     assert!(project.child(".codex/agents/explorer.toml").exists());
+    assert!(
+        project
+            .child(".codex/agents/integration-tester.toml")
+            .exists(),
+        "EmitAll should emit every agent to every configured harness target"
+    );
 
     let codex_toml =
         fs::read_to_string(project.child(".codex/agents/explorer.toml").path()).unwrap();
@@ -676,7 +682,10 @@ path = "{}"
             .child(".opencode/agents/integration-tester.md")
             .exists()
     );
-    assert!(!project.child(".opencode/agents/explorer.md").exists());
+    assert!(
+        project.child(".opencode/agents/explorer.md").exists(),
+        "EmitAll should emit explorer to opencode even when profile.harness is codex"
+    );
     let opencode_native = fs::read_to_string(
         project
             .child(".opencode/agents/integration-tester.md")
@@ -1531,9 +1540,13 @@ path = "{}"
         .assert()
         .success();
 
+    // A genuinely unmanaged, user-authored agent uses a name mars does not emit.
+    // Under full-coverage EmitAll, mars owns every *source* agent name on every
+    // configured target, so an edit to design-lead.md is managed drift that sync
+    // restores. Unmanaged-collision protection only guards non-source names.
     fs::create_dir_all(project.child(".cursor/agents").path()).unwrap();
     fs::write(
-        project.child(".cursor/agents/design-lead.md").path(),
+        project.child(".cursor/agents/handwritten-only.md").path(),
         "# hand-written\n",
     )
     .unwrap();
@@ -1543,10 +1556,13 @@ path = "{}"
         .assert()
         .success();
 
+    // The unmanaged file survives untouched.
     assert_eq!(
-        fs::read_to_string(project.child(".cursor/agents/design-lead.md").path()).unwrap(),
+        fs::read_to_string(project.child(".cursor/agents/handwritten-only.md").path()).unwrap(),
         "# hand-written\n"
     );
+    // And full-coverage EmitAll still emits the mars source agent to the target.
+    assert!(project.child(".cursor/agents/design-lead.md").exists());
 }
 
 #[test]


### PR DESCRIPTION
## Why

Two needs converged on this branch:

1. **Harness-aware agent inventory** — Meridian was re-deriving the agent inventory prompt itself (a second renderer that drifted from Mars). Mars should own the inventory contract and emit it ready-to-embed.
2. **Standalone provisioning** — `mars sync` outside Meridian (`EmitAll`) only emitted native agents to `profile.harness`, leaving agents without an explicit harness pin uncovered, and ignored per-agent overlays. Coverage should follow configured targets.

The original launch-actions projection that opened this PR is kept but **quarantined as experimental** (Meridian still owns launch argv/env; the duplication is not expanded).

## Goal

After merge:
- Mars renders `prompt_surface.inventory_prompt` (Meridian agents vs harness-native agents) and Meridian embeds it verbatim — one renderer.
- `EmitAll` emits every agent to every **configured** managed-target harness, model-faithful-else-clear; per-agent overlays drive native model selection in both `EmitAll` and `EmitSelective`.
- `launch_actions` projection stays behind `--context`, is documented experimental, and is safe to delete later.

## Summary

- **launch_actions (experimental):** `--context`/`--transport` on `mars build launch-bundle`, v4 `launch_actions` with argv/env/files/protocol; marked EXPERIMENTAL + siloed with a deletion checklist and parity TODO ledger; stderr warning when `--context` is used.
- **Harness-aware inventory + manifest:** `prompt_surface.inventory_prompt` split (Meridian `meridian spawn -a <name>` + model/fanout vs harness-native), and `.mars/native-agents.json` manifest.
- **Standalone provisioning Piece 1:** config moved from `[settings.agent_copy]` → `[settings.meridian.agent_copy]` (readers, layering, link, docs, CHANGELOG).
- **Piece 2:** `EmitAll` broadened to full configured-target coverage (`managed_targets()` → harness kinds). Per-(agent, harness) model is faithful-else-clear via a `NativeModelDirective { Resolved(Option<String>), Clear }` so non-resolving models do not leak.
- **Piece 3:** overlay-driven native model selection. Shared `config::overlay_then_profile_model` / `overlay_then_profile_policies` helpers; `effective_policies` (launch-bundle) refactored onto the policy helper preserving `PolicyLayer`/per-layer indices; native emission consumes `overlay.model` + `overlay.model_policies` (not `overlay.harness`) in both `EmitAll` and `EmitSelective`, with matching selective-reconcile.

## Work Item

harness-aware-agent-inventory / launch-bundle-projection

## Changes

- `EmitAll`/`agent_emission = "always"` now **own every source agent name on every configured target**; authored `harness:` pins become model-selection hints, not emission filters. Empty configured targets emit nothing (intended).
- Unmanaged-collision protection still guards genuinely non-source agent files.
- `effective_policies` behavior is preserved exactly (fallback indexing intact); `settings.model_policies` stay launch-bundle/spawn-only.
- Bundle v4 launch_actions remain experimental; Meridian deliberately does **not** consume them (it keeps launch ownership). Phase 2 is parked.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets` (clean)
- `cargo test` — full suite green (post-review: **1330 lib tests** + all integration suites); pre-push preflight (tests + release build) passed on push
- The 118-test `build::policy` suite confirms the `effective_policies` refactor is behavior-preserving (live spawn/launch routing untouched)
- New native-emission tests: model-faithful vs model-less, multi-target coverage, empty-target = nothing, authored-pin-does-not-block-coverage, overlay.model re-pin, overlay model-policy supply, overlay.harness ignored
- Pre-push preflight (tests + release build) passed

## Knowledge Updates

- `CHANGELOG.md` `[Unreleased]` updated
- `src/compiler/AGENTS.md` and `docs/config/*`, `docs/cli/commands.md` updated to `settings.meridian.agent_copy`
- `build/project/mod.rs` module doc carries the launch_actions EXPERIMENTAL deletion checklist + parity ledger
- PR template unified with meridian (shared structure + full release-label guide) (24538c3)

## Spawn Trace

- p3697 — meridian launch-path scoping (inventory consumption)
- p3698 — mars projection parity scoping
- p3702 coder — Piece 2 broaden EmitAll (verified + bug-fixed by lead before commit)
- p3704 reviewer — thermo-nuclear structural review (overlay threading, lowering boundary)
- p3705 reviewer — adversarial correctness review (overlay/harness leak)
- p3707 coder — overlay/harness fix (patch applied + verified by lead)
- p3709 coder — test-architecture cleanup (context_json builder, prose-pin loosening)

## Review Follow-ups (thermo-nuclear)

A strict structural + correctness review (3 reviewers, distinct lenses) ran after the initial branch. Acted on here:

- **Fix — overlay/harness model leak** (`2cd5369`): `agent_qualifies_for_harness` short-circuited on `profile.harness` without checking the (overlay-)effective model resolves there, pinning a foreign model into the declared-harness native file (e.g. a claude/opus overlay on a codex-authored agent emitting opus into `.codex`). Now gated on the canonical resolution primitive (`model_resolved_harness`); model-faithful-else-clear. Fixes the new overlay case **and** the pre-existing latent same-harness leak. +6 tests.
- **Refactor — resolve overlays once** (`fc6f81f`, behavior-preserving): effective profiles resolved a single time at the native lifecycle entry; `agent_overlays` removed from both contexts (2 structs + 4 construction sites) and the double-merge.
- **Refactor — authoritative `NativeModel`** (`5064777`, behavior-preserving): one owned `NativeModel { Inherit, Set, Clear }` at the lowering boundary replaces `NativeModelDirective` + the profile-clone + the `.or(profile.model)` fallback across 7 lowering fns (native emission is the sole caller).

- **E2E** (`7dcabf8`): CLI-level regression driving the real `mars` binary — overlay-resolved model must not leak into the declared harness file under `mars sync`. Live standalone→managed→standalone swap verified: EmitAll emits both agents to `.claude`+`.codex`; EmitSelective(claude) prunes `.codex`; standalone re-emits — converges, no stale files.

Rejected/deferred: legacy `[settings.agent_copy]` silent no-op (rejected — no-backcompat policy); `EmitAll` reconcile no-prune on target removal (pre-existing; follow-up).

### Sync-summary observability (e2e follow-up — fc9e6f1)
- `mars sync` reported `already up to date` while a managed/SuppressAll sync silently pruned native harness agents (found driving the standalone↔managed swap end-to-end).
- `SyncReport` now carries `native_emitted` / `native_removed`; `finalize()` diffs emissions vs the prior lock (`lock::native_output_is_new_or_changed`) so steady-state stays quiet while real emits/prunes show as `emitted/removed N native agents` (+per-line, +`--json`).
- Verified live: standalone emit → `emitted 1 native agents`; managed prune → `removed 1 native agents`; re-sync → `already up to date`. New test `agent_emission::sync_summary_reports_native_emit_and_prune`. Full suite green (1324 unit + integration), clippy clean.

### Test-architecture cleanup (follow-up — dcb674c)

`/test-architecture` audit of this branch's test diff. Acted on:

- `launch_actions.rs`: added a `context_json()` builder so each test shows only the fields it varies — removed 8 near-identical copies of a 12-field context literal. Fixed misleading `name: coder` frontmatter (`setup_bundle_project` owns the agent filename `reviewer`, so `name:` was silently ignored) in 5 tests.
- `prompt_surface.rs`: replaced the golden-string `assert_eq!` on the full `system_instruction` with structural `contains()` checks plus explicit section-ordering assertions; stopped pinning tunable prompt prose while strengthening the inventory-before-report contract.
- Verified: `cargo fmt --check` clean; `launch_bundle` 118 + `agent_copy` 13 + `agent_emission` 7 + `sync_behavior` 25 pass; pre-push preflight green.

## Release Label Guide

`release:minor` (set) — feature-level work; bumps to the next minor.

## Cleanup

```bash
scripts/prune-worktrees.sh
```




