### PR TITLE
Promote cursor to first-class, fix test env leak

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,8 +24,7 @@ meridian -C "$MERIDIAN_TASK_DIR" mars sync
 
 ## Target Support Status
 
-- `.claude`, `.codex`, `.opencode` are first-class targets.
-- `.cursor` is **experimental**.
+- `.claude`, `.codex`, `.opencode`, `.cursor` are first-class targets.
 - `.pi` is under active design/development.
 
 ## Critical Invariants

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Cursor promoted from experimental to first-class launch-bundle target. Removed `is_experimental` flag, `harness_stability` provenance, and user-facing warning.
+- Inventory prompt-file idiom updated from `/tmp/<name>.md` to `$(meridian work path prompts/<name>.md)`.
+
+### Fixed
+- Test harness now sanitizes `MERIDIAN_MANAGED` env var, preventing `managed_cmd` output drift when tests run inside a meridian session.
+
 ## [0.8.7] - 2026-06-12
 
 ### Changed

--- a/src/build/inventory.rs
+++ b/src/build/inventory.rs
@@ -126,7 +126,7 @@ pub fn build_inventory_prompt(
     let mut lines = vec![
         "# Meridian Agents".to_string(),
         "".to_string(),
-        "Write prompts to `/tmp/<name>.md`.".to_string(),
+        "Write prompts to `$(meridian work path prompts/<name>.md)`.".to_string(),
         "Use `--bg` + `meridian spawn wait` for parallel work.".to_string(),
         "Use `/handoff` when passing control back to the user.".to_string(),
     ];
@@ -377,7 +377,7 @@ mod tests {
         let inventory =
             build_inventory_prompt(&mars_dir, &[], "claude", &[], &mut warnings).unwrap();
 
-        assert!(inventory.contains("Write prompts to `/tmp/<name>.md`."));
+        assert!(inventory.contains("Write prompts to `$(meridian work path prompts/<name>.md)`."));
         assert!(inventory.contains("## Subagent"));
         assert!(
             inventory.contains(

--- a/src/build/policy/harness.rs
+++ b/src/build/policy/harness.rs
@@ -20,7 +20,6 @@ pub(super) struct HarnessResolution {
     /// Set to Some(()) when a soft-fail cleared the model so harness could proceed.
     /// Downstream routing should treat model/provider fields as empty when this is Some.
     pub(super) model_override: Option<()>,
-    pub(super) is_experimental: bool,
     pub(super) resolved_harness: HarnessKind,
     pub(super) warnings: Vec<String>,
 }
@@ -275,7 +274,6 @@ where
     })?;
 
     Ok(HarnessResolution {
-        is_experimental: harness.value == "cursor",
         resolved_harness,
         harness,
         harness_order_position: selected_harness_order_position,

--- a/src/build/policy/mod.rs
+++ b/src/build/policy/mod.rs
@@ -464,13 +464,6 @@ pub fn resolve_policy(
     {
         provenance.insert("harness_order_position".to_string(), position.to_string());
     }
-    if harness_resolution.is_experimental {
-        warnings.push(
-            "Cursor is an experimental launch-bundle target. The contract may change without notice.".to_string(),
-        );
-        provenance.insert("harness_stability".to_string(), "experimental".to_string());
-    }
-
     let matched_harness_override = input
         .profile
         .harness_overrides

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -246,7 +246,8 @@ pub fn configure_assert_cmd(cmd: &mut Command, temp_root: &Path, api_url: &str) 
         .env("XDG_DATA_HOME", &xdg_data)
         .env("MARS_CACHE_DIR", &mars_cache)
         .env("NO_COLOR", "1")
-        .env_remove("MARS_OFFLINE");
+        .env_remove("MARS_OFFLINE")
+        .env_remove("MERIDIAN_MANAGED");
 }
 
 pub fn configure_std_cmd(cmd: &mut StdCommand, temp_root: &Path, api_url: &str) {
@@ -265,7 +266,8 @@ pub fn configure_std_cmd(cmd: &mut StdCommand, temp_root: &Path, api_url: &str) 
         .env("XDG_DATA_HOME", &xdg_data)
         .env("MARS_CACHE_DIR", &mars_cache)
         .env("NO_COLOR", "1")
-        .env_remove("MARS_OFFLINE");
+        .env_remove("MARS_OFFLINE")
+        .env_remove("MERIDIAN_MANAGED");
 }
 
 pub fn mars_cmd(project_root: &Path, temp_root: &Path, api_url: &str) -> Command {

--- a/tests/launch_bundle.rs
+++ b/tests/launch_bundle.rs
@@ -542,8 +542,8 @@ fn build_launch_bundle_cursor_and_pi_unknown_tools_pass_silently() {
 }
 
 #[test]
-fn build_launch_bundle_accepts_cursor_harness_flag_and_marks_experimental() {
-    cursor::build_launch_bundle_accepts_cursor_harness_flag_and_marks_experimental();
+fn build_launch_bundle_accepts_cursor_harness_flag() {
+    cursor::build_launch_bundle_accepts_cursor_harness_flag();
 }
 
 #[test]

--- a/tests/launch_bundle/cursor.rs
+++ b/tests/launch_bundle/cursor.rs
@@ -5,7 +5,7 @@ use crate::test_common::{API_PATH, mars_cmd};
 use assert_fs::TempDir;
 use serde_json::Value;
 
-pub(crate) fn build_launch_bundle_accepts_cursor_harness_flag_and_marks_experimental() {
+pub(crate) fn build_launch_bundle_accepts_cursor_harness_flag() {
     let temp = TempDir::new().unwrap();
     let bin_dir = install_fake_harnesses(temp.path(), &["cursor"]);
     let agent_content = r#"---
@@ -32,17 +32,10 @@ Review code changes."#;
     let bundle: Value = serde_json::from_slice(&output.stdout).unwrap();
 
     assert_eq!(bundle["routing"]["harness"].as_str(), Some("cursor"));
-    assert_eq!(
-        bundle["provenance"]["harness_stability"].as_str(),
-        Some("experimental")
+    assert!(
+        bundle["provenance"].get("harness_stability").is_none(),
+        "cursor should not be marked experimental"
     );
-    let warnings = bundle["warnings"]
-        .as_array()
-        .expect("warnings should be an array");
-    assert!(warnings.iter().any(|warning| {
-        warning.as_str().unwrap_or_default()
-            == "Cursor is an experimental launch-bundle target. The contract may change without notice."
-    }));
 }
 
 pub(crate) fn build_launch_bundle_accepts_profile_cursor_harness() {
@@ -70,9 +63,9 @@ Review code changes."#;
         bundle["provenance"]["harness_source"].as_str(),
         Some("profile")
     );
-    assert_eq!(
-        bundle["provenance"]["harness_stability"].as_str(),
-        Some("experimental")
+    assert!(
+        bundle["provenance"].get("harness_stability").is_none(),
+        "cursor should not be marked experimental"
     );
 }
 
@@ -151,9 +144,9 @@ harness = "cursor""#;
         bundle["provenance"]["harness_source"].as_str(),
         Some("alias")
     );
-    assert_eq!(
-        bundle["provenance"]["harness_stability"].as_str(),
-        Some("experimental")
+    assert!(
+        bundle["provenance"].get("harness_stability").is_none(),
+        "cursor should not be marked experimental"
     );
     assert_eq!(
         bundle["skills"]["loaded"][0]["name"].as_str(),


### PR DESCRIPTION
## Why

Cursor is the primary harness for most spawns but still triggers an "experimental" warning on every launch. Additionally, the inventory prompt-file idiom still references `/tmp/<name>.md` despite the standardization to work-dir paths, and `MERIDIAN_MANAGED` leaks from session env into test subprocesses causing assertion drift.

## Goal

Clean up three independent hygiene issues: cursor stability status, prompt-file idiom, and test env isolation.

## Summary

- Removed cursor experimental flag from harness resolution (policy + provenance + warning)
- Updated inventory prompt-file path from `/tmp/<name>.md` to `$(meridian work path prompts/<name>.md)`
- Sanitized `MERIDIAN_MANAGED` in both test command helpers to prevent `managed_cmd` output drift

## Resulting Behavior

- `mars build launch-bundle --harness cursor` no longer emits experimental warning or `harness_stability: experimental` provenance
- Agent inventory block shows `$(meridian work path prompts/<name>.md)` instead of `/tmp/<name>.md`
- Tests produce deterministic output regardless of whether they run inside a meridian session

## Changes

- `src/build/policy/harness.rs`: removed `is_experimental` field from `HarnessResolution`, removed `harness.value == "cursor"` assignment
- `src/build/policy/mod.rs`: removed experimental warning emission + provenance block
- `src/build/inventory.rs`: updated prompt-file instruction text + unit test assertion
- `tests/launch_bundle/cursor.rs`: 3 tests updated to assert stability absent
- `tests/launch_bundle.rs`: renamed test wrapper
- `tests/common/mod.rs`: `env_remove("MERIDIAN_MANAGED")` in both `configure_assert_cmd` and `configure_std_cmd`
- `AGENTS.md`: `.cursor` promoted to first-class alongside `.claude`, `.codex`, `.opencode`

## Work Item

probe-runtime-sanity-20260617

## Verification

- `cargo build` clean
- `cargo test --test launch_bundle`: 112/112 pass (including previously-failing `rejects_legacy_lock_missing_dependency_alias_authority`)
- `cargo clippy`: clean
- `cargo fmt --check`: clean

## Knowledge Updates

AGENTS.md updated to reflect cursor first-class status.

## Spawn Trace

Manual — changes made in product-lead primary session.

## Release Label Guide

`release:patch`

## Cleanup

Branch can be deleted after merge.