### PR TITLE
feat(agent-copy): add fanout_agents selective filter

### DIFF
--- a/src/compiler/agent_copy.rs
+++ b/src/compiler/agent_copy.rs
@@ -13,6 +13,7 @@ use crate::models::{ModelAlias, ModelSpec};
 pub struct AgentCopySpec {
     pub harnesses: Vec<HarnessKind>,
     pub include_fanout: bool,
+    pub fanout_agents: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -73,6 +74,7 @@ pub fn build_agent_copy_spec(
     Some(AgentCopySpec {
         harnesses,
         include_fanout: config.include_fanout,
+        fanout_agents: config.fanout_agents.clone(),
     })
 }
 
@@ -446,6 +448,7 @@ mod tests {
         let config = AgentCopyConfig {
             harnesses: vec!["gemini".to_string(), "claude".to_string()],
             include_fanout: false,
+            fanout_agents: Vec::new(),
         };
         let mut diag = DiagnosticCollector::new();
         let spec = build_agent_copy_spec(Some(&config), &[".agents".to_string()], &mut diag);
@@ -491,6 +494,68 @@ mod tests {
         aliases.insert("opus".to_string(), anthropic_alias());
         assert!(
             agent_qualifies_for_harness(&profile, &HarnessKind::Claude, &aliases, false).is_some()
+        );
+    }
+
+    #[test]
+    fn fanout_agent_effective_true_qualifies() {
+        let mut profile = empty_profile();
+        profile.model_policies.push(ModelPolicyRule {
+            match_type: ModelPolicyMatchType::Alias,
+            match_value: "sonnet".to_string(),
+            no_fallback: false,
+            overrides: serde_yaml::Mapping::new(),
+        });
+        let mut aliases = IndexMap::new();
+        aliases.insert(
+            "sonnet".to_string(),
+            ModelAlias {
+                harness: None,
+                description: None,
+                default_effort: None,
+                autocompact: None,
+                autocompact_pct: None,
+                spec: ModelSpec::Pinned {
+                    model: "claude-sonnet-4-6".to_string(),
+                    provider: Some("anthropic".to_string()),
+                },
+            },
+        );
+        let emission = agent_qualifies_for_harness(&profile, &HarnessKind::Claude, &aliases, true)
+            .expect("effective fanout should qualify via model policy");
+        assert!(matches!(
+            emission,
+            QualifiedEmission::PolicyModel(ref m) if m == "sonnet"
+        ));
+    }
+
+    #[test]
+    fn fanout_agent_effective_false_does_not_qualify() {
+        let mut profile = empty_profile();
+        profile.model_policies.push(ModelPolicyRule {
+            match_type: ModelPolicyMatchType::Alias,
+            match_value: "sonnet".to_string(),
+            no_fallback: false,
+            overrides: serde_yaml::Mapping::new(),
+        });
+        let mut aliases = IndexMap::new();
+        aliases.insert(
+            "sonnet".to_string(),
+            ModelAlias {
+                harness: None,
+                description: None,
+                default_effort: None,
+                autocompact: None,
+                autocompact_pct: None,
+                spec: ModelSpec::Pinned {
+                    model: "claude-sonnet-4-6".to_string(),
+                    provider: Some("anthropic".to_string()),
+                },
+            },
+        );
+        assert!(
+            agent_qualifies_for_harness(&profile, &HarnessKind::Claude, &aliases, false).is_none(),
+            "without effective fanout, model policies should not qualify"
         );
     }
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -284,6 +284,7 @@ mod skill_surface_tests {
         let spec = agent_copy::AgentCopySpec {
             harnesses: vec![HarnessKind::Claude],
             include_fanout: false,
+            fanout_agents: Vec::new(),
         };
         assert!(matches!(
             agent_surface_policy(Some(&AgentEmission::Auto), Some(&spec), true),
@@ -296,6 +297,7 @@ mod skill_surface_tests {
         let spec = agent_copy::AgentCopySpec {
             harnesses: vec![HarnessKind::Claude],
             include_fanout: false,
+            fanout_agents: Vec::new(),
         };
         assert!(matches!(
             agent_surface_policy(Some(&AgentEmission::Never), Some(&spec), false),
@@ -308,6 +310,7 @@ mod skill_surface_tests {
         let spec = agent_copy::AgentCopySpec {
             harnesses: vec![HarnessKind::Claude],
             include_fanout: false,
+            fanout_agents: Vec::new(),
         };
         assert_eq!(
             agent_surface_policy(Some(&AgentEmission::Always), Some(&spec), true),

--- a/src/compiler/native_agents.rs
+++ b/src/compiler/native_agents.rs
@@ -755,9 +755,13 @@ pub(crate) fn compile_native_agents<'a>(
     // run_native_agent_post_sync_lifecycle for both reconcile and compile).
     for agent in mars_agents {
         let effective_profile = &agent.profile;
-        for (harness, model) in
-            qualifying_emissions(effective_profile, &agent.agent_name, policy, ctx, model_router)
-        {
+        for (harness, model) in qualifying_emissions(
+            effective_profile,
+            &agent.agent_name,
+            policy,
+            ctx,
+            model_router,
+        ) {
             emit_lowered_native_agent(
                 &NativeAgentEmit {
                     harness: &harness,

--- a/src/compiler/native_agents.rs
+++ b/src/compiler/native_agents.rs
@@ -287,12 +287,14 @@ fn reconcile_selective_native_agent_surfaces(
         // `agent.profile` is already overlay-resolved (see the lifecycle), so reconcile
         // and emission qualify against identical effective profiles.
         for harness in harnesses {
+            let effective_fanout =
+                spec.include_fanout || spec.fanout_agents.iter().any(|n| n == &agent.agent_name);
             let qualifies = spec.harnesses.contains(harness)
                 && agent_copy::agent_qualifies_for_harness(
                     &agent.profile,
                     harness,
                     ctx.model_aliases,
-                    spec.include_fanout,
+                    effective_fanout,
                 )
                 .is_some();
             if qualifies {
@@ -371,7 +373,9 @@ pub(crate) fn compile_native_agents(
     // run_native_agent_post_sync_lifecycle for both reconcile and compile).
     for agent in mars_agents {
         let effective_profile = &agent.profile;
-        for (harness, model) in qualifying_emissions(effective_profile, policy, ctx, diag) {
+        for (harness, model) in
+            qualifying_emissions(effective_profile, &agent.agent_name, policy, ctx, diag)
+        {
             emit_lowered_native_agent(
                 &NativeAgentEmit {
                     harness: &harness,
@@ -429,6 +433,7 @@ fn native_model_from_override(
 
 fn qualifying_emissions(
     profile: &crate::compiler::agents::AgentProfile,
+    agent_name: &str,
     policy: &AgentSurfacePolicy,
     ctx: &NativeAgentCompileCtx<'_>,
     diag: &mut DiagnosticCollector,
@@ -472,6 +477,8 @@ fn qualifying_emissions(
             emissions
         }
         AgentSurfacePolicy::EmitSelective(spec) => {
+            let effective_fanout =
+                spec.include_fanout || spec.fanout_agents.iter().any(|n| n == agent_name);
             let mut emissions = Vec::new();
             for harness in &spec.harnesses {
                 if !in_scope(harness) {
@@ -481,7 +488,7 @@ fn qualifying_emissions(
                     profile,
                     harness,
                     ctx.model_aliases,
-                    spec.include_fanout,
+                    effective_fanout,
                 ) else {
                     continue;
                 };

--- a/src/compiler/native_agents/tests.rs
+++ b/src/compiler/native_agents/tests.rs
@@ -213,6 +213,7 @@ fn reconcile_selective_removes_native_when_agent_stops_qualifying() {
     let spec = agent_copy::AgentCopySpec {
         harnesses: vec![HarnessKind::Claude],
         include_fanout: false,
+        fanout_agents: Vec::new(),
     };
     let mut aliases = IndexMap::new();
     aliases.insert(
@@ -293,6 +294,7 @@ fn reconcile_selective_keeps_lock_when_native_remove_fails() {
     let spec = agent_copy::AgentCopySpec {
         harnesses: vec![HarnessKind::Claude],
         include_fanout: false,
+        fanout_agents: Vec::new(),
     };
     let mut aliases = IndexMap::new();
     aliases.insert(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -542,6 +542,8 @@ pub struct AgentCopyConfig {
     pub harnesses: Vec<String>,
     #[serde(default)]
     pub include_fanout: bool,
+    #[serde(default)]
+    pub fanout_agents: Vec<String>,
 }
 
 /// Meridian-managed settings nested under `[settings.meridian]`.


### PR DESCRIPTION
## Why

With `include_fanout = false`, agents whose primary model doesn't map to a configured harness (e.g. `reviewer` with `Model: gpt-5.4` when `harnesses = ["claude"]`) are completely excluded from native agent emission — even though they have model-policies that *would* qualify them if fanout was enabled. `include_fanout = true` is too broad: it enables fanout for all agents.

## Goal

Users can selectively enable fanout qualification for specific agents without turning it on globally.

## Summary

Added a `fanout_agents: Vec<String>` field to `AgentCopyConfig` and `AgentCopySpec`. At each call site where `spec.include_fanout` is passed to `agent_qualifies_for_harness()`, the code now computes `effective_fanout = spec.include_fanout || spec.fanout_agents.contains(agent_name)` and passes that instead.

## Resulting Behavior

```toml
[settings.meridian.agent_copy]
harnesses = ["claude"]
include_fanout = false
fanout_agents = ["reviewer", "investigator"]
```

After `mars sync`, `reviewer` and `investigator` get `.claude/agents/` files emitted (via their model-policy fanout qualification), while all other agents remain excluded from fanout. The listed agents still must actually qualify via model-policies — this is a scope filter, not force-emit.

## Changes

- `src/config/mod.rs` — `fanout_agents: Vec<String>` with `#[serde(default)]` on `AgentCopyConfig`
- `src/compiler/agent_copy.rs` — propagated through `AgentCopySpec` and `build_agent_copy_spec()`; `agent_qualifies_for_harness()` signature unchanged (callers compute effective fanout)
- `src/compiler/native_agents.rs` — `qualifying_emissions()` gained `agent_name: &str` param; both `EmitSelective` call sites compute effective fanout. `EmitAll` still passes `true` (unchanged).
- Updated all 5 existing `AgentCopySpec` test literals in `mod.rs` and `native_agents/tests.rs`
- Added 2 new unit tests proving the effective-fanout pattern

## Work Item

N/A — user request during session.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean  
- `cargo test` — 1327 passed (1315 lib + 12 integration), 0 failed

## Knowledge Updates

N/A — config field is self-documenting via existing patterns.

## Spawn Trace

- p4229 coder — implemented the feature
- p4228 product-lead — orchestrated exploration and planning

## Release Label Guide

`release:patch` — additive config field, no breaking changes.