### PR TITLE
feat: separate fanout config from agent_copy + dual inventory routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - Moved fanout agent list from `[settings.meridian.agent_copy].fanout_agents` to `[settings.meridian.fanout].agents`. Old key parses with a migration warning and is ignored.
 - Fanout agents that are native-for-harness now appear in both the Meridian spawn inventory and the native harness agents section.
+- Fanout agent list matching is case-insensitive for native emission, consistent with inventory dual-listing.
 
 ## [0.8.4] - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fanout agents that are native-for-harness now appear in both the Meridian spawn inventory and the native harness agents section.
 - Fanout agent list matching is case-insensitive for native emission, consistent with inventory dual-listing.
 
+### Fixed
+- `mars build launch-bundle` now surfaces the deprecated `agent_copy.fanout_agents` migration warning in bundle `warnings`.
+
 ## [0.8.4] - 2026-06-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Moved fanout agent list from `[settings.meridian.agent_copy].fanout_agents` to `[settings.meridian.fanout].agents`. Old key parses with a migration warning and is ignored.
+- Fanout agents that are native-for-harness now appear in both the Meridian spawn inventory and the native harness agents section.
+
 ## [0.8.4] - 2026-06-11
 
 ### Added

--- a/src/build/inventory.rs
+++ b/src/build/inventory.rs
@@ -7,7 +7,7 @@ use crate::compiler::native_agent_manifest::{
 };
 use crate::error::{ConfigError, MarsError};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct ParsedAgentInventory {
     name: String,
     description: String,
@@ -20,6 +20,7 @@ pub fn build_inventory_prompt(
     mars_dir: &Path,
     subagents_filter: &[String],
     harness: &str,
+    fanout_agents: &[String],
     warnings: &mut Vec<String>,
 ) -> Result<String, MarsError> {
     let agents_dir = mars_dir.join("agents");
@@ -94,16 +95,28 @@ pub fn build_inventory_prompt(
     let mut meridian_subagent = Vec::new();
     let mut native_agents = Vec::new();
 
+    let is_fanout_agent = |agent: &ParsedAgentInventory| -> bool {
+        fanout_agents
+            .iter()
+            .any(|name| name.eq_ignore_ascii_case(&agent.name))
+    };
+
     for agent in primary_agents {
         if is_native_for_harness(&agent) {
-            native_agents.push(agent);
+            native_agents.push(agent.clone());
+            if is_fanout_agent(&agent) {
+                meridian_primary.push(agent);
+            }
         } else {
             meridian_primary.push(agent);
         }
     }
     for agent in subagent_agents {
         if is_native_for_harness(&agent) {
-            native_agents.push(agent);
+            native_agents.push(agent.clone());
+            if is_fanout_agent(&agent) {
+                meridian_subagent.push(agent);
+            }
         } else {
             meridian_subagent.push(agent);
         }
@@ -361,7 +374,8 @@ mod tests {
         );
 
         let mut warnings = Vec::new();
-        let inventory = build_inventory_prompt(&mars_dir, &[], "claude", &mut warnings).unwrap();
+        let inventory =
+            build_inventory_prompt(&mars_dir, &[], "claude", &[], &mut warnings).unwrap();
 
         assert!(inventory.contains("Write prompts to `/tmp/<name>.md`."));
         assert!(inventory.contains("## Subagent"));
@@ -407,7 +421,8 @@ mod tests {
         .unwrap();
 
         let mut warnings = Vec::new();
-        let inventory = build_inventory_prompt(&mars_dir, &[], "claude", &mut warnings).unwrap();
+        let inventory =
+            build_inventory_prompt(&mars_dir, &[], "claude", &[], &mut warnings).unwrap();
 
         assert!(
             inventory.contains(
@@ -448,7 +463,8 @@ mod tests {
         .unwrap();
 
         let mut warnings = Vec::new();
-        let inventory = build_inventory_prompt(&mars_dir, &[], "claude", &mut warnings).unwrap();
+        let inventory =
+            build_inventory_prompt(&mars_dir, &[], "claude", &[], &mut warnings).unwrap();
 
         assert!(
             inventory.contains("## Claude Agents (use `Agent({subagent_type: \"...\"})` tool)")
@@ -475,12 +491,45 @@ mod tests {
         .unwrap();
 
         let mut warnings = Vec::new();
-        let inventory = build_inventory_prompt(&mars_dir, &[], "codex", &mut warnings).unwrap();
+        let inventory =
+            build_inventory_prompt(&mars_dir, &[], "codex", &[], &mut warnings).unwrap();
 
         assert!(inventory.contains(
             "- `meridian spawn -a frontend-coder`: Frontend implementation | Model: test-model"
         ));
         assert!(!inventory.contains("## Native Agents"));
         assert!(!inventory.contains("## Claude Agents"));
+    }
+
+    #[test]
+    fn inventory_fanout_agent_dual_lists_in_meridian_and_native_sections() {
+        let temp = TempDir::new().unwrap();
+        let project_root = temp.path();
+        let mars_dir = project_root.join(".mars");
+        write_agent(
+            &mars_dir,
+            "reviewer",
+            &sample_agent_content("reviewer", "subagent", "Adversarial review"),
+        );
+
+        write_native_agent_manifest_from_lock(
+            project_root,
+            &lock_with_native_agent("reviewer", HarnessKind::Claude),
+        )
+        .unwrap();
+
+        let fanout = vec!["reviewer".to_string()];
+        let mut warnings = Vec::new();
+        let inventory =
+            build_inventory_prompt(&mars_dir, &[], "claude", &fanout, &mut warnings).unwrap();
+
+        assert!(inventory.contains("## Subagent"));
+        assert!(
+            inventory.contains("- `meridian spawn -a reviewer`: Adversarial review | Model: test-model")
+        );
+        assert!(
+            inventory.contains("## Claude Agents (use `Agent({subagent_type: \"...\"})` tool)")
+        );
+        assert!(inventory.contains("- reviewer: Adversarial review"));
     }
 }

--- a/src/build/inventory.rs
+++ b/src/build/inventory.rs
@@ -525,7 +525,8 @@ mod tests {
 
         assert!(inventory.contains("## Subagent"));
         assert!(
-            inventory.contains("- `meridian spawn -a reviewer`: Adversarial review | Model: test-model")
+            inventory
+                .contains("- `meridian spawn -a reviewer`: Adversarial review | Model: test-model")
         );
         assert!(
             inventory.contains("## Claude Agents (use `Agent({subagent_type: \"...\"})` tool)")

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -81,6 +81,11 @@ pub fn build_launch_bundle(
     }
 
     let effective_project_config = load_effective_project_config_or_default(&ctx.project_root)?;
+    if let Some(message) = crate::compiler::agent_copy::deprecated_fanout_agents_warning(
+        effective_project_config.settings.meridian_agent_copy(),
+    ) {
+        warnings.push(message);
+    }
     let lock = crate::lock::load_for_runtime_aliases(&ctx.project_root)?;
     let runtime_aliases = crate::models::merged_runtime_aliases(
         &lock.dependency_model_aliases,

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -117,6 +117,7 @@ pub fn build_launch_bundle(
         &policy.routing.model_token,
         &policy.routing.model,
         &profile.subagents,
+        effective_project_config.settings.meridian_fanout_agents(),
     )?;
 
     warnings.extend(prompt.warnings);

--- a/src/build/prompt.rs
+++ b/src/build/prompt.rs
@@ -53,6 +53,7 @@ pub fn compile_prompt_surface(
     selected_model_token: &str,
     canonical_model_id: &str,
     subagents_filter: &[String],
+    fanout_agents: &[String],
 ) -> Result<PromptCompilation, MarsError> {
     let _ = (selected_model_token, canonical_model_id);
 
@@ -123,8 +124,13 @@ pub fn compile_prompt_surface(
         }
     }
 
-    let inventory_prompt =
-        build_inventory_prompt(mars_dir, subagents_filter, harness_id, &mut warnings)?;
+    let inventory_prompt = build_inventory_prompt(
+        mars_dir,
+        subagents_filter,
+        harness_id,
+        fanout_agents,
+        &mut warnings,
+    )?;
     let system_instruction = compose_system_instruction(
         agent_body,
         &supplemental_documents,

--- a/src/compiler/agent_copy.rs
+++ b/src/compiler/agent_copy.rs
@@ -125,7 +125,9 @@ mod tests {
         assert!(!spec.include_fanout);
         let messages: Vec<_> = diag.drain().into_iter().map(|d| d.message).collect();
         assert!(
-            messages.iter().any(|m| m.contains("[settings.meridian.fanout].agents")),
+            messages
+                .iter()
+                .any(|m| m.contains("[settings.meridian.fanout].agents")),
             "{messages:?}"
         );
     }

--- a/src/compiler/agent_copy.rs
+++ b/src/compiler/agent_copy.rs
@@ -10,7 +10,6 @@ use crate::harness::registry;
 pub struct AgentCopySpec {
     pub harnesses: Vec<HarnessKind>,
     pub include_fanout: bool,
-    pub fanout_agents: Vec<String>,
 }
 
 /// Validate `agent_copy.harnesses` and build a spec for the compiler.
@@ -20,6 +19,13 @@ pub fn build_agent_copy_spec(
     diag: &mut DiagnosticCollector,
 ) -> Option<AgentCopySpec> {
     let config = config?;
+    if !config.deprecated_fanout_agents.is_empty() {
+        diag.warn(
+            "agent-copy-fanout-moved",
+            "settings.meridian.agent_copy.fanout_agents is deprecated; move agents to \
+             [settings.meridian.fanout].agents (old value ignored)",
+        );
+    }
     if config.harnesses.is_empty() {
         return None;
     }
@@ -65,7 +71,6 @@ pub fn build_agent_copy_spec(
     Some(AgentCopySpec {
         harnesses,
         include_fanout: config.include_fanout,
-        fanout_agents: config.fanout_agents.clone(),
     })
 }
 
@@ -79,7 +84,7 @@ mod tests {
         let config = AgentCopyConfig {
             harnesses: vec!["gemini".to_string(), "claude".to_string()],
             include_fanout: false,
-            fanout_agents: Vec::new(),
+            deprecated_fanout_agents: Vec::new(),
         };
         let mut diag = DiagnosticCollector::new();
         let spec = build_agent_copy_spec(Some(&config), &[".agents".to_string()], &mut diag);
@@ -100,30 +105,20 @@ mod tests {
     }
 
     #[test]
-    fn fanout_agents_propagated_to_spec() {
+    fn deprecated_fanout_agents_emits_migration_warning() {
         let config = AgentCopyConfig {
             harnesses: vec!["claude".to_string()],
             include_fanout: false,
-            fanout_agents: vec!["reviewer".to_string(), "investigator".to_string()],
+            deprecated_fanout_agents: vec!["reviewer".to_string(), "investigator".to_string()],
         };
         let mut diag = DiagnosticCollector::new();
         let spec =
             build_agent_copy_spec(Some(&config), &[".claude".to_string()], &mut diag).unwrap();
         assert!(!spec.include_fanout);
-        assert_eq!(spec.fanout_agents, vec!["reviewer", "investigator"]);
-        assert!(diag.drain().is_empty());
-    }
-
-    #[test]
-    fn fanout_agents_defaults_to_empty() {
-        let config = AgentCopyConfig {
-            harnesses: vec!["claude".to_string()],
-            include_fanout: false,
-            fanout_agents: Vec::new(),
-        };
-        let mut diag = DiagnosticCollector::new();
-        let spec =
-            build_agent_copy_spec(Some(&config), &[".claude".to_string()], &mut diag).unwrap();
-        assert!(spec.fanout_agents.is_empty());
+        let messages: Vec<_> = diag.drain().into_iter().map(|d| d.message).collect();
+        assert!(
+            messages.iter().any(|m| m.contains("[settings.meridian.fanout].agents")),
+            "{messages:?}"
+        );
     }
 }

--- a/src/compiler/agent_copy.rs
+++ b/src/compiler/agent_copy.rs
@@ -12,6 +12,18 @@ pub struct AgentCopySpec {
     pub include_fanout: bool,
 }
 
+/// Migration notice when the deprecated `agent_copy.fanout_agents` key is set.
+/// Returns `None` when the key is absent/empty.
+pub fn deprecated_fanout_agents_warning(config: Option<&AgentCopyConfig>) -> Option<String> {
+    config
+        .filter(|c| !c.deprecated_fanout_agents.is_empty())
+        .map(|_| {
+            "settings.meridian.agent_copy.fanout_agents is deprecated; move agents to \
+             [settings.meridian.fanout].agents (old value ignored)"
+                .to_string()
+        })
+}
+
 /// Validate `agent_copy.harnesses` and build a spec for the compiler.
 pub fn build_agent_copy_spec(
     config: Option<&AgentCopyConfig>,
@@ -19,12 +31,8 @@ pub fn build_agent_copy_spec(
     diag: &mut DiagnosticCollector,
 ) -> Option<AgentCopySpec> {
     let config = config?;
-    if !config.deprecated_fanout_agents.is_empty() {
-        diag.warn(
-            "agent-copy-fanout-moved",
-            "settings.meridian.agent_copy.fanout_agents is deprecated; move agents to \
-             [settings.meridian.fanout].agents (old value ignored)",
-        );
+    if let Some(message) = deprecated_fanout_agents_warning(Some(config)) {
+        diag.warn("agent-copy-fanout-moved", message);
     }
     if config.harnesses.is_empty() {
         return None;

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -123,6 +123,7 @@ pub fn compile(
         );
         &ownership_lock
     };
+    let fanout_agents = loaded.effective.settings.meridian_fanout_agents();
     let native_reconcile_ctx = native_agents::NativeAgentReconcileCtx {
         policy: agent_surface_policy.clone(),
         project_root: &ctx.project_root,
@@ -130,6 +131,7 @@ pub fn compile(
         old_lock,
         dry_run: request.options.dry_run,
         selective_harness_scope: None,
+        fanout_agents,
     };
     let native_compile_ctx = if matches!(agent_surface_policy, AgentSurfacePolicy::SuppressAll) {
         None
@@ -144,6 +146,7 @@ pub fn compile(
                 collision_hint: crate::surface_ownership::CollisionAdoptHint::SyncForce,
                 dry_run: request.options.dry_run,
             },
+            fanout_agents,
         })
     };
     (
@@ -296,7 +299,6 @@ mod skill_surface_tests {
         let spec = agent_copy::AgentCopySpec {
             harnesses: vec![HarnessKind::Claude],
             include_fanout: false,
-            fanout_agents: Vec::new(),
         };
         assert!(matches!(
             agent_surface_policy(Some(&AgentEmission::Auto), Some(&spec), true),
@@ -309,7 +311,6 @@ mod skill_surface_tests {
         let spec = agent_copy::AgentCopySpec {
             harnesses: vec![HarnessKind::Claude],
             include_fanout: false,
-            fanout_agents: Vec::new(),
         };
         assert!(matches!(
             agent_surface_policy(Some(&AgentEmission::Never), Some(&spec), false),
@@ -322,7 +323,6 @@ mod skill_surface_tests {
         let spec = agent_copy::AgentCopySpec {
             harnesses: vec![HarnessKind::Claude],
             include_fanout: false,
-            fanout_agents: Vec::new(),
         };
         assert_eq!(
             agent_surface_policy(Some(&AgentEmission::Always), Some(&spec), true),

--- a/src/compiler/native_agents.rs
+++ b/src/compiler/native_agents.rs
@@ -672,10 +672,11 @@ fn reconcile_selective_native_agent_surfaces(
         // `agent.profile` is already overlay-resolved (see the lifecycle), so reconcile
         // and emission qualify against identical effective profiles.
         for harness in harnesses {
+            // Case-insensitive match — consistent with inventory dual-listing (`inventory.rs`).
             let effective_fanout = spec.include_fanout
                 || fanout_agents
                     .iter()
-                    .any(|n| n == &agent.agent_name);
+                    .any(|n| n.eq_ignore_ascii_case(&agent.agent_name));
             let qualifies = spec.harnesses.contains(harness)
                 && matches!(
                     model_router.decision_for_profile(
@@ -853,8 +854,10 @@ fn qualifying_emissions(
             emissions
         }
         AgentSurfacePolicy::EmitSelective(spec) => {
-            let effective_fanout =
-                spec.include_fanout || fanout_agents.iter().any(|n| n == agent_name);
+            let effective_fanout = spec.include_fanout
+                || fanout_agents
+                    .iter()
+                    .any(|n| n.eq_ignore_ascii_case(agent_name));
             let mut emissions = Vec::new();
             for harness in &spec.harnesses {
                 if !in_scope(harness) {

--- a/src/compiler/native_agents.rs
+++ b/src/compiler/native_agents.rs
@@ -28,6 +28,8 @@ pub(crate) struct NativeAgentReconcileCtx<'a> {
     pub dry_run: bool,
     /// When set (e.g. `mars link <target>`), selective reconcile only touches these harnesses.
     pub selective_harness_scope: Option<&'a [crate::compiler::agents::HarnessKind]>,
+    /// Agents from `[settings.meridian.fanout].agents` for per-agent fanout qualification.
+    pub fanout_agents: &'a [String],
 }
 
 pub(crate) struct NativeAgentSurfaceCompileOptions {
@@ -43,6 +45,8 @@ pub(crate) struct NativeAgentCompileCtx<'a> {
     pub harness_scope: Option<&'a [crate::compiler::agents::HarnessKind]>,
     pub configured_emit_harnesses: &'a [crate::compiler::agents::HarnessKind],
     pub options: NativeAgentSurfaceCompileOptions,
+    /// Agents from `[settings.meridian.fanout].agents` for per-agent fanout qualification.
+    pub fanout_agents: &'a [String],
 }
 
 struct NativeAgentEmit<'a> {
@@ -570,6 +574,7 @@ pub(crate) fn reconcile_native_agent_surfaces(
             reconcile_selective_native_agent_surfaces(
                 ctx,
                 spec,
+                ctx.fanout_agents,
                 harnesses,
                 mars_agents,
                 model_router,
@@ -656,6 +661,7 @@ fn remove_native_agent_shapes(
 fn reconcile_selective_native_agent_surfaces(
     ctx: &NativeAgentReconcileCtx<'_>,
     spec: &agent_copy::AgentCopySpec,
+    fanout_agents: &[String],
     harnesses: &[crate::compiler::agents::HarnessKind],
     mars_agents: &[MarsCanonicalAgent],
     model_router: &mut NativeModelRoutingRuntime<'_>,
@@ -666,8 +672,10 @@ fn reconcile_selective_native_agent_surfaces(
         // `agent.profile` is already overlay-resolved (see the lifecycle), so reconcile
         // and emission qualify against identical effective profiles.
         for harness in harnesses {
-            let effective_fanout =
-                spec.include_fanout || spec.fanout_agents.iter().any(|n| n == &agent.agent_name);
+            let effective_fanout = spec.include_fanout
+                || fanout_agents
+                    .iter()
+                    .any(|n| n == &agent.agent_name);
             let qualifies = spec.harnesses.contains(harness)
                 && matches!(
                     model_router.decision_for_profile(
@@ -759,6 +767,7 @@ pub(crate) fn compile_native_agents<'a>(
             effective_profile,
             &agent.agent_name,
             policy,
+            ctx.fanout_agents,
             ctx,
             model_router,
         ) {
@@ -809,6 +818,7 @@ fn qualifying_emissions(
     profile: &crate::compiler::agents::AgentProfile,
     agent_name: &str,
     policy: &AgentSurfacePolicy,
+    fanout_agents: &[String],
     ctx: &NativeAgentCompileCtx<'_>,
     model_router: &mut NativeModelRoutingRuntime<'_>,
 ) -> Vec<(
@@ -844,7 +854,7 @@ fn qualifying_emissions(
         }
         AgentSurfacePolicy::EmitSelective(spec) => {
             let effective_fanout =
-                spec.include_fanout || spec.fanout_agents.iter().any(|n| n == agent_name);
+                spec.include_fanout || fanout_agents.iter().any(|n| n == agent_name);
             let mut emissions = Vec::new();
             for harness in &spec.harnesses {
                 if !in_scope(harness) {
@@ -1189,6 +1199,7 @@ pub(crate) fn materialize_native_agents_after_link(
         .iter()
         .filter_map(|t| HarnessKind::from_target_dir(t))
         .collect();
+    let fanout_agents = input.effective.settings.meridian_fanout_agents();
     let reconcile_ctx = NativeAgentReconcileCtx {
         policy: policy.clone(),
         project_root: &input.mars_ctx.project_root,
@@ -1196,6 +1207,7 @@ pub(crate) fn materialize_native_agents_after_link(
         old_lock: input.old_lock,
         dry_run: false,
         selective_harness_scope: harness_scope,
+        fanout_agents,
     };
     let ownership_lock;
     let compile_ctx = if matches!(policy, AgentSurfacePolicy::SuppressAll) {
@@ -1213,6 +1225,7 @@ pub(crate) fn materialize_native_agents_after_link(
                 collision_hint: crate::surface_ownership::CollisionAdoptHint::LinkForce,
                 dry_run: false,
             },
+            fanout_agents,
         })
     };
     let (compiled_native_outputs, removed_native_outputs) = run_native_agent_post_sync_lifecycle(

--- a/src/compiler/native_agents/tests.rs
+++ b/src/compiler/native_agents/tests.rs
@@ -301,6 +301,7 @@ fn link_suppress_all_reconciles_selective_native_target() {
             old_lock: &lock,
             dry_run: false,
             selective_harness_scope: Some(&[HarnessKind::Claude]),
+            fanout_agents: &[],
         },
         &mars_agents,
         &mut diag,
@@ -336,7 +337,6 @@ fn reconcile_selective_removes_native_when_agent_stops_qualifying() {
     let spec = agent_copy::AgentCopySpec {
         harnesses: vec![HarnessKind::Claude],
         include_fanout: false,
-        fanout_agents: Vec::new(),
     };
     let mut aliases = IndexMap::new();
     aliases.insert(
@@ -367,6 +367,7 @@ fn reconcile_selective_removes_native_when_agent_stops_qualifying() {
             old_lock: &lock,
             dry_run: false,
             selective_harness_scope: None,
+            fanout_agents: &[],
         },
         &mars_agents,
         &mut router,
@@ -419,7 +420,6 @@ fn reconcile_selective_keeps_lock_when_native_remove_fails() {
     let spec = agent_copy::AgentCopySpec {
         harnesses: vec![HarnessKind::Claude],
         include_fanout: false,
-        fanout_agents: Vec::new(),
     };
     let mut aliases = IndexMap::new();
     aliases.insert(
@@ -450,6 +450,7 @@ fn reconcile_selective_keeps_lock_when_native_remove_fails() {
             old_lock: &lock,
             dry_run: false,
             selective_harness_scope: None,
+            fanout_agents: &[],
         },
         &mars_agents,
         &mut router,
@@ -500,6 +501,7 @@ fn compile_emit_all_agents(
             collision_hint: crate::surface_ownership::CollisionAdoptHint::SyncForce,
             dry_run: false,
         },
+        fanout_agents: &[],
     };
     let mut router = test_router(aliases, &models_cache);
     compile_native_agents(
@@ -665,6 +667,7 @@ fn compile_emit_all_with_overlays(
             collision_hint: crate::surface_ownership::CollisionAdoptHint::SyncForce,
             dry_run: false,
         },
+        fanout_agents: &[],
     };
     // Mirror the lifecycle: resolve overlays before compile (compile no longer merges).
     let resolved = resolve_native_agent_profiles(agents, overlays);

--- a/src/compiler/native_agents/tests.rs
+++ b/src/compiler/native_agents/tests.rs
@@ -381,6 +381,58 @@ fn reconcile_selective_removes_native_when_agent_stops_qualifying() {
 }
 
 #[test]
+fn emit_selective_fanout_agents_match_case_insensitively() {
+    let dir = TempDir::new().unwrap();
+    std::fs::create_dir_all(dir.path().join(".claude/agents")).unwrap();
+
+    let agent = parse_mars_agent(
+        "---\nname: reviewer\nmodel: gpt-5.3-codex\nmodel-policies:\n  - match:\n      alias: opus\n    override: {}\n---\n# Reviewer\n",
+        "reviewer",
+    );
+    let mut aliases = IndexMap::new();
+    aliases.insert(
+        "opus".to_string(),
+        pinned_alias_with_harness("claude-opus-4-6", "claude", None),
+    );
+
+    let spec = agent_copy::AgentCopySpec {
+        harnesses: vec![HarnessKind::Claude],
+        include_fanout: false,
+    };
+    let fanout_agents = vec!["Reviewer".to_string()];
+    let mut diag = DiagnosticCollector::new();
+    let models_cache = empty_models_cache();
+    let ctx = NativeAgentCompileCtx {
+        project_root: dir.path(),
+        old_lock: &LockFile::empty(),
+        harness_scope: None,
+        configured_emit_harnesses: &[HarnessKind::Claude],
+        options: NativeAgentSurfaceCompileOptions {
+            force: false,
+            collision_hint: crate::surface_ownership::CollisionAdoptHint::SyncForce,
+            dry_run: false,
+        },
+        fanout_agents: &fanout_agents,
+    };
+    let mut router = test_router(&aliases, &models_cache);
+    let records = compile_native_agents(
+        &ctx,
+        &AgentSurfacePolicy::EmitSelective(spec),
+        std::slice::from_ref(&agent),
+        &mut router,
+        &mut diag,
+    );
+
+    assert_eq!(records.len(), 1);
+    assert!(dir.path().join(".claude/agents/reviewer.md").exists());
+    let native = std::fs::read_to_string(dir.path().join(".claude/agents/reviewer.md")).unwrap();
+    assert!(
+        native.contains("model: claude-opus-4-6"),
+        "fanout list entry must qualify reviewer via model-policies despite casing mismatch: {native}"
+    );
+}
+
+#[test]
 #[cfg(unix)]
 fn reconcile_selective_keeps_lock_when_native_remove_fails() {
     use std::os::unix::fs::PermissionsExt;

--- a/src/config/layering.rs
+++ b/src/config/layering.rs
@@ -83,6 +83,9 @@ impl LocalSettings {
         if let Some(value) = &self.meridian.agent_copy {
             merged.meridian.agent_copy = Some(value.clone());
         }
+        if let Some(value) = &self.meridian.fanout {
+            merged.meridian.fanout = Some(value.clone());
+        }
         if let Some(value) = &self.model_policies {
             merged.model_policies = value.clone();
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -542,8 +542,21 @@ pub struct AgentCopyConfig {
     pub harnesses: Vec<String>,
     #[serde(default)]
     pub include_fanout: bool,
+    /// Deprecated: use `[settings.meridian.fanout].agents` instead. Parsed only to emit a migration warning.
+    #[serde(
+        default,
+        rename = "fanout_agents",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub deprecated_fanout_agents: Vec<String>,
+}
+
+/// Fanout agent list for native emission qualification and dual inventory listing.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct FanoutConfig {
     #[serde(default)]
-    pub fanout_agents: Vec<String>,
+    pub agents: Vec<String>,
 }
 
 /// Meridian-managed settings nested under `[settings.meridian]`.
@@ -552,11 +565,13 @@ pub struct AgentCopyConfig {
 pub struct MeridianSettings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_copy: Option<AgentCopyConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fanout: Option<FanoutConfig>,
 }
 
 impl MeridianSettings {
     pub fn is_empty(&self) -> bool {
-        self.agent_copy.is_none()
+        self.agent_copy.is_none() && self.fanout.is_none()
     }
 }
 
@@ -619,6 +634,15 @@ impl Settings {
     /// Selective native agent copy config from `[settings.meridian.agent_copy]`.
     pub fn meridian_agent_copy(&self) -> Option<&AgentCopyConfig> {
         self.meridian.agent_copy.as_ref()
+    }
+
+    /// Fanout agent list from `[settings.meridian.fanout]`.
+    pub fn meridian_fanout_agents(&self) -> &[String] {
+        self.meridian
+            .fanout
+            .as_ref()
+            .map(|f| f.agents.as_slice())
+            .unwrap_or(&[])
     }
 }
 
@@ -1243,6 +1267,15 @@ fn validate_save_roundtrip(original: &Config, reparsed: &Config) -> Result<(), M
             message: format!(
                 "refusing to save config: settings.meridian.agent_copy changed during roundtrip ({:?} -> {:?})",
                 original.settings.meridian.agent_copy, reparsed.settings.meridian.agent_copy
+            ),
+        }
+        .into());
+    }
+    if reparsed.settings.meridian.fanout != original.settings.meridian.fanout {
+        return Err(ConfigError::Invalid {
+            message: format!(
+                "refusing to save config: settings.meridian.fanout changed during roundtrip ({:?} -> {:?})",
+                original.settings.meridian.fanout, reparsed.settings.meridian.fanout
             ),
         }
         .into());

--- a/tests/launch_bundle.rs
+++ b/tests/launch_bundle.rs
@@ -107,6 +107,11 @@ fn build_launch_bundle_fanout_agent_dual_lists_in_inventory() {
 }
 
 #[test]
+fn build_launch_bundle_warns_on_deprecated_agent_copy_fanout_agents() {
+    prompt_surface::build_launch_bundle_warns_on_deprecated_agent_copy_fanout_agents();
+}
+
+#[test]
 fn build_launch_bundle_inventory_hides_model_non_invocable_agents_and_shows_fanout() {
     prompt_surface::build_launch_bundle_inventory_hides_model_non_invocable_agents_and_shows_fanout(
     );

--- a/tests/launch_bundle.rs
+++ b/tests/launch_bundle.rs
@@ -102,6 +102,11 @@ fn build_launch_bundle_orders_skills_by_type_and_bookends_principles() {
 }
 
 #[test]
+fn build_launch_bundle_fanout_agent_dual_lists_in_inventory() {
+    prompt_surface::build_launch_bundle_fanout_agent_dual_lists_in_inventory();
+}
+
+#[test]
 fn build_launch_bundle_inventory_hides_model_non_invocable_agents_and_shows_fanout() {
     prompt_surface::build_launch_bundle_inventory_hides_model_non_invocable_agents_and_shows_fanout(
     );

--- a/tests/launch_bundle/prompt_surface.rs
+++ b/tests/launch_bundle/prompt_surface.rs
@@ -473,13 +473,11 @@ agents = ["reviewer"]
         .as_str()
         .expect("inventory_prompt should be string");
     assert!(inventory_prompt.contains("## Subagent"));
+    assert!(inventory_prompt.contains(
+        "- `meridian spawn -a reviewer`: Review implementation | Model: claude-opus-4-6"
+    ));
     assert!(
-        inventory_prompt
-            .contains("- `meridian spawn -a reviewer`: Review implementation | Model: claude-opus-4-6")
-    );
-    assert!(
-        inventory_prompt
-            .contains("## Claude Agents (use `Agent({subagent_type: \"...\"})` tool)")
+        inventory_prompt.contains("## Claude Agents (use `Agent({subagent_type: \"...\"})` tool)")
     );
     assert!(inventory_prompt.contains("- reviewer: Review implementation"));
 }
@@ -497,13 +495,8 @@ Review code changes."#;
 fanout_agents = ["reviewer"]
 "#;
 
-    let (server, project_root) = setup_bundle_project(
-        &temp,
-        "bundle-source",
-        reviewer_content,
-        &[],
-        extra_toml,
-    );
+    let (server, project_root) =
+        setup_bundle_project(&temp, "bundle-source", reviewer_content, &[], extra_toml);
 
     let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
     cmd.args(["build", "launch-bundle", "--agent", "reviewer"]);

--- a/tests/launch_bundle/prompt_surface.rs
+++ b/tests/launch_bundle/prompt_surface.rs
@@ -484,6 +484,44 @@ agents = ["reviewer"]
     assert!(inventory_prompt.contains("- reviewer: Review implementation"));
 }
 
+pub(crate) fn build_launch_bundle_warns_on_deprecated_agent_copy_fanout_agents() {
+    let temp = TempDir::new().unwrap();
+    let reviewer_content = r#"---
+name: reviewer
+model: claude-opus-4-6
+---
+Review code changes."#;
+
+    let extra_toml = r#"
+[settings.meridian.agent_copy]
+fanout_agents = ["reviewer"]
+"#;
+
+    let (server, project_root) = setup_bundle_project(
+        &temp,
+        "bundle-source",
+        reviewer_content,
+        &[],
+        extra_toml,
+    );
+
+    let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
+    cmd.args(["build", "launch-bundle", "--agent", "reviewer"]);
+
+    let output = cmd.assert().success().get_output().clone();
+    let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    let warnings = bundle["warnings"]
+        .as_array()
+        .expect("warnings should be an array");
+    assert!(warnings.iter().any(|warning| {
+        warning
+            .as_str()
+            .unwrap_or_default()
+            .contains("[settings.meridian.fanout].agents")
+    }));
+}
+
 pub(crate) fn build_launch_bundle_inventory_hides_model_non_invocable_agents_and_shows_fanout() {
     let temp = TempDir::new().unwrap();
     let reviewer_content = r#"---

--- a/tests/launch_bundle/prompt_surface.rs
+++ b/tests/launch_bundle/prompt_surface.rs
@@ -427,6 +427,63 @@ Review code changes."#;
     );
 }
 
+pub(crate) fn build_launch_bundle_fanout_agent_dual_lists_in_inventory() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = install_fake_harnesses(temp.path(), &["claude"]);
+    let reviewer_content = r#"---
+name: reviewer
+description: Review implementation
+mode: subagent
+model: claude-opus-4-6
+---
+Review code changes."#;
+
+    let extra_toml = r#"
+[settings]
+targets = [".claude"]
+agent_emission = "always"
+
+[settings.meridian.fanout]
+agents = ["reviewer"]
+"#;
+
+    let (server, project_root) = setup_bundle_project_with_agents(
+        &temp,
+        "bundle-source",
+        &[("reviewer", reviewer_content)],
+        &[],
+        extra_toml,
+    );
+
+    let mut cmd = mars_cmd(&project_root, temp.path(), &server.url(API_PATH));
+    cmd.args([
+        "build",
+        "launch-bundle",
+        "--agent",
+        "reviewer",
+        "--harness",
+        "claude",
+    ]);
+    cmd.env("PATH", replace_path_with(&bin_dir));
+
+    let output = cmd.assert().success().get_output().clone();
+    let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    let inventory_prompt = bundle["prompt_surface"]["inventory_prompt"]
+        .as_str()
+        .expect("inventory_prompt should be string");
+    assert!(inventory_prompt.contains("## Subagent"));
+    assert!(
+        inventory_prompt
+            .contains("- `meridian spawn -a reviewer`: Review implementation | Model: claude-opus-4-6")
+    );
+    assert!(
+        inventory_prompt
+            .contains("## Claude Agents (use `Agent({subagent_type: \"...\"})` tool)")
+    );
+    assert!(inventory_prompt.contains("- reviewer: Review implementation"));
+}
+
 pub(crate) fn build_launch_bundle_inventory_hides_model_non_invocable_agents_and_shows_fanout() {
     let temp = TempDir::new().unwrap();
     let reviewer_content = r#"---


### PR DESCRIPTION
## Why

`fanout_agents` lived nested under `[settings.meridian.agent_copy]`, conflating two concerns: `agent_copy` controls native-copy *emission* (mechanism), while fanout is about *routing* — which agents are reachable through both `meridian spawn -a <name>` and the harness-native tool. Worse, the inventory renderer routed each native agent to exactly one section, so a fanout agent like `reviewer` showed only as a Claude native agent and lost its primary `meridian spawn -a reviewer` identity.

## Goal

Separate fanout config from agent_copy, and make fanout agents appear in **both** inventory sections simultaneously — `meridian spawn -a <name>` as the primary route, native `Agent({subagent_type})` as escalation.

## Summary

- New config surface `[settings.meridian.fanout]` with `agents = [...]`, a peer to `[settings.meridian.agent_copy]` (no longer nested).
- The `fanout.agents` list drives two effects from one source: native-copy emission qualification (unchanged behavior) and dual inventory listing.
- Old `agent_copy.fanout_agents` is deprecated: it parses via a capture field, emits a migration warning, and its value is ignored (no backwards compat).
- Fanout list threaded as a first-class parameter through emission and inventory paths (off `AgentCopySpec`).

## Resulting Behavior

With `[settings.meridian.fanout] agents = ["reviewer"]` and a native Claude copy present, the launch inventory shows `reviewer` in BOTH the `## Subagent` section (`meridian spawn -a reviewer`) and the `## Claude Agents` section (`Agent({subagent_type: "reviewer"})`). Without the fanout block, the agent appears only in the native section (prior behavior). A config still using `agent_copy.fanout_agents` emits a deprecation warning on both `mars sync` and `mars build launch-bundle`, pointing to the new location.

## Changes

- `src/config/mod.rs`: `FanoutConfig`, `meridian.fanout` field, `meridian_fanout_agents()` accessor, deprecated capture field on `AgentCopyConfig`, `is_empty`/roundtrip-guard wiring.
- `src/config/layering.rs`: fanout overlay (local overrides project).
- `src/compiler/agent_copy.rs`: drop `fanout_agents` from `AgentCopySpec`; shared `deprecated_fanout_agents_warning()` helper.
- `src/compiler/native_agents.rs`, `src/compiler/mod.rs`: thread fanout list separately; case-insensitive matching (consistent with inventory).
- `src/build/inventory.rs`: dual-listing logic.
- `src/build/prompt.rs`, `src/build/mod.rs`: thread fanout list; surface deprecation warning into bundle warnings.

## Work Item

fanout-separation

## Verification

- `cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo build --release`: clean.
- `cargo test`: full suite green in a non-managed environment (the one failing test locally, `lock::tests::...legacy_v2...`, is an artifact of `MERIDIAN_MANAGED=1` altering `managed_cmd` output — passes with the var unset, as in CI; unrelated to this change).
- New tests: inventory dual-listing, migration warning (sync + launch-bundle paths), case-insensitive emission match.
- End-to-end probe with the real binary + real `claude` 2.1.175: confirmed `reviewer` dual-lists with the production config; control case shows native-only; migration warning fires and old value is ignored.
- Three adversarial reviewers (correctness, structural, end-to-end) — all approve; the one finding (case-sensitivity divergence between the two consumers) was fixed.

## Knowledge Updates

Docs updated in the companion meridian-cli PR (`docs/configuration.md`). No `.context/`/KB change needed — behavior documented at the config-surface layer.

## Spawn Trace

- p4287 coder — core implementation (config + emission + inventory + threading + tests)
- p4293 coder — case-insensitive native emission match fix
- p4300 coder — surface deprecation warning on launch-bundle path
- 3 Claude reviewer/prober subagents — correctness, structural, and end-to-end runtime verification

## Release Label

release:patch

## Cleanup

Worktree prune after merge.
