### PR TITLE
fix: write Claude hooks to settings.local.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Claude target writes hook bindings to `settings.local.json` (gitignored) instead of `settings.json`. Hook commands embed machine-local cache paths that churn on every sync and every machine, so they no longer belong in the committed file. Existing managed hooks in `settings.json` are migrated out on next sync; user-owned hooks are preserved.
+
 ## [0.8.5] - 2026-06-12
 
 ### Changed

--- a/src/target/claude.rs
+++ b/src/target/claude.rs
@@ -393,10 +393,7 @@ fn remove_hook_entries_by_key(entry_keys: &[String], target_dir: &Path) -> Resul
 /// Remove the given (event, name) managed hook bindings from a single settings
 /// file, if it exists. Conservative — only removes entries whose command path
 /// matches a mars-managed hook (`/hooks/<name>/`).
-fn remove_hook_keys_from_file(
-    path: &Path,
-    hook_keys: &[(String, &str)],
-) -> Result<(), MarsError> {
+fn remove_hook_keys_from_file(path: &Path, hook_keys: &[(String, &str)]) -> Result<(), MarsError> {
     if !path.is_file() {
         return Ok(());
     }
@@ -703,8 +700,7 @@ mod tests {
         adapter.write_config_entries(&entries, tmp.path()).unwrap();
 
         // New hook lands in settings.local.json.
-        let local_raw =
-            std::fs::read_to_string(tmp.path().join("settings.local.json")).unwrap();
+        let local_raw = std::fs::read_to_string(tmp.path().join("settings.local.json")).unwrap();
         let local: serde_json::Value = serde_json::from_str(&local_raw).unwrap();
         let local_hooks = local["hooks"]["PreToolUse"].as_array().unwrap();
         assert_eq!(local_hooks.len(), 1);
@@ -720,10 +716,7 @@ mod tests {
         let committed: serde_json::Value = serde_json::from_str(&committed_raw).unwrap();
         let committed_hooks = committed["hooks"]["PreToolUse"].as_array().unwrap();
         assert_eq!(committed_hooks.len(), 1);
-        assert_eq!(
-            committed_hooks[0]["hooks"][0]["command"],
-            "echo user-owned"
-        );
+        assert_eq!(committed_hooks[0]["hooks"][0]["command"], "echo user-owned");
     }
 
     #[test]

--- a/src/target/claude.rs
+++ b/src/target/claude.rs
@@ -1,11 +1,13 @@
 /// `.claude` target adapter.
 ///
 /// Handles MCP server registration in `.mcp.json` and hook binding in
-/// `settings.json` within the `.claude/` target directory.
+/// `settings.local.json` within the `.claude/` target directory.
 ///
 /// Claude-native lowering:
 /// - MCP: writes to `.mcp.json` (mcpServers section)
-/// - Hooks: writes to `settings.json` (hooks section)
+/// - Hooks: writes to `settings.local.json` (hooks section). Hook commands
+///   carry machine-local cache paths, so they belong in the gitignored
+///   `settings.local.json` rather than the committed `settings.json`.
 /// - Env references: rendered as `${VAR_NAME}` for Claude Desktop config compat
 use std::path::{Path, PathBuf};
 
@@ -199,10 +201,14 @@ fn remove_mcp_entries_by_key(entry_keys: &[String], target_dir: &Path) -> Result
 }
 
 // ---------------------------------------------------------------------------
-// Hooks — `settings.json` format
+// Hooks — `settings.local.json` format
 // ---------------------------------------------------------------------------
 
-/// Write (or merge) hook bindings into `<target_dir>/settings.json`.
+/// Write (or merge) hook bindings into `<target_dir>/settings.local.json`.
+///
+/// Hooks go to `settings.local.json` (gitignored) rather than `settings.json`
+/// because hook commands embed machine-local cache paths that change on every
+/// sync and every machine.
 ///
 /// Claude hooks live in the `hooks` section:
 /// ```json
@@ -215,7 +221,7 @@ fn remove_mcp_entries_by_key(entry_keys: &[String], target_dir: &Path) -> Result
 /// }
 /// ```
 fn write_hooks_settings(target_dir: &Path, hooks: &[&HookEntry]) -> Result<PathBuf, MarsError> {
-    let path = target_dir.join("settings.json");
+    let path = target_dir.join("settings.local.json");
 
     let mut root: serde_json::Value = if path.is_file() {
         let raw = std::fs::read_to_string(&path).map_err(MarsError::from)?;
@@ -271,7 +277,70 @@ fn write_hooks_settings(target_dir: &Path, hooks: &[&HookEntry]) -> Result<PathB
     })?;
     crate::fs::atomic_write(&path, content.as_bytes())?;
 
+    // Migrate any stale managed hooks out of the committed settings.json. Users
+    // who synced before hooks moved to settings.local.json have leftover entries
+    // there with machine-local paths; clean them up so they don't persist.
+    let hook_names: Vec<&str> = hooks.iter().map(|h| h.name.as_str()).collect();
+    migrate_hooks_from_settings_json(target_dir, &hook_names)?;
+
     Ok(path)
+}
+
+/// Remove mars-managed hook bindings from the committed `settings.json`.
+///
+/// Hooks now live in `settings.local.json`; this strips any leftover managed
+/// bindings (matched by `/hooks/<name>/` in the command path) from
+/// `settings.json` so stale machine-local paths don't persist in the committed
+/// file. Writes back only when something changed.
+fn migrate_hooks_from_settings_json(
+    target_dir: &Path,
+    hook_names: &[&str],
+) -> Result<(), MarsError> {
+    let path = target_dir.join("settings.json");
+    if !path.is_file() {
+        return Ok(());
+    }
+
+    let raw = std::fs::read_to_string(&path).map_err(MarsError::from)?;
+    let mut root: serde_json::Value =
+        serde_json::from_str(&raw).unwrap_or_else(|_| serde_json::json!({}));
+
+    let mut changed = false;
+
+    if let Some(obj) = root.as_object_mut()
+        && let Some(hooks_value) = obj.get_mut("hooks")
+        && let Some(hooks_map) = hooks_value.as_object_mut()
+    {
+        for event_hooks in hooks_map.values_mut() {
+            if let Some(arr) = event_hooks.as_array_mut() {
+                let before = arr.len();
+                for name in hook_names {
+                    remove_managed_hook_bindings(arr, name);
+                }
+                if arr.len() != before {
+                    changed = true;
+                }
+            }
+        }
+
+        // Drop empty event arrays, then the hooks section if nothing remains.
+        hooks_map.retain(|_, v| !v.as_array().map(|a| a.is_empty()).unwrap_or(false));
+        if hooks_map.is_empty() {
+            obj.remove("hooks");
+            changed = true;
+        }
+    }
+
+    if changed {
+        let content = serde_json::to_string_pretty(&root).map_err(|e| {
+            MarsError::Config(crate::error::ConfigError::Invalid {
+                message: format!("failed to serialize {}: {e}", path.display()),
+            })
+        })?;
+        crate::fs::atomic_write(&path, content.as_bytes())?;
+    }
+
+    Ok(())
 }
 
 fn remove_managed_hook_bindings(bindings: &mut Vec<serde_json::Value>, hook_name: &str) {
@@ -293,20 +362,15 @@ fn is_managed_hook_command_for(command: &str, hook_name: &str) -> bool {
     normalized.contains(&format!("/hooks/{hook_name}/"))
 }
 
-/// Remove hook entries by key from `settings.json`.
+/// Remove hook entries by key from `settings.local.json`.
 ///
 /// Keys are "hook:<event>:<name>" — we use the native event name to locate
-/// the section. Because hooks are additive and the settings.json may contain
+/// the section. Because hooks are additive and the settings file may contain
 /// user-owned entries, we only remove entries we wrote (matched by command path).
+///
+/// We also apply the same removal to the committed `settings.json` so any stale
+/// managed bindings left there by an older sync get cleaned up.
 fn remove_hook_entries_by_key(entry_keys: &[String], target_dir: &Path) -> Result<(), MarsError> {
-    let path = target_dir.join("settings.json");
-    if !path.is_file() {
-        return Ok(());
-    }
-
-    // For now: if any hook keys are being removed, we reload and remove matching
-    // command entries. This is conservative — we only remove entries we know
-    // belong to mars-managed hooks.
     let hook_keys: Vec<(String, &str)> = entry_keys
         .iter()
         .filter_map(|k| {
@@ -320,38 +384,37 @@ fn remove_hook_entries_by_key(entry_keys: &[String], target_dir: &Path) -> Resul
         return Ok(());
     }
 
-    let raw = std::fs::read_to_string(&path).map_err(MarsError::from)?;
+    remove_hook_keys_from_file(&target_dir.join("settings.local.json"), &hook_keys)?;
+    remove_hook_keys_from_file(&target_dir.join("settings.json"), &hook_keys)?;
+
+    Ok(())
+}
+
+/// Remove the given (event, name) managed hook bindings from a single settings
+/// file, if it exists. Conservative — only removes entries whose command path
+/// matches a mars-managed hook (`/hooks/<name>/`).
+fn remove_hook_keys_from_file(
+    path: &Path,
+    hook_keys: &[(String, &str)],
+) -> Result<(), MarsError> {
+    if !path.is_file() {
+        return Ok(());
+    }
+
+    let raw = std::fs::read_to_string(path).map_err(MarsError::from)?;
     let mut root: serde_json::Value =
         serde_json::from_str(&raw).unwrap_or_else(|_| serde_json::json!({}));
 
-    // We track removed hooks by their universal event + name in the command string.
-    // The format we write is "bash <script_path>", so we match on that prefix.
     if let Some(hooks_map) = root
         .as_object_mut()
         .and_then(|o| o.get_mut("hooks"))
         .and_then(|v| v.as_object_mut())
     {
-        for (event, name) in &hook_keys {
+        for (event, name) in hook_keys {
             if let Some(event_hooks) = hooks_map.get_mut(event)
                 && let Some(arr) = event_hooks.as_array_mut()
             {
-                arr.retain(|binding| {
-                    // Retain if we can't parse it (not ours) or if it doesn't
-                    // contain the hook name in any inner command.
-                    let Some(inner_hooks) = binding.get("hooks").and_then(|h| h.as_array()) else {
-                        return true;
-                    };
-                    !inner_hooks.iter().any(|h| {
-                        h.get("command")
-                            .and_then(|c| c.as_str())
-                            .map(|cmd| {
-                                // Exact path-segment match to avoid partial name collisions
-                                // (e.g., "audit" must not match "audit-extended").
-                                is_managed_hook_command_for(cmd, name)
-                            })
-                            .unwrap_or(false)
-                    })
-                });
+                remove_managed_hook_bindings(arr, name);
             }
         }
     }
@@ -361,7 +424,7 @@ fn remove_hook_entries_by_key(entry_keys: &[String], target_dir: &Path) -> Resul
             message: format!("failed to serialize {}: {e}", path.display()),
         })
     })?;
-    crate::fs::atomic_write(&path, content.as_bytes())?;
+    crate::fs::atomic_write(path, content.as_bytes())?;
 
     Ok(())
 }
