### PR TITLE
Fix lock carry-forward and local discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - `mars sync` lock rebuild now carries forward existing non-canonical target ownership records while refreshing canonical `.mars` records, instead of relying on a post-build safety-net pass.
+- Local package discovery scans only `.mars-src/`, preventing package source `agents/` / `skills/` directories at the project root from being misread as local unmanaged items; `--force` also repairs stale canonical cache files left by the old discovery behavior.
 
 ## [0.8.1] - 2026-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `mars sync` lock rebuild now carries forward existing non-canonical target ownership records while refreshing canonical `.mars` records, instead of relying on a post-build safety-net pass.
+
 ## [0.8.1] - 2026-06-06
 
 ### Removed

--- a/docs/config/mars-toml.md
+++ b/docs/config/mars-toml.md
@@ -55,7 +55,7 @@ description = "Core agents and skills for meridian"  # optional
 | `version` | string | yes | Semver version of this package |
 | `description` | string | no | Human-readable description |
 
-When `[package]` is present, Mars also reads legacy repo-root `agents/` and `skills/` directories during sync. `.mars-src/` always takes precedence over the legacy root if an item name is defined in both.
+Project-local agents and skills are read from `.mars-src/` during sync. Repo-root `agents/` and `skills/` directories are package contents for downstream consumers, not local `_self` discovery roots.
 
 ### `[dependencies]`
 
@@ -397,4 +397,4 @@ See [local-development.md](../dev/local-development.md) for workflows.
 
 ## Reserved Names
 
-- `_self` is reserved for project-local items: agents and skills discovered from `.mars-src/` (always) and from the legacy repo-root `agents/`/`skills/` directories (only when `[package]` is present). `_self` is the synthetic source name used in the lock file and in `mars list --status` output for these items.
+- `_self` is reserved for project-local items: agents and skills discovered from `.mars-src/`. `_self` is the synthetic source name used in the lock file and in `mars list --status` output for these items.