@@ -487,16 +550,17 @@ mod tests {
     }
 
     #[test]
-    fn write_hooks_creates_settings_json() {
+    fn write_hooks_creates_settings_local_json() {
         let tmp = TempDir::new().unwrap();
         let adapter = ClaudeAdapter;
         let entries = vec![make_hook_entry("audit", "tool.pre", "PreToolUse")];
         let written = adapter.write_config_entries(&entries, tmp.path()).unwrap();
 
         assert_eq!(written.len(), 1);
-        assert!(tmp.path().join("settings.json").exists());
+        assert!(tmp.path().join("settings.local.json").exists());
+        assert!(!tmp.path().join("settings.json").exists());
 
-        let raw = std::fs::read_to_string(tmp.path().join("settings.json")).unwrap();
+        let raw = std::fs::read_to_string(tmp.path().join("settings.local.json")).unwrap();
         let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
         assert!(json["hooks"]["PreToolUse"].is_array());
         assert!(!json["hooks"]["PreToolUse"].as_array().unwrap().is_empty());
@@ -529,7 +593,7 @@ mod tests {
             )
             .unwrap();
 
-        let raw = std::fs::read_to_string(tmp.path().join("settings.json")).unwrap();
+        let raw = std::fs::read_to_string(tmp.path().join("settings.local.json")).unwrap();
         let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
         let hooks = json["hooks"]["PreToolUse"].as_array().unwrap();
         assert_eq!(hooks.len(), 1);
@@ -565,7 +629,8 @@ mod tests {
         let written = adapter.write_config_entries(&entries, tmp.path()).unwrap();
         assert_eq!(written.len(), 2);
         assert!(tmp.path().join(".mcp.json").exists());
-        assert!(tmp.path().join("settings.json").exists());
+        assert!(tmp.path().join("settings.local.json").exists());
+        assert!(!tmp.path().join("settings.json").exists());
     }
 
     #[test]
@@ -590,16 +655,109 @@ mod tests {
             }
         });
         std::fs::write(
-            tmp.path().join("settings.json"),
+            tmp.path().join("settings.local.json"),
             serde_json::to_string_pretty(&existing).unwrap(),
         )
         .unwrap();
 
         remove_hook_entries_by_key(&["hook:tool.pre:audit".to_string()], tmp.path()).unwrap();
 
-        let raw = std::fs::read_to_string(tmp.path().join("settings.json")).unwrap();
+        let raw = std::fs::read_to_string(tmp.path().join("settings.local.json")).unwrap();
         let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
         let hooks = json["hooks"]["PreToolUse"].as_array().unwrap();
         assert_eq!(hooks.len(), 1);
+    }
+
+    #[test]
+    fn write_hooks_migrates_stale_hooks_out_of_settings_json() {
+        let tmp = TempDir::new().unwrap();
+
+        // Simulate an older sync that wrote a managed hook into the committed
+        // settings.json, alongside a user-owned hook that must be preserved.
+        let stale = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "",
+                        "hooks": [
+                            { "type": "command", "command": "bash /old/cache/hooks/audit/run.sh" }
+                        ]
+                    },
+                    {
+                        "matcher": "",
+                        "hooks": [
+                            { "type": "command", "command": "echo user-owned" }
+                        ]
+                    }
+                ]
+            }
+        });
+        std::fs::write(
+            tmp.path().join("settings.json"),
+            serde_json::to_string_pretty(&stale).unwrap(),
+        )
+        .unwrap();
+
+        let adapter = ClaudeAdapter;
+        let entries = vec![make_hook_entry("audit", "tool.pre", "PreToolUse")];
+        adapter.write_config_entries(&entries, tmp.path()).unwrap();
+
+        // New hook lands in settings.local.json.
+        let local_raw =
+            std::fs::read_to_string(tmp.path().join("settings.local.json")).unwrap();
+        let local: serde_json::Value = serde_json::from_str(&local_raw).unwrap();
+        let local_hooks = local["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(local_hooks.len(), 1);
+        assert!(
+            local_hooks[0]["hooks"][0]["command"]
+                .as_str()
+                .unwrap()
+                .contains("/hooks/audit/")
+        );
+
+        // Stale managed hook is gone from settings.json; user-owned hook stays.
+        let committed_raw = std::fs::read_to_string(tmp.path().join("settings.json")).unwrap();
+        let committed: serde_json::Value = serde_json::from_str(&committed_raw).unwrap();
+        let committed_hooks = committed["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(committed_hooks.len(), 1);
+        assert_eq!(
+            committed_hooks[0]["hooks"][0]["command"],
+            "echo user-owned"
+        );
+    }
+
+    #[test]
+    fn write_hooks_drops_empty_hooks_section_from_settings_json() {
+        let tmp = TempDir::new().unwrap();
+
+        // Only a managed hook in settings.json — after migration the hooks
+        // section should be removed entirely.
+        let stale = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "",
+                        "hooks": [
+                            { "type": "command", "command": "bash /old/cache/hooks/audit/run.sh" }
+                        ]
+                    }
+                ]
+            },
+            "other": "preserved"
+        });
+        std::fs::write(
+            tmp.path().join("settings.json"),
+            serde_json::to_string_pretty(&stale).unwrap(),
+        )
+        .unwrap();
+
+        let adapter = ClaudeAdapter;
+        let entries = vec![make_hook_entry("audit", "tool.pre", "PreToolUse")];
+        adapter.write_config_entries(&entries, tmp.path()).unwrap();
+
+        let committed_raw = std::fs::read_to_string(tmp.path().join("settings.json")).unwrap();
+        let committed: serde_json::Value = serde_json::from_str(&committed_raw).unwrap();
+        assert!(committed.get("hooks").is_none());
+        assert_eq!(committed["other"], "preserved");
     }
 }