--- a/docs/dev/local-development.md
+++ b/docs/dev/local-development.md
@@ -166,7 +166,7 @@ name = "my-project-agents"
 version = "0.1.0"
 ```
 
-With `[package]` present, Mars also reads legacy repo-root `agents/` and `skills/` directories in addition to `.mars-src/`. If the same item name exists in both, `.mars-src/` takes precedence (with a warning). See [configuration.md](configuration.md#package-optional) for the full schema.
+Source package contents can live in repo-root `agents/` and `skills/` directories for downstream consumers. For items you want the package project itself to sync as `_self`, put them in `.mars-src/`. See [`mars.toml`](../config/mars-toml.md#package-optional) for the full schema.
 
 ### Validating Before Publishing
 

--- a/docs/internals/lock-file.md
+++ b/docs/internals/lock-file.md
@@ -112,7 +112,7 @@ Checksums use the format `sha256:<hex>`. For agents (single files), this is the 
 
 ## The `_self` Source
 
-Project-local agents and skills — those in `.mars-src/` or, for source packages with `[package]`, in the legacy repo-root `agents/`/`skills/` directories — appear in the lock under `source = "_self"`. `_self` is the reserved synthetic source name for all items provided by the current project. The `_self` dependency entry uses `path = "."` to indicate the local project.
+Project-local agents and skills in `.mars-src/` appear in the lock under `source = "_self"`. `_self` is the reserved synthetic source name for all items provided by the current project. The `_self` dependency entry uses `path = "."` to indicate the local project.
 
 `[package]` is not required for `_self` items to appear in the lock — any project with content in `.mars-src/` will have them after sync.
 

--- a/docs/internals/sync-pipeline.md
+++ b/docs/internals/sync-pipeline.md
@@ -152,8 +152,7 @@ With `--force`, the baseline for "local changed" shifts to `source_checksum`, so
 
 Also injects project-local items under the `_self` source name (`_self` is the reserved local-project source identifier):
 - Items from `.mars-src/` are always discovered, regardless of whether `[package]` is present.
-- Items from the legacy repo-root `agents/`/`skills/` directories are discovered only when `[package]` is in `mars.toml`.
-- If the same item name exists in both `.mars-src/` and the repo root, `.mars-src/` wins (with a `duplicate-local-definition` warning).
+- Repo-root `agents/`/`skills/` directories are not local discovery roots; published source packages still expose those directories when consumed as dependencies.
 
 ### 5. Apply Plan (`apply_plan`)
 
@@ -233,9 +232,8 @@ Project-local agents and skills are discovered, hashed, and installed into the m
 | Source | When included |
 |---|---|
 | `.mars-src/agents/` and `.mars-src/skills/` | Always |
-| Repo-root `agents/` and `skills/` (legacy) | Only when `[package]` is present in `mars.toml` |
 
-`.mars-src/` is the preferred location. The repo-root directories are a legacy path retained for source packages that published content there before `.mars-src/` existed. If the same item name appears in both, `.mars-src/` wins.
+`.mars-src/` is the only project-local source root. Repo-root `agents/` and `skills/` directories remain valid package contents when the project is consumed as a dependency, but `mars sync` no longer scans them as local `_self` items in that same project.
 
 All `_self` items follow the same behavior:
 - Shadow external dependency items if names collide (with a warning)

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -98,15 +98,6 @@ pub fn compile(
     // Per-agent overlays merged from mars.toml + mars.local.toml (loaded.effective is
     // EffectiveConfig, which does not carry the overlay map).
     let agent_overlays = crate::config::merged_agent_overlays(&loaded.config.agents, &loaded.local);
-    let native_reconcile_ctx = native_agents::NativeAgentReconcileCtx {
-        policy: agent_surface_policy.clone(),
-        project_root: &ctx.project_root,
-        model_aliases: &model_aliases,
-        outcomes,
-        old_lock,
-        dry_run: request.options.dry_run,
-        selective_harness_scope: None,
-    };
     let ownership_lock;
     let native_ownership_lock = if request.options.dry_run {
         old_lock
@@ -117,6 +108,15 @@ pub fn compile(
             &synced.target_outcomes,
         );
         &ownership_lock
+    };
+    let native_reconcile_ctx = native_agents::NativeAgentReconcileCtx {
+        policy: agent_surface_policy.clone(),
+        project_root: &ctx.project_root,
+        model_aliases: &model_aliases,
+        outcomes,
+        old_lock,
+        dry_run: request.options.dry_run,
+        selective_harness_scope: None,
     };
     let native_compile_ctx = if matches!(agent_surface_policy, AgentSurfacePolicy::SuppressAll) {
         None

--- a/src/compiler/native_agents.rs
+++ b/src/compiler/native_agents.rs
@@ -350,10 +350,10 @@ fn remove_native_agent_shapes_for_harness(
 }
 
 /// Compile native harness agents from a pre-scanned canonical store.
-pub(crate) fn compile_native_agents(
+pub(crate) fn compile_native_agents<'a>(
     ctx: &NativeAgentCompileCtx<'_>,
     policy: &AgentSurfacePolicy,
-    mars_agents: &[MarsCanonicalAgent],
+    mars_agents: impl IntoIterator<Item = &'a MarsCanonicalAgent>,
     diag: &mut DiagnosticCollector,
 ) -> Vec<CompiledNativeOutput> {
     if matches!(policy, AgentSurfacePolicy::SuppressAll) {
@@ -778,7 +778,17 @@ pub(crate) fn run_native_agent_post_sync_lifecycle(
     let removed_native_outputs = reconcile_native_agent_surfaces(reconcile_ctx, &resolved, diag);
     let compiled_native_outputs = match compile_ctx {
         None => Vec::new(),
-        Some(ctx) => compile_native_agents(ctx, policy, &resolved, diag),
+        Some(ctx) => compile_native_agents(
+            ctx,
+            policy,
+            resolved.iter().filter(|agent| {
+                ctx.old_lock.contains_output(
+                    crate::lock::CANONICAL_TARGET_ROOT,
+                    &agent.canonical_dest_path,
+                )
+            }),
+            diag,
+        ),
     };
     (compiled_native_outputs, removed_native_outputs)
 }

--- a/src/local_source.rs
+++ b/src/local_source.rs
@@ -1,10 +1,7 @@
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use crate::diagnostic::DiagnosticCollector;
 use crate::discover::{self, DiscoveredItem};
 use crate::error::MarsError;
-use crate::lock::ItemId;
 
 pub const LOCAL_SOURCE_DIR: &str = ".mars-src";
 
@@ -24,43 +21,19 @@ pub fn preferred_local_source_root(project_root: &Path) -> PathBuf {
     project_root.join(LOCAL_SOURCE_DIR)
 }
 
-pub fn local_discovery_roots(project_root: &Path, include_legacy_root: bool) -> Vec<PathBuf> {
-    let mut roots = vec![preferred_local_source_root(project_root)];
-    if include_legacy_root {
-        roots.push(project_root.to_path_buf());
-    }
-    roots
+pub fn local_discovery_roots(project_root: &Path) -> Vec<PathBuf> {
+    vec![preferred_local_source_root(project_root)]
 }
 
 pub fn discover_local_items(
     project_root: &Path,
-    include_legacy_root: bool,
     source_name: Option<&str>,
-    diag: &mut DiagnosticCollector,
 ) -> Result<Vec<LocalDiscoveredItem>, MarsError> {
-    let mut seen: HashMap<ItemId, PathBuf> = HashMap::new();
     let mut merged = Vec::new();
 
-    for root in local_discovery_roots(project_root, include_legacy_root) {
+    for root in local_discovery_roots(project_root) {
         let discovered = discover::discover_source(&root, source_name)?;
         for item in discovered {
-            let current_path = root.join(&item.source_path);
-            if let Some(existing_path) = seen.get(&item.id) {
-                diag.warn(
-                    "duplicate-local-definition",
-                    format!(
-                        "local {} `{}` is defined in both `{}` and `{}` — using `{}`",
-                        item.id.kind,
-                        item.id.name,
-                        relative_display(project_root, existing_path),
-                        relative_display(project_root, &current_path),
-                        LOCAL_SOURCE_DIR,
-                    ),
-                );
-                continue;
-            }
-
-            seen.insert(item.id.clone(), current_path);
             merged.push(LocalDiscoveredItem {
                 discovered: item,
                 root: root.clone(),
@@ -70,12 +43,6 @@ pub fn discover_local_items(
 
     Ok(merged)
 }
-fn relative_display(project_root: &Path, path: &Path) -> String {
-    path.strip_prefix(project_root)
-        .unwrap_or(path)
-        .display()
-        .to_string()
-}
 
 #[cfg(test)]
 mod tests {
@@ -84,7 +51,7 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
-    fn prefers_mars_src_over_repo_root() {
+    fn discovers_mars_src_not_repo_root() {
         let dir = TempDir::new().unwrap();
         let project_root = dir.path();
 
@@ -104,57 +71,11 @@ mod tests {
         std::fs::create_dir_all(&preferred).unwrap();
         std::fs::write(preferred.join("SKILL.md"), "# Preferred").unwrap();
 
-        let mut diag = DiagnosticCollector::new();
-        let items = discover_local_items(project_root, true, Some("_self"), &mut diag).unwrap();
+        let items = discover_local_items(project_root, Some("_self")).unwrap();
 
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].discovered.id.kind, ItemKind::Skill);
         assert_eq!(items[0].discovered.id.name.as_str(), "planning");
         assert_eq!(items[0].root, preferred_local_source_root(project_root));
-
-        let diagnostics = diag.drain();
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].code, "duplicate-local-definition");
-        assert!(diagnostics[0].message.contains(".mars-src"));
-    }
-
-    #[test]
-    fn includes_repo_root_when_preferred_root_is_empty() {
-        let dir = TempDir::new().unwrap();
-        let project_root = dir.path();
-
-        std::fs::create_dir_all(project_root.join("agents")).unwrap();
-        std::fs::write(project_root.join("agents").join("coder.md"), "# Coder").unwrap();
-
-        let mut diag = DiagnosticCollector::new();
-        let items = discover_local_items(project_root, true, Some("_self"), &mut diag).unwrap();
-
-        assert_eq!(items.len(), 1);
-        assert_eq!(items[0].discovered.id.kind, ItemKind::Agent);
-        assert_eq!(items[0].discovered.id.name.as_str(), "coder");
-        assert_eq!(items[0].root, project_root);
-        assert!(diag.is_empty());
-    }
-
-    #[test]
-    fn skips_legacy_repo_root_without_package_gate() {
-        let dir = TempDir::new().unwrap();
-        let project_root = dir.path();
-
-        std::fs::create_dir_all(project_root.join("skills").join("planning")).unwrap();
-        std::fs::write(
-            project_root
-                .join("skills")
-                .join("planning")
-                .join("SKILL.md"),
-            "# Legacy",
-        )
-        .unwrap();
-
-        let mut diag = DiagnosticCollector::new();
-        let items = discover_local_items(project_root, false, Some("_self"), &mut diag).unwrap();
-
-        assert!(items.is_empty());
-        assert!(diag.is_empty());
     }
 }

--- a/src/lock/mod.rs
+++ b/src/lock/mod.rs
@@ -734,8 +734,13 @@ pub fn build(
                     .expect("validated above: installed_checksum exists for write actions");
 
                 let key = item_key(&outcome.item_id);
+                let old_item = old_lock.items.get(&key).or_else(|| {
+                    old_lock_index
+                        .item_for_output(CANONICAL_TARGET_ROOT, &outcome.dest_path)
+                        .map(|(_, old_item, _)| old_item)
+                });
                 let outputs = outputs_with_carried_non_canonical(
-                    old_lock.items.get(&key),
+                    old_item,
                     OutputRecord {
                         target_root: CANONICAL_TARGET_ROOT.to_string(),
                         dest_path,
@@ -945,17 +950,28 @@ pub fn apply_apply_outcomes_to_lock(
                 };
 
                 let key = item_key(&outcome.item_id);
-                let mut outputs = vec![OutputRecord {
-                    target_root: CANONICAL_TARGET_ROOT.to_string(),
-                    dest_path: outcome.dest_path.clone(),
-                    installed_checksum: installed_checksum.clone(),
-                }];
-                if let Some(old_item) = old_lock.items.get(&key) {
-                    for old_output in &old_item.outputs {
-                        if old_output.target_root != CANONICAL_TARGET_ROOT {
-                            outputs.push(old_output.clone());
-                        }
-                    }
+                let old_entry = old_lock
+                    .items
+                    .get(&key)
+                    .map(|old_item| (key.as_str(), old_item))
+                    .or_else(|| {
+                        old_lock_index
+                            .item_for_output(CANONICAL_TARGET_ROOT, &outcome.dest_path)
+                            .map(|(old_key, old_item, _)| (old_key, old_item))
+                    });
+                let old_key = old_entry.map(|(old_key, _)| old_key.to_string());
+                let outputs = outputs_with_carried_non_canonical(
+                    old_entry.map(|(_, old_item)| old_item),
+                    OutputRecord {
+                        target_root: CANONICAL_TARGET_ROOT.to_string(),
+                        dest_path: outcome.dest_path.clone(),
+                        installed_checksum: installed_checksum.clone(),
+                    },
+                );
+                if let Some(old_key) = old_key
+                    && old_key != key
+                {
+                    lock.items.shift_remove(&old_key);
                 }
                 lock.items.insert(
                     key,
@@ -1876,6 +1892,130 @@ installed_checksum = "sha256:222"
         assert!(!new_lock.items.contains_key("skill/skills/review"));
         assert!(new_lock.contains_output(".mars", "skills/review"));
         assert!(new_lock.contains_output(".codex", "skills/review/SKILL.md"));
+    }
+
+    #[test]
+    fn build_write_fallback_carries_non_canonical_outputs() {
+        let old_lock = LockFile {
+            version: LOCK_VERSION,
+            dependencies: IndexMap::new(),
+            items: IndexMap::from([(
+                "agent/agents/coder.md".to_string(),
+                LockedItemV2 {
+                    source: "base".into(),
+                    kind: ItemKind::Agent,
+                    version: None,
+                    source_checksum: "sha256:old-src".into(),
+                    outputs: vec![
+                        OutputRecord {
+                            target_root: ".mars".to_string(),
+                            dest_path: "agents/coder.md".into(),
+                            installed_checksum: "sha256:old-mars".into(),
+                        },
+                        OutputRecord {
+                            target_root: ".claude".to_string(),
+                            dest_path: "agents/coder.md".into(),
+                            installed_checksum: "sha256:old-claude".into(),
+                        },
+                    ],
+                },
+            )]),
+            config_entries: BTreeMap::new(),
+            dependency_model_aliases: IndexMap::new(),
+        };
+        let graph = ResolvedGraph {
+            nodes: IndexMap::new(),
+            order: Vec::new(),
+            filters: HashMap::new(),
+            version_constraints: std::collections::HashMap::new(),
+        };
+        let applied = ApplyResult {
+            outcomes: vec![ActionOutcome {
+                item_id: ItemId {
+                    kind: ItemKind::Agent,
+                    name: "coder".into(),
+                },
+                action: ActionTaken::Updated,
+                dest_path: "agents/coder.md".into(),
+                source_name: "base".into(),
+                source_checksum: Some("sha256:new-src".into()),
+                installed_checksum: Some("sha256:new-mars".into()),
+            }],
+        };
+
+        let new_lock = build(
+            &graph,
+            &applied,
+            &old_lock,
+            std::collections::BTreeMap::new(),
+        )
+        .unwrap();
+
+        assert!(!new_lock.items.contains_key("agent/agents/coder.md"));
+        assert!(new_lock.contains_output(".mars", "agents/coder.md"));
+        assert!(new_lock.contains_output(".claude", "agents/coder.md"));
+        let item = &new_lock.items["agent/coder"];
+        assert_eq!(item.source_checksum, "sha256:new-src");
+        let claude = item
+            .outputs
+            .iter()
+            .find(|o| o.target_root == ".claude")
+            .unwrap();
+        assert_eq!(claude.installed_checksum, "sha256:old-claude");
+    }
+
+    #[test]
+    fn apply_apply_outcomes_write_fallback_carries_non_canonical_outputs() {
+        let old_lock = LockFile {
+            version: LOCK_VERSION,
+            dependencies: IndexMap::new(),
+            items: IndexMap::from([(
+                "agent/agents/coder.md".to_string(),
+                LockedItemV2 {
+                    source: "base".into(),
+                    kind: ItemKind::Agent,
+                    version: None,
+                    source_checksum: "sha256:old-src".into(),
+                    outputs: vec![
+                        OutputRecord {
+                            target_root: ".mars".to_string(),
+                            dest_path: "agents/coder.md".into(),
+                            installed_checksum: "sha256:old-mars".into(),
+                        },
+                        OutputRecord {
+                            target_root: ".claude".to_string(),
+                            dest_path: "agents/coder.md".into(),
+                            installed_checksum: "sha256:old-claude".into(),
+                        },
+                    ],
+                },
+            )]),
+            config_entries: BTreeMap::new(),
+            dependency_model_aliases: IndexMap::new(),
+        };
+        let mut lock = old_lock.clone();
+
+        apply_apply_outcomes_to_lock(
+            &mut lock,
+            &old_lock,
+            &[ActionOutcome {
+                item_id: ItemId {
+                    kind: ItemKind::Agent,
+                    name: "coder".into(),
+                },
+                action: ActionTaken::Updated,
+                dest_path: "agents/coder.md".into(),
+                source_name: "base".into(),
+                source_checksum: Some("sha256:new-src".into()),
+                installed_checksum: Some("sha256:new-mars".into()),
+            }],
+        );
+
+        assert!(!lock.items.contains_key("agent/agents/coder.md"));
+        assert!(lock.contains_output(".mars", "agents/coder.md"));
+        assert!(lock.contains_output(".claude", "agents/coder.md"));
+        let item = &lock.items["agent/coder"];
+        assert_eq!(item.source_checksum, "sha256:new-src");
     }
 
     #[test]

--- a/src/lock/mod.rs
+++ b/src/lock/mod.rs
@@ -232,6 +232,20 @@ impl<'a> LockIndex<'a> {
         self.locked_item_for(item_key, output_idx)
     }
 
+    fn item_for_output(
+        &self,
+        target_root: &str,
+        dest_path: &DestPath,
+    ) -> Option<(&'a str, &'a LockedItemV2, &'a OutputRecord)> {
+        let (item_key, output_idx) = *self.by_output.get(&(
+            target_root.to_string(),
+            normalize_dest_path(dest_path.as_str()),
+        ))?;
+        let item = self.lock.items.get(item_key)?;
+        let output = item.outputs.get(output_idx)?;
+        Some((item_key, item, output))
+    }
+
     /// Whether any output is recorded for `target_root + dest_path`.
     pub fn contains_output(&self, target_root: &str, dest_path: &DestPath) -> bool {
         self.by_output.contains_key(&(
@@ -630,21 +644,27 @@ pub fn build(
                     } else {
                         // Fall back: search old lock by dest_path (handles v1→v2 migrations
                         // where item_key may not match yet)
-                        if let Some(flat) =
-                            old_lock_index.find_output(CANONICAL_TARGET_ROOT, &outcome.dest_path)
+                        if let Some((_, old_item, old_output)) = old_lock_index
+                            .item_for_output(CANONICAL_TARGET_ROOT, &outcome.dest_path)
                         {
-                            let key =
-                                format!("{}/{}", flat.kind, outcome.dest_path.item_name(flat.kind));
+                            let key = format!(
+                                "{}/{}",
+                                old_item.kind,
+                                outcome.dest_path.item_name(old_item.kind)
+                            );
                             items.entry(key).or_insert_with(|| LockedItemV2 {
-                                source: flat.source,
-                                kind: flat.kind,
-                                version: flat.version,
-                                source_checksum: flat.source_checksum,
-                                outputs: vec![OutputRecord {
-                                    target_root: ".mars".to_string(),
-                                    dest_path: flat.dest_path,
-                                    installed_checksum: flat.installed_checksum,
-                                }],
+                                source: old_item.source.clone(),
+                                kind: old_item.kind,
+                                version: old_item.version.clone(),
+                                source_checksum: old_item.source_checksum.clone(),
+                                outputs: outputs_with_carried_non_canonical(
+                                    Some(old_item),
+                                    OutputRecord {
+                                        target_root: CANONICAL_TARGET_ROOT.to_string(),
+                                        dest_path: old_output.dest_path.clone(),
+                                        installed_checksum: old_output.installed_checksum.clone(),
+                                    },
+                                ),
                             });
                         }
                     }
@@ -656,20 +676,27 @@ pub fn build(
                 let item_key = item_key(&outcome.item_id);
                 if let Some(old_item) = old_lock.items.get(&item_key) {
                     items.insert(item_key, old_item.clone());
-                } else if let Some(flat) =
-                    old_lock_index.find_output(CANONICAL_TARGET_ROOT, &outcome.dest_path)
+                } else if let Some((_, old_item, old_output)) =
+                    old_lock_index.item_for_output(CANONICAL_TARGET_ROOT, &outcome.dest_path)
                 {
-                    let key = format!("{}/{}", flat.kind, outcome.dest_path.item_name(flat.kind));
+                    let key = format!(
+                        "{}/{}",
+                        old_item.kind,
+                        outcome.dest_path.item_name(old_item.kind)
+                    );
                     items.entry(key).or_insert_with(|| LockedItemV2 {
-                        source: flat.source,
-                        kind: flat.kind,
-                        version: flat.version,
-                        source_checksum: flat.source_checksum,
-                        outputs: vec![OutputRecord {
-                            target_root: ".mars".to_string(),
-                            dest_path: flat.dest_path,
-                            installed_checksum: flat.installed_checksum,
-                        }],
+                        source: old_item.source.clone(),
+                        kind: old_item.kind,
+                        version: old_item.version.clone(),
+                        source_checksum: old_item.source_checksum.clone(),
+                        outputs: outputs_with_carried_non_canonical(
+                            Some(old_item),
+                            OutputRecord {
+                                target_root: CANONICAL_TARGET_ROOT.to_string(),
+                                dest_path: old_output.dest_path.clone(),
+                                installed_checksum: old_output.installed_checksum.clone(),
+                            },
+                        ),
                     });
                 }
             }
@@ -707,6 +734,14 @@ pub fn build(
                     .expect("validated above: installed_checksum exists for write actions");
 
                 let key = item_key(&outcome.item_id);
+                let outputs = outputs_with_carried_non_canonical(
+                    old_lock.items.get(&key),
+                    OutputRecord {
+                        target_root: CANONICAL_TARGET_ROOT.to_string(),
+                        dest_path,
+                        installed_checksum,
+                    },
+                );
                 items.insert(
                     key,
                     LockedItemV2 {
@@ -714,11 +749,7 @@ pub fn build(
                         kind: outcome.item_id.kind,
                         version,
                         source_checksum,
-                        outputs: vec![OutputRecord {
-                            target_root: ".mars".to_string(),
-                            dest_path,
-                            installed_checksum,
-                        }],
+                        outputs,
                     },
                 );
             }
@@ -776,6 +807,21 @@ pub fn build(
         config_entries,
         dependency_model_aliases: IndexMap::new(),
     })
+}
+
+fn outputs_with_carried_non_canonical(
+    old_item: Option<&LockedItemV2>,
+    canonical_output: OutputRecord,
+) -> Vec<OutputRecord> {
+    let mut outputs = vec![canonical_output];
+    if let Some(old_item) = old_item {
+        for old_output in &old_item.outputs {
+            if old_output.target_root != CANONICAL_TARGET_ROOT {
+                outputs.push(old_output.clone());
+            }
+        }
+    }
+    outputs
 }
 
 /// Lock view for native emission immediately after apply + target sync.
@@ -989,63 +1035,6 @@ pub fn apply_compiled_native_outputs(lock: &mut LockFile, records: &[CompiledNat
             &record.dest_path,
             &record.installed_checksum,
         );
-    }
-}
-
-/// Carry forward non-canonical output records (`.claude`, `.cursor`, `.codex`,
-/// etc.) from `old_lock` that were not refreshed by the current compile pass.
-///
-/// When native agent compilation fails (I/O error, permission failure, schema
-/// error), `apply_compiled_native_outputs` has no `CompiledNativeOutput` record
-/// for the affected item. Without this carry-forward the old target output
-/// record is silently dropped, and the next sync treats the still-managed file
-/// as an unmanaged collision.
-///
-/// This function preserves ownership by copying non-canonical records from
-/// `old_lock` for every item that:
-/// - exists in both `old_lock` and `new_lock` (was not removed), and
-/// - has a non-canonical output record in `old_lock`, and
-/// - does NOT already have a record for that `(target_root, dest_path)` in
-///   `new_lock` (compile succeeded → `apply_compiled_native_outputs` already
-///   upserted a fresh record), and
-/// - was not explicitly removed by reconciliation (`removed_native_outputs`).
-pub fn carry_forward_unrefreshed_native_outputs(
-    new_lock: &mut LockFile,
-    old_lock: &LockFile,
-    removed_native_outputs: &[(String, String)],
-) {
-    for (key, old_item) in &old_lock.items {
-        let Some(new_item) = new_lock.items.get_mut(key.as_str()) else {
-            continue;
-        };
-        for old_output in &old_item.outputs {
-            if old_output.target_root == CANONICAL_TARGET_ROOT {
-                continue;
-            }
-            let was_removed = removed_native_outputs.iter().any(|(tr, dp)| {
-                tr == &old_output.target_root
-                    && crate::target::dest_paths_equivalent(dp, old_output.dest_path.as_str())
-            });
-            if was_removed {
-                continue;
-            }
-            let already_present = new_item.outputs.iter().any(|o| {
-                o.target_root == old_output.target_root
-                    && crate::target::dest_paths_equivalent(
-                        o.dest_path.as_str(),
-                        old_output.dest_path.as_str(),
-                    )
-            });
-            if already_present {
-                continue;
-            }
-            new_item.outputs.push(old_output.clone());
-        }
-        new_item.outputs.sort_by(|a, b| {
-            a.target_root
-                .cmp(&b.target_root)
-                .then_with(|| a.dest_path.as_str().cmp(b.dest_path.as_str()))
-        });
     }
 }
 
@@ -1724,10 +1713,7 @@ installed_checksum = "sha256:222"
     }
 
     #[test]
-    fn carry_forward_unrefreshed_native_outputs_preserves_on_compile_failure() {
-        // Simulate: old lock has .claude record, build() creates only .mars,
-        // native compile fails (no CompiledNativeOutput for .claude).
-        // carry_forward should preserve the old .claude record.
+    fn build_updated_carries_non_canonical_outputs() {
         let mut old_lock = sample_lock();
         old_lock
             .items
@@ -1740,30 +1726,33 @@ installed_checksum = "sha256:222"
                 installed_checksum: "sha256:claude-old".into(),
             });
 
-        // Build new lock (only .mars records)
-        let mut new_lock = LockFile {
-            version: LOCK_VERSION,
-            dependencies: old_lock.dependencies.clone(),
-            items: IndexMap::from([(
-                "agent/coder".to_string(),
-                LockedItemV2 {
-                    source: "base".into(),
+        let graph = ResolvedGraph {
+            nodes: IndexMap::new(),
+            order: Vec::new(),
+            filters: HashMap::new(),
+            version_constraints: std::collections::HashMap::new(),
+        };
+        let applied = ApplyResult {
+            outcomes: vec![ActionOutcome {
+                item_id: ItemId {
                     kind: ItemKind::Agent,
-                    version: Some("v1.0.0".into()),
-                    source_checksum: "sha256:new-src".into(),
-                    outputs: vec![OutputRecord {
-                        target_root: ".mars".to_string(),
-                        dest_path: "agents/coder.md".into(),
-                        installed_checksum: "sha256:new-mars".into(),
-                    }],
+                    name: "coder".into(),
                 },
-            )]),
-            config_entries: BTreeMap::new(),
-            dependency_model_aliases: IndexMap::new(),
+                action: ActionTaken::Updated,
+                dest_path: "agents/coder.md".into(),
+                source_name: "base".into(),
+                source_checksum: Some("sha256:new-src".into()),
+                installed_checksum: Some("sha256:new-mars".into()),
+            }],
         };
 
-        // No CompiledNativeOutput — simulating compile failure for .claude.
-        carry_forward_unrefreshed_native_outputs(&mut new_lock, &old_lock, &[]);
+        let new_lock = build(
+            &graph,
+            &applied,
+            &old_lock,
+            std::collections::BTreeMap::new(),
+        )
+        .unwrap();
 
         assert!(new_lock.contains_output(".mars", "agents/coder.md"));
         assert!(
@@ -1772,6 +1761,13 @@ installed_checksum = "sha256:222"
         );
         let item = &new_lock.items["agent/coder"];
         assert_eq!(item.outputs.len(), 2);
+        assert_eq!(item.source_checksum, "sha256:new-src");
+        let mars = item
+            .outputs
+            .iter()
+            .find(|o| o.target_root == ".mars")
+            .unwrap();
+        assert_eq!(mars.installed_checksum, "sha256:new-mars");
         let claude = item
             .outputs
             .iter()
@@ -1781,142 +1777,105 @@ installed_checksum = "sha256:222"
     }
 
     #[test]
-    fn carry_forward_unrefreshed_native_outputs_no_duplicate_when_compile_succeeded() {
-        // When native compile succeeds, apply_compiled_native_outputs already
-        // upserted a fresh .claude record. carry_forward must NOT duplicate it.
-        let mut old_lock = sample_lock();
-        old_lock
-            .items
-            .get_mut("agent/coder")
-            .unwrap()
-            .outputs
-            .push(OutputRecord {
-                target_root: ".claude".to_string(),
-                dest_path: "agents/coder.md".into(),
-                installed_checksum: "sha256:claude-old".into(),
-            });
-
-        // Build new lock (.mars only), then simulate successful compile.
-        let mut new_lock = LockFile {
+    fn build_fallback_carries_non_canonical_outputs_for_skipped_and_kept() {
+        let old_lock = LockFile {
             version: LOCK_VERSION,
-            dependencies: old_lock.dependencies.clone(),
-            items: IndexMap::from([(
-                "agent/coder".to_string(),
-                LockedItemV2 {
-                    source: "base".into(),
-                    kind: ItemKind::Agent,
-                    version: Some("v1.0.0".into()),
-                    source_checksum: "sha256:new-src".into(),
-                    outputs: vec![OutputRecord {
-                        target_root: ".mars".to_string(),
-                        dest_path: "agents/coder.md".into(),
-                        installed_checksum: "sha256:new-mars".into(),
-                    }],
-                },
-            )]),
+            dependencies: IndexMap::new(),
+            items: IndexMap::from([
+                (
+                    "agent/agents/coder.md".to_string(),
+                    LockedItemV2 {
+                        source: "base".into(),
+                        kind: ItemKind::Agent,
+                        version: None,
+                        source_checksum: "sha256:coder-src".into(),
+                        outputs: vec![
+                            OutputRecord {
+                                target_root: ".mars".to_string(),
+                                dest_path: "agents/coder.md".into(),
+                                installed_checksum: "sha256:coder-mars".into(),
+                            },
+                            OutputRecord {
+                                target_root: ".claude".to_string(),
+                                dest_path: "agents/coder.md".into(),
+                                installed_checksum: "sha256:coder-claude".into(),
+                            },
+                        ],
+                    },
+                ),
+                (
+                    "skill/skills/review".to_string(),
+                    LockedItemV2 {
+                        source: "base".into(),
+                        kind: ItemKind::Skill,
+                        version: None,
+                        source_checksum: "sha256:review-src".into(),
+                        outputs: vec![
+                            OutputRecord {
+                                target_root: ".mars".to_string(),
+                                dest_path: "skills/review".into(),
+                                installed_checksum: "sha256:review-mars".into(),
+                            },
+                            OutputRecord {
+                                target_root: ".codex".to_string(),
+                                dest_path: "skills/review/SKILL.md".into(),
+                                installed_checksum: "sha256:review-codex".into(),
+                            },
+                        ],
+                    },
+                ),
+            ]),
             config_entries: BTreeMap::new(),
             dependency_model_aliases: IndexMap::new(),
         };
-        apply_compiled_native_outputs(
-            &mut new_lock,
-            &[CompiledNativeOutput {
-                owner_canonical_dest_path: "agents/coder.md".to_string(),
-                target_root: ".claude".to_string(),
-                dest_path: "agents/coder.md".to_string(),
-                installed_checksum: "sha256:claude-fresh".into(),
-            }],
-        );
-
-        carry_forward_unrefreshed_native_outputs(&mut new_lock, &old_lock, &[]);
-
-        let item = &new_lock.items["agent/coder"];
-        // Should have exactly 2 outputs: .mars + .claude (no duplicate).
-        assert_eq!(item.outputs.len(), 2, "should not duplicate .claude output");
-        let claude = item
-            .outputs
-            .iter()
-            .find(|o| o.target_root == ".claude")
-            .unwrap();
-        // Fresh checksum from compile must win over old stale record.
-        assert_eq!(claude.installed_checksum, "sha256:claude-fresh");
-    }
-
-    #[test]
-    fn carry_forward_unrefreshed_native_outputs_skips_removed_items() {
-        // Item existed in old_lock but was removed (not in new_lock).
-        // carry_forward should not resurrect it.
-        let mut old_lock = sample_lock();
-        old_lock
-            .items
-            .get_mut("agent/coder")
-            .unwrap()
-            .outputs
-            .push(OutputRecord {
-                target_root: ".claude".to_string(),
-                dest_path: "agents/coder.md".into(),
-                installed_checksum: "sha256:claude-old".into(),
-            });
-
-        // New lock does NOT contain agent/coder (item was removed).
-        let mut new_lock = LockFile::empty();
-
-        carry_forward_unrefreshed_native_outputs(&mut new_lock, &old_lock, &[]);
-
-        assert!(
-            new_lock.items.is_empty(),
-            "removed item should not be resurrected"
-        );
-    }
-
-    #[test]
-    fn carry_forward_skips_explicitly_removed_native_outputs() {
-        let mut old_lock = sample_lock();
-        old_lock
-            .items
-            .get_mut("agent/coder")
-            .unwrap()
-            .outputs
-            .push(OutputRecord {
-                target_root: ".claude".to_string(),
-                dest_path: "agents/coder.md".into(),
-                installed_checksum: "sha256:claude-old".into(),
-            });
-
-        let mut new_lock = LockFile {
-            version: LOCK_VERSION,
-            dependencies: old_lock.dependencies.clone(),
-            items: IndexMap::from([(
-                "agent/coder".to_string(),
-                LockedItemV2 {
-                    source: "base".into(),
-                    kind: ItemKind::Agent,
-                    version: Some("v1.0.0".into()),
-                    source_checksum: "sha256:new-src".into(),
-                    outputs: vec![OutputRecord {
-                        target_root: ".mars".to_string(),
-                        dest_path: "agents/coder.md".into(),
-                        installed_checksum: "sha256:new-mars".into(),
-                    }],
+        let graph = ResolvedGraph {
+            nodes: IndexMap::new(),
+            order: Vec::new(),
+            filters: HashMap::new(),
+            version_constraints: std::collections::HashMap::new(),
+        };
+        let applied = ApplyResult {
+            outcomes: vec![
+                ActionOutcome {
+                    item_id: ItemId {
+                        kind: ItemKind::Agent,
+                        name: "coder".into(),
+                    },
+                    action: ActionTaken::Skipped,
+                    dest_path: "agents/coder.md".into(),
+                    source_name: "base".into(),
+                    source_checksum: None,
+                    installed_checksum: None,
                 },
-            )]),
-            config_entries: BTreeMap::new(),
-            dependency_model_aliases: IndexMap::new(),
+                ActionOutcome {
+                    item_id: ItemId {
+                        kind: ItemKind::Skill,
+                        name: "review".into(),
+                    },
+                    action: ActionTaken::Kept,
+                    dest_path: "skills/review".into(),
+                    source_name: "base".into(),
+                    source_checksum: None,
+                    installed_checksum: None,
+                },
+            ],
         };
 
-        let removed = vec![(".claude".to_string(), "agents/coder.md".to_string())];
-        carry_forward_unrefreshed_native_outputs(&mut new_lock, &old_lock, &removed);
+        let new_lock = build(
+            &graph,
+            &applied,
+            &old_lock,
+            std::collections::BTreeMap::new(),
+        )
+        .unwrap();
 
-        let item = &new_lock.items["agent/coder"];
-        assert_eq!(
-            item.outputs.len(),
-            1,
-            "removed .claude record should not be carried forward"
-        );
+        assert!(!new_lock.items.contains_key("agent/agents/coder.md"));
         assert!(new_lock.contains_output(".mars", "agents/coder.md"));
-        assert!(
-            !new_lock.contains_output(".claude", "agents/coder.md"),
-            "explicitly removed native output should not be restored"
-        );
+        assert!(new_lock.contains_output(".claude", "agents/coder.md"));
+
+        assert!(!new_lock.items.contains_key("skill/skills/review"));
+        assert!(new_lock.contains_output(".mars", "skills/review"));
+        assert!(new_lock.contains_output(".codex", "skills/review/SKILL.md"));
     }
 
     #[test]

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -25,14 +25,9 @@ pub fn read(
 
     // Local package discovery — produces source paths only (no DestPath).
     // Dest-path assignment is the compiler's responsibility.
-    let has_package = resolved.loaded.config.package.is_some();
     let local_source_name = crate::types::SourceOrigin::LocalPackage.to_string();
-    let local_items = local_source::discover_local_items(
-        &ctx.project_root,
-        has_package,
-        Some(local_source_name.as_str()),
-        diag,
-    )?;
+    let local_items =
+        local_source::discover_local_items(&ctx.project_root, Some(local_source_name.as_str()))?;
 
     Ok(ReaderIr {
         resolved,

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -622,11 +622,6 @@ pub(crate) fn finalize(
         crate::lock::apply_target_sync_outputs(&mut new_lock, &state.target_outcomes);
         crate::lock::apply_removed_native_outputs(&mut new_lock, &state.removed_native_outputs);
         crate::lock::apply_compiled_native_outputs(&mut new_lock, &state.compiled_native_outputs);
-        crate::lock::carry_forward_unrefreshed_native_outputs(
-            &mut new_lock,
-            old_lock,
-            &state.removed_native_outputs,
-        );
         if let Some(warning) =
             crate::compiler::persist_lock_then_native_agent_manifest(project_root, &new_lock)?
         {

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -270,7 +270,7 @@ pub(crate) fn build_target(
     ctx: &MarsContext,
     resolved: ResolvedState,
     local_items: Vec<crate::local_source::LocalDiscoveredItem>,
-    _request: &SyncRequest,
+    request: &SyncRequest,
     diag: &mut DiagnosticCollector,
 ) -> Result<TargetedState, MarsError> {
     // Use .mars/ as the canonical content root for diff/collision checks.
@@ -379,8 +379,12 @@ pub(crate) fn build_target(
     let warnings = validate_skill_refs(&target_state);
 
     // Prevent managed installs from overwriting unmanaged files.
-    let unmanaged_collisions =
-        target::check_unmanaged_collisions(managed_root, &resolved.loaded.old_lock, &target_state);
+    let unmanaged_collisions = target::check_unmanaged_collisions(
+        managed_root,
+        &resolved.loaded.old_lock,
+        &target_state,
+        request.options.force,
+    );
     for collision in &unmanaged_collisions {
         diag.warn(
             "unmanaged-collision",

--- a/src/sync/target.rs
+++ b/src/sync/target.rs
@@ -213,6 +213,7 @@ pub fn check_unmanaged_collisions(
     install_target: &Path,
     lock: &LockFile,
     target: &TargetState,
+    force: bool,
 ) -> Vec<UnmanagedCollision> {
     let mut collisions = Vec::new();
     let lock_index = LockIndex::new(lock);
@@ -224,6 +225,9 @@ pub fn check_unmanaged_collisions(
 
         let disk_path = target_item.dest_path.resolve(install_target);
         if disk_path.exists() {
+            if force {
+                continue;
+            }
             // Check if disk content matches what we'd install — if so,
             // this is a partial prior install (crash recovery), not an
             // unmanaged user file. Safe to overwrite.
@@ -757,7 +761,7 @@ mod tests {
         fs::write(&existing, "# user-authored").unwrap();
 
         let collisions =
-            check_unmanaged_collisions(install_root.path(), &LockFile::empty(), &target);
+            check_unmanaged_collisions(install_root.path(), &LockFile::empty(), &target, false);
         assert_eq!(collisions.len(), 1);
         assert_eq!(collisions[0].source_name.as_ref(), "base");
         assert_eq!(collisions[0].path.as_str(), "agents/coder.md");
@@ -785,7 +789,7 @@ mod tests {
 
         // Should skip collision — disk content matches planned install (crash recovery)
         let collisions =
-            check_unmanaged_collisions(install_root.path(), &LockFile::empty(), &target);
+            check_unmanaged_collisions(install_root.path(), &LockFile::empty(), &target, false);
         assert!(collisions.is_empty());
     }
 
@@ -809,9 +813,32 @@ mod tests {
         fs::write(&existing, "# different user content").unwrap();
 
         let collisions =
-            check_unmanaged_collisions(install_root.path(), &LockFile::empty(), &target);
+            check_unmanaged_collisions(install_root.path(), &LockFile::empty(), &target, false);
         assert_eq!(collisions.len(), 1);
         assert_eq!(collisions[0].source_name.as_ref(), "base");
         assert_eq!(collisions[0].path.as_str(), "agents/coder.md");
+    }
+
+    #[test]
+    fn unmanaged_collision_skipped_under_force() {
+        let tree = make_source_tree(&[("coder.md", "# managed")], &[]);
+        let (graph, config) = make_graph_and_config(vec![(
+            "base",
+            &tree,
+            Some("https://github.com/org/base"),
+            FilterMode::All,
+        )]);
+
+        let (target, renames) = build_with_collisions(&graph, &config).unwrap();
+        assert!(renames.is_empty());
+        let install_root = TempDir::new().unwrap();
+
+        let existing = install_root.path().join("agents").join("coder.md");
+        fs::create_dir_all(existing.parent().unwrap()).unwrap();
+        fs::write(&existing, "# stale cache content").unwrap();
+
+        let collisions =
+            check_unmanaged_collisions(install_root.path(), &LockFile::empty(), &target, true);
+        assert!(collisions.is_empty());
     }
 }

--- a/tests/local_package.rs
+++ b/tests/local_package.rs
@@ -56,8 +56,8 @@ fn full_pipeline_with_local_package_and_custom_target() {
     config_str.push_str("\n[package]\nname = \"test-project\"\nversion = \"1.0.0\"\n");
     fs::write(project.child("mars.toml").path(), &config_str).unwrap();
 
-    // Create local agent and skill
-    let local_agents = project.child("agents");
+    // Create local agent and skill under the local package source root.
+    let local_agents = project.child(".mars-src").child("agents");
     local_agents.create_dir_all().unwrap();
     fs::write(
         local_agents.child("local-agent.md").path(),
@@ -65,7 +65,10 @@ fn full_pipeline_with_local_package_and_custom_target() {
     )
     .unwrap();
 
-    let local_skill = project.child("skills").child("local-skill");
+    let local_skill = project
+        .child(".mars-src")
+        .child("skills")
+        .child("local-skill");
     fs::create_dir_all(local_skill.path()).unwrap();
     fs::write(
         local_skill.child("SKILL.md").path(),
@@ -234,8 +237,7 @@ fn sync_prefers_mars_src_local_items_over_repo_root() {
         .args(["sync", "--root", project.path().to_str().unwrap()])
         .assert()
         .success()
-        .stderr(predicate::str::contains("defined in both"))
-        .stderr(predicate::str::contains(".mars-src"));
+        .stderr(predicate::str::is_empty());
 
     assert_eq!(
         fs::read_to_string(
@@ -386,7 +388,7 @@ fn sync_reads_mars_src_local_items_without_package_section() {
 }
 
 #[test]
-fn sync_ignores_repo_root_local_items_without_package_section() {
+fn sync_ignores_repo_root_local_items_with_package_section() {
     let dir = TempDir::new().unwrap();
     let project = dir.child("project");
     project.create_dir_all().unwrap();
@@ -395,6 +397,11 @@ fn sync_ignores_repo_root_local_items_without_package_section() {
         .args(["init", "--root", project.path().to_str().unwrap()])
         .assert()
         .success();
+    fs::write(
+        project.child("mars.toml").path(),
+        "[dependencies]\n\n[package]\nname = \"pkg\"\nversion = \"1.0.0\"\n",
+    )
+    .unwrap();
 
     let legacy_skill = project.child("skills").child("legacy-only");
     legacy_skill.create_dir_all().unwrap();


### PR DESCRIPTION
## Why

Two `mars sync` paths were losing ownership state:

- Lock rebuild refreshed canonical `.mars` records for updated/installed items but discarded existing native target records (`.claude`, `.cursor`, `.codex`, etc.), forcing later fixups to reconstruct ownership.
- Local package discovery still scanned repo-root `agents/` / `skills/` when `[package]` existed, so package source files could be misread as local `_self` items and collide with `.mars/` cache contents.

## Goal

Make lock rebuild preserve known target ownership at the source of truth, and make local package discovery scan only `.mars-src/`.

## Summary

- Carry non-canonical output records forward during `lock::build()` and the native ownership view used before target/native emission.
- Remove the post-build `carry_forward_unrefreshed_native_outputs` safety-net pass.
- Stop scanning repo-root `agents/` / `skills/` as local package discovery roots; `_self` items now come only from `.mars-src/`.
- Let `mars sync --force` reclaim stale unmanaged canonical `.mars` cache files left by the legacy discovery behavior.
- Filter native agent compilation to canonical agents that the ownership lock actually owns, so stale unowned `.mars/agents/*` files do not emit native artifacts.
- Update docs and changelog for the new discovery and ownership behavior.

## Resulting Behavior

- Rebuilding `mars.lock` for updated or installed items keeps existing native target ownership records instead of dropping them.
- Package repos can keep published source files under repo-root `agents/` / `skills/` without `mars sync` treating them as local `_self` inputs.
- Running `mars sync --force` in affected package repos repairs stale canonical cache artifacts instead of repeatedly warning about unmanaged collisions.
- Repeated syncs no longer warn about previously managed native outputs as unmanaged files after lock rebuild.

## Changes

- `src/lock/mod.rs`
  - Added carry-forward of non-canonical outputs while refreshing canonical records.
  - Covered legacy key fallback paths where the old lock item key differs from the current item id.
  - Removed `carry_forward_unrefreshed_native_outputs` and its finalize call.
- `src/local_source.rs` / `src/reader/mod.rs`
  - Removed the legacy-root flag and duplicate-root handling.
  - Local discovery roots now resolve to `.mars-src/` only.
- `src/sync/target.rs`
  - `--force` skips unmanaged canonical cache collisions so stale `.mars/` files can be overwritten.
- `src/compiler/native_agents.rs`
  - Native compile only sees canonical agents present in the current ownership lock.
- Tests and docs updated for the new behavior.

Risk: `--force` now adopts unmanaged canonical `.mars` cache collisions. That is scoped to the canonical store, not user target surfaces, and matches the intended repair behavior for stale cache files.

## Work Item

mars-lock-build-and-discovery-fix

## Verification

Automated:

- `cargo test build_write_fallback_carries_non_canonical_outputs`
- `cargo test apply_apply_outcomes_write_fallback_carries_non_canonical_outputs`
- `cargo test local_source::tests`
- `cargo test --test local_package`
- `cargo test unmanaged_collision_skipped_under_force`
- `cargo test --test agent_emission`
- `cargo test fs::tests::file_lock_released_on_drop`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- Pre-push hook: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test -- --skip cli::version::tests::run`, `cargo build --release`

Manual/live:

- Ran branch binary in `/home/jimyao/gitrepos/prompts/creative-writing-skills`:
  - `/home/jimyao/gitrepos/mars-agents/target/debug/mars sync --force --root /home/jimyao/gitrepos/prompts/creative-writing-skills`
  - Follow-up run reported `already up to date`.
  - Grep found zero target warning matches for unmanaged collisions / untracked Mars files / force adoption warnings.
- Ran branch binary dry-run against `/home/jimyao/gitrepos/voluma`; no “exists locally but is not tracked by Mars” warnings were observed.

Note: one earlier full `cargo test` hit `fs::tests::file_lock_released_on_drop` once; rerunning that exact test and the full suite passed.

## Knowledge Updates

- `CHANGELOG.md` updated under `[Unreleased]`.
- Docs updated:
  - `docs/config/mars-toml.md`
  - `docs/dev/local-development.md`
  - `docs/internals/lock-file.md`
  - `docs/internals/sync-pipeline.md`

No KB entry added; behavior is covered by repo docs and changelog.

## Spawn Trace

- p21 prober — runtime verification for `.mars-src` discovery and lock carry-forward fixtures.
- p3739 reviewer — correctness/regression review; findings fixed.
- p20 reviewer — discarded because it received polluted/wrong-repo context.

## Release Label Guide

Set one `release:*` label on this PR:

- `release:patch` / `release:stable` — next stable **patch** release after merge
- `release:minor` — next stable **minor** release after merge
- `release:major` — next stable **major** release after merge
- `release:rc` — next **prerelease (RC)** after merge
- `release:skip` — no release for this merge

No `release:*` label defaults to a prerelease (RC). Unknown `release:*` labels also default to RC.

## Post-Merge Automation

After merge to `main`, CI (`.github/workflows/release-on-main.yml`) will:

1. Read the PR release label
2. Skip only when `release:skip` is present (no label defaults to RC)
3. Compute the next stable or RC version from existing `v*` tags
4. Update Cargo/PyPI/npm package versions + promote `CHANGELOG.md` `[Unreleased]`
5. Commit `release: vX.Y.Z` (or `release: vX.Y.Z-rc.N`), create/push the matching tag
6. Run `.github/workflows/release.yml` from the tag

## Cleanup

After merge, clean merged worktrees with:

```bash
scripts/prune-worktrees.sh
```