--- a/tests/filter_and_rename.rs
+++ b/tests/filter_and_rename.rs
@@ -22,7 +22,9 @@ fn add_with_agents_filter() {
         &[],
     );
 
-    let agents_dir = dir.child("project").child(".agents");
+    // Agents materialize to the canonical `.mars/agents` store; the `.agents`
+    // link target only receives native skills.
+    let mars_agents_dir = dir.child("project").child(".mars").child("agents");
     mars()
         .args([
             "init",
@@ -46,9 +48,9 @@ fn add_with_agents_filter() {
         .success();
 
     // Only coder should be installed
-    assert!(agents_dir.child("agents").child("coder.md").exists());
-    assert!(!agents_dir.child("agents").child("reviewer.md").exists());
-    assert!(!agents_dir.child("agents").child("planner.md").exists());
+    assert!(mars_agents_dir.child("coder.md").exists());
+    assert!(!mars_agents_dir.child("reviewer.md").exists());
+    assert!(!mars_agents_dir.child("planner.md").exists());
 }
 
 #[test]
@@ -56,7 +58,8 @@ fn rename_applies_path_mapping_during_sync() {
     let dir = TempDir::new().unwrap();
     let source = create_source(&dir, "base", &[("coder", "# Coder")], &[]);
 
-    let agents_dir = dir.child("project").child(".agents");
+    // Agents materialize to the canonical `.mars/agents` store.
+    let mars_agents_dir = dir.child("project").child(".mars").child("agents");
     mars()
         .args([
             "init",
@@ -88,13 +91,8 @@ fn rename_applies_path_mapping_during_sync() {
         .assert()
         .success();
 
-    assert!(
-        agents_dir
-            .child("agents")
-            .child("coder-renamed.md")
-            .exists()
-    );
-    assert!(!agents_dir.child("agents").child("coder.md").exists());
+    assert!(mars_agents_dir.child("coder-renamed.md").exists());
+    assert!(!mars_agents_dir.child("coder.md").exists());
 
     let lock_content = fs::read_to_string(dir.child("project").child("mars.lock").path()).unwrap();
     let lock: Value = toml::from_str(&lock_content).unwrap();
@@ -163,7 +161,10 @@ fn rename_skill_rewrites_agent_skill_references() {
         .child("planning")
         .assert(predicate::path::missing());
 
-    let agent_content = fs::read_to_string(agents_dir.child("agents").child("coder.md").path())
+    // Agents materialize to the canonical `.mars/agents` store, not the
+    // `.agents` link target (which only receives native skills).
+    let mars_agents_dir = project_root.child(".mars").child("agents");
+    let agent_content = fs::read_to_string(mars_agents_dir.child("coder.md").path())
         .expect("expected installed agent");
     assert!(
         agent_content.contains("- strategy"),

--- a/tests/launch_bundle/routing.rs
+++ b/tests/launch_bundle/routing.rs
@@ -655,8 +655,8 @@ commit = "abc123"
         "expected missing dependency alias authority error, stderr:\n{stderr}"
     );
     assert!(
-        stderr.contains("run `mars sync`"),
-        "expected sync remediation hint, stderr:\n{stderr}"
+        stderr.contains("mars repair`") || stderr.contains("mars sync`"),
+        "expected repair/sync remediation hint, stderr:\n{stderr}"
     );
 }
 

--- a/tests/local_package.rs
+++ b/tests/local_package.rs
@@ -93,28 +93,30 @@ fn full_pipeline_with_local_package_and_custom_target() {
         .assert()
         .success();
 
-    // 7-10. Verify items exist in target and .mars/ canonical store
+    // 7-10. Verify items exist in .mars/ canonical store and target.
+    // Agents now materialize to .mars/agents/ (canonical store), not the
+    // managed target dir. Skills still go to the target.
     let managed = project.child(".custom");
-    let local_agent_target = managed.child("agents").child("local-agent.md");
     let local_skill_target = managed.child("skills").child("local-skill");
-    let external_agent = managed.child("agents").child("external-agent.md");
+
+    let mars_dir = project.child(".mars");
+    let mars_local_agent = mars_dir.child("agents").child("local-agent.md");
+    let mars_external_agent = mars_dir.child("agents").child("external-agent.md");
 
     assert!(
-        local_agent_target.path().exists(),
-        "local agent should exist"
+        mars_local_agent.path().exists(),
+        "local agent should exist in .mars/agents/"
     );
     assert!(
         local_skill_target.path().exists(),
         "local skill should exist"
     );
     assert!(
-        external_agent.path().exists(),
-        "external agent should exist"
+        mars_external_agent.path().exists(),
+        "external agent should exist in .mars/agents/"
     );
 
     // In .mars/ canonical store, local items are regular copied content
-    let mars_dir = project.child(".mars");
-    let mars_local_agent = mars_dir.child("agents").child("local-agent.md");
     assert!(
         !mars_local_agent
             .path()
@@ -125,18 +127,9 @@ fn full_pipeline_with_local_package_and_custom_target() {
         "local agent in .mars/ should be a regular file copy"
     );
 
-    // In target directories, ALL items are regular file copies (D26)
+    // External agent is also a regular file copy (D26)
     assert!(
-        !local_agent_target
-            .path()
-            .symlink_metadata()
-            .unwrap()
-            .file_type()
-            .is_symlink(),
-        "local agent in target should be a regular file copy, not a symlink"
-    );
-    assert!(
-        !external_agent
+        !mars_external_agent
             .path()
             .symlink_metadata()
             .unwrap()

--- a/tests/lock_and_repair.rs
+++ b/tests/lock_and_repair.rs
@@ -105,7 +105,7 @@ fn sync_errors_when_lock_is_corrupt() {
         .assert()
         .code(2)
         .stderr(predicate::str::contains("lock file corrupt"))
-        .stderr(predicate::str::contains("run `mars repair`"));
+        .stderr(predicate::str::contains("mars repair`"));
 }
 
 #[test]

--- a/tests/model_config.rs
+++ b/tests/model_config.rs
@@ -1369,8 +1369,8 @@ commit = "abc123"
             "expected missing dependency alias authority error for {args:?}, stderr:\n{stderr}"
         );
         assert!(
-            stderr.contains("run `mars sync`"),
-            "expected sync remediation hint for {args:?}, stderr:\n{stderr}"
+            stderr.contains("mars repair`") || stderr.contains("mars sync`"),
+            "expected repair/sync remediation hint for {args:?}, stderr:\n{stderr}"
         );
     }
 

--- a/tests/sync_behavior.rs
+++ b/tests/sync_behavior.rs
@@ -47,7 +47,9 @@ fn sync_force_overwrites_local_changes() {
     let dir = TempDir::new().unwrap();
     let source = create_source(&dir, "base", &[("coder", "# Original content")], &[]);
 
-    let agents_dir = dir.child("project").child(".agents");
+    // Agents materialize to the canonical `.mars/agents` store; the `.agents`
+    // link target only receives native skills.
+    let mars_agents_dir = dir.child("project").child(".mars").child("agents");
     mars()
         .args([
             "init",
@@ -68,8 +70,8 @@ fn sync_force_overwrites_local_changes() {
         .assert()
         .success();
 
-    // Locally modify the file
-    let installed_file = agents_dir.child("agents").child("coder.md");
+    // Locally modify the canonical store file
+    let installed_file = mars_agents_dir.child("coder.md");
     fs::write(installed_file.path(), "# Locally modified").unwrap();
 
     // Also update source so there's a conflict
@@ -382,10 +384,11 @@ fn sync_force_overwrites_divergent_target() {
         .assert()
         .success();
 
-    // Manually edit the target (.agents/) to simulate divergence
+    // Manually edit the canonical store to simulate divergence. Agents
+    // materialize to `.mars/agents`, not the `.agents` link target.
     let target_installed = dir
         .child("project")
-        .child(".agents")
+        .child(".mars")
         .child("agents")
         .child("coder.md");
     fs::write(target_installed.path(), "# Hand-edited content\n").unwrap();
@@ -1606,7 +1609,10 @@ path = "{}"
 #[test]
 fn link_fails_on_unmanaged_collision_without_force() {
     let dir = TempDir::new().unwrap();
-    let source = create_source(&dir, "base", &[("coder", "# Coder from Mars")], &[]);
+    // Skills are the only items emitted to the `.agents` link target now;
+    // agents materialize to the canonical `.mars/agents` store. Test the
+    // unmanaged-collision guard against a skill the link target would touch.
+    let source = create_source(&dir, "base", &[], &[("planning", "# Planning from Mars")]);
 
     let project = dir.child("project");
     project.create_dir_all().unwrap();
@@ -1623,9 +1629,9 @@ fn link_fails_on_unmanaged_collision_without_force() {
         .assert()
         .success();
 
-    fs::create_dir_all(project.child(".agents/agents").path()).unwrap();
+    fs::create_dir_all(project.child(".agents/skills/planning").path()).unwrap();
     fs::write(
-        project.child(".agents/agents/coder.md").path(),
+        project.child(".agents/skills/planning/SKILL.md").path(),
         "# hand-written\n",
     )
     .unwrap();
@@ -1641,7 +1647,7 @@ fn link_fails_on_unmanaged_collision_without_force() {
         .failure();
 
     assert_eq!(
-        fs::read_to_string(project.child(".agents/agents/coder.md").path()).unwrap(),
+        fs::read_to_string(project.child(".agents/skills/planning/SKILL.md").path()).unwrap(),
         "# hand-written\n"
     );
 }
@@ -1649,7 +1655,10 @@ fn link_fails_on_unmanaged_collision_without_force() {
 #[test]
 fn link_force_adopts_unmanaged_collision_and_records_lock() {
     let dir = TempDir::new().unwrap();
-    let source = create_source(&dir, "base", &[("coder", "# Coder from Mars")], &[]);
+    // Skills are the only items emitted to the `.agents` link target now;
+    // agents materialize to the canonical `.mars/agents` store. Test
+    // `--force` adoption against a skill the link target would touch.
+    let source = create_source(&dir, "base", &[], &[("planning", "# Planning from Mars")]);
 
     let project = dir.child("project");
     project.create_dir_all().unwrap();
@@ -1666,9 +1675,9 @@ fn link_force_adopts_unmanaged_collision_and_records_lock() {
         .assert()
         .success();
 
-    fs::create_dir_all(project.child(".agents/agents").path()).unwrap();
+    fs::create_dir_all(project.child(".agents/skills/planning").path()).unwrap();
     fs::write(
-        project.child(".agents/agents/coder.md").path(),
+        project.child(".agents/skills/planning/SKILL.md").path(),
         "# hand-written\n",
     )
     .unwrap();
@@ -1685,10 +1694,10 @@ fn link_force_adopts_unmanaged_collision_and_records_lock() {
         .success();
 
     assert_eq!(
-        fs::read_to_string(project.child(".agents/agents/coder.md").path()).unwrap(),
-        "# Coder from Mars"
+        fs::read_to_string(project.child(".agents/skills/planning/SKILL.md").path()).unwrap(),
+        "# Planning from Mars"
     );
 
     let lock = mars_agents::lock::load(project.path()).unwrap();
-    assert!(lock.contains_output(".agents", "agents/coder.md"));
+    assert!(lock.contains_output(".agents", "skills/planning"));
 }


### PR DESCRIPTION
## Why

`mars sync` writes hook entries into `.claude/settings.json` with absolute paths into the local mars cache (`~/.cache/mars/cache/archives/<hash>/hooks/...`). These paths are machine-specific and change on every sync when the upstream package version changes, creating noise diffs on the committed `settings.json`.

## Goal

Hook bindings go to `settings.local.json` (gitignored) instead of `settings.json`. Existing stale hooks in `settings.json` are migrated out on next sync.

## Summary

- `write_hooks_settings` now targets `settings.local.json`
- New `migrate_hooks_from_settings_json` helper strips managed hooks from `settings.json` after writing to `settings.local.json`, cleaning up stale entries
- `remove_hook_entries_by_key` applies removal to both files via shared `remove_hook_keys_from_file` helper
- Also fixes 8 pre-existing integration test failures (stale assertions from agent materialization path change and remediation hint rewording)

## Resulting Behavior

After `mars sync`:
- Hook entries appear in `.claude/settings.local.json` (gitignored) — no more churn on the committed `settings.json`
- Any pre-existing managed hooks in `settings.json` are cleaned out automatically
- User-owned hooks/settings in `settings.json` are preserved
- Claude reads both files, so hooks still work identically at runtime

## Changes

**`src/target/claude.rs`**:
- Write path: `settings.json` → `settings.local.json`
- Migration: after write, clean managed hooks from `settings.json` (empty sections removed)
- Removal path: shared `remove_hook_keys_from_file` applied to both files
- 10 unit tests (2 new migration tests)

**Integration test fixes** (pre-existing on `main`, unrelated to hooks):
- `tests/filter_and_rename.rs`, `tests/local_package.rs`, `tests/sync_behavior.rs`: agents now materialize to `.mars/agents/`, not target dir
- `tests/launch_bundle/routing.rs`, `tests/lock_and_repair.rs`, `tests/model_config.rs`: remediation hint changed from `mars sync` to `meridian mars repair`

## Work Item

N/A — ad-hoc fix

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test -- --skip cli::version::tests::run` — 1586 tests pass, 0 failures
- Pre-push preflight passed (fmt + clippy + test + release build)

## Knowledge Updates

Not applicable — behavioral fix, no new concepts.

## Spawn Trace

- Interactive primary session (product-lead)
- tech-lead agent — implemented hooks → settings.local.json change
- tech-lead agent — fixed sync_behavior test assertions
- Direct fixes for remaining test assertions

## Cleanup

After merge:
```bash
scripts/prune-worktrees.sh
```