### PR TITLE
Add launch-resolved model prompting guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
-- `mars models prompt <ref>` resolves agent refs before model aliases and shows model prompting guidance, with JSON output for the resolved ref.
+- `mars models prompting <ref>` resolves agent refs before model aliases and shows model prompting guidance, with JSON output for the resolved ref.
 
 ## [0.8.9] - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- `mars models prompt <ref>` resolves agent refs before model aliases and shows model prompting guidance, with JSON output for the resolved ref.
+
 ## [0.8.9] - 2026-06-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - `mars models prompting <ref>` resolves agent refs before model aliases and shows model prompting guidance, with JSON output for the resolved ref.
+- `mars models prompting` accepts `--refresh-models` / `--no-refresh-models` for launch-policy model resolution.
+
+### Fixed
+- `mars models prompting <agent>` now reports guidance for the launch-resolved runnable model, including overlays, model policies, fallbacks, and model clearing.
 
 ## [0.8.9] - 2026-06-19
 

--- a/src/build/policy/harness.rs
+++ b/src/build/policy/harness.rs
@@ -623,6 +623,7 @@ mod tests {
         ModelAlias {
             harness: harness.map(str::to_string),
             description: None,
+            prompting: None,
             default_effort: None,
             autocompact: None,
             autocompact_pct: None,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -19,6 +19,8 @@ pub mod init;
 pub mod link;
 pub mod list;
 pub mod models;
+mod models_common;
+mod models_prompting;
 pub mod outdated;
 pub mod output;
 pub mod override_cmd;

--- a/src/cli/models.rs
+++ b/src/cli/models.rs
@@ -40,8 +40,7 @@ pub enum ModelsCommand {
     /// Show resolution chain for a specific alias.
     Resolve(ResolveAliasArgs),
     /// Show prompting guidance for an agent or model alias.
-    #[command(name = "prompt", alias = "prompting")]
-    Prompt(PromptArgs),
+    Prompting(PromptingArgs),
     /// Quick-add a pinned alias to mars.toml [models].
     Alias(AddAliasArgs),
     #[command(name = "__refresh-probe", hide = true)]
@@ -95,8 +94,10 @@ pub struct RefreshProbeArgs {
 }
 
 #[derive(Debug, Parser)]
-#[command(after_help = "Examples:\n  mars models prompt @explorer\n  mars models prompt gpt55")]
-pub struct PromptArgs {
+#[command(
+    after_help = "Examples:\n  mars models prompting @explorer\n  mars models prompting gpt55"
+)]
+pub struct PromptingArgs {
     /// Agent name/ref or model alias to look up prompting guidance for.
     pub reference: String,
 }
@@ -120,7 +121,7 @@ pub fn run(args: &ModelsArgs, ctx: &MarsContext, json: bool) -> Result<i32, Mars
         ModelsCommand::Refresh => run_refresh(ctx, json),
         ModelsCommand::List(args) => run_list(args, ctx, json),
         ModelsCommand::Resolve(a) => run_resolve(a, ctx, json),
-        ModelsCommand::Prompt(a) => run_prompt(a, ctx, json),
+        ModelsCommand::Prompting(a) => run_prompting(a, ctx, json),
         ModelsCommand::Alias(a) => run_alias(a, ctx, json),
         ModelsCommand::RefreshProbe(a) => run_refresh_probe(a),
     }
@@ -1856,7 +1857,7 @@ fn run_alias(args: &AddAliasArgs, ctx: &MarsContext, json: bool) -> Result<i32, 
     Ok(0)
 }
 
-fn run_prompt(args: &PromptArgs, ctx: &MarsContext, json: bool) -> Result<i32, MarsError> {
+fn run_prompting(args: &PromptingArgs, ctx: &MarsContext, json: bool) -> Result<i32, MarsError> {
     let project_config = load_project_config_layers_optional(&ctx.project_root)?;
     let merged = load_merged_aliases(&ctx.project_root, project_config.as_ref())?;
 
@@ -1873,8 +1874,8 @@ fn run_prompt(args: &PromptArgs, ctx: &MarsContext, json: bool) -> Result<i32, M
             args.reference
         );
         eprintln!("Examples:");
-        eprintln!("  mars models prompt @explorer");
-        eprintln!("  mars models prompt gpt55");
+        eprintln!("  mars models prompting @explorer");
+        eprintln!("  mars models prompting gpt55");
         return Ok(1);
     }
 
@@ -2116,8 +2117,8 @@ fn print_prompt_target(target: &PromptTarget) {
 
     println!();
     println!("Examples:");
-    println!("  mars models prompt @explorer");
-    println!("  mars models prompt gpt55");
+    println!("  mars models prompting @explorer");
+    println!("  mars models prompting gpt55");
 }
 
 fn print_prompting_field_hint(model_alias: &str) {

--- a/src/cli/models.rs
+++ b/src/cli/models.rs
@@ -5,6 +5,7 @@ use clap::{Parser, Subcommand};
 use indexmap::IndexMap;
 use std::collections::HashSet;
 
+use crate::build::policy::{PolicyInput, resolve_policy};
 use crate::compiler::agents::{AgentProfile, parse_agent_content};
 use crate::config::routing_settings::ResolvedRoutingSettings;
 use crate::diagnostic::{Diagnostic, DiagnosticCollector, DiagnosticLevel};
@@ -100,6 +101,12 @@ pub struct RefreshProbeArgs {
 pub struct PromptingArgs {
     /// Agent name/ref or model alias to look up prompting guidance for.
     pub reference: String,
+    /// Refresh models.dev catalog and harness probes synchronously before resolving an agent.
+    #[arg(long, conflicts_with = "no_refresh_models")]
+    refresh_models: bool,
+    /// Skip automatic models-cache refresh; use whatever is on disk.
+    #[arg(long, conflicts_with = "refresh_models")]
+    no_refresh_models: bool,
 }
 
 #[derive(Debug, Parser)]
@@ -1860,8 +1867,16 @@ fn run_alias(args: &AddAliasArgs, ctx: &MarsContext, json: bool) -> Result<i32, 
 fn run_prompting(args: &PromptingArgs, ctx: &MarsContext, json: bool) -> Result<i32, MarsError> {
     let project_config = load_project_config_layers_optional(&ctx.project_root)?;
     let merged = load_merged_aliases(&ctx.project_root, project_config.as_ref())?;
+    let refresh =
+        models::resolve_models_refresh_control(args.refresh_models, args.no_refresh_models)?;
 
-    let target = resolve_prompt_ref(&args.reference, ctx, &merged, project_config.as_ref())?;
+    let target = resolve_prompt_ref(
+        &args.reference,
+        ctx,
+        &merged,
+        project_config.as_ref(),
+        refresh,
+    )?;
 
     if json {
         let out = target.to_json(&args.reference);
@@ -1937,9 +1952,10 @@ fn resolve_prompt_ref(
     ctx: &MarsContext,
     aliases: &IndexMap<String, ModelAlias>,
     project_config: Option<&crate::config::LoadedProjectConfig>,
+    refresh: models::ModelsRefreshControl,
 ) -> Result<PromptTarget, MarsError> {
-    if let Some(agent) = resolve_prompt_agent(input_ref, ctx, project_config)? {
-        return Ok(prompt_target_for_agent(agent, aliases));
+    if let Some(agent) = resolve_prompt_agent(input_ref, ctx)? {
+        return prompt_target_for_agent(agent, ctx, aliases, project_config, refresh);
     }
 
     if input_ref.starts_with('@') {
@@ -1948,23 +1964,45 @@ fn resolve_prompt_ref(
 
     Ok(aliases
         .get(input_ref)
-        .map(|alias| prompt_target_for_model(input_ref, alias))
+        .map(|alias| prompt_target_for_model(input_ref, alias, ctx, project_config, refresh))
         .unwrap_or_else(PromptTarget::unknown))
 }
 
 struct PromptAgent {
     name: String,
-    model_token: Option<String>,
+    file_stem: String,
+    profile: AgentProfile,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PromptAgentMatch {
+    FileStem,
+    ProfileName,
 }
 
 fn resolve_prompt_agent(
     input_ref: &str,
     ctx: &MarsContext,
-    project_config: Option<&crate::config::LoadedProjectConfig>,
 ) -> Result<Option<PromptAgent>, MarsError> {
     let lookup_name = agent_ref_lookup_name(input_ref);
+    let mut agents = load_prompt_agents(ctx)?;
+
+    for match_kind in [PromptAgentMatch::FileStem, PromptAgentMatch::ProfileName] {
+        if let Some(index) = agents
+            .iter()
+            .position(|agent| prompt_agent_matches(agent, lookup_name, match_kind))
+        {
+            return Ok(Some(agents.remove(index)));
+        }
+    }
+
+    Ok(None)
+}
+
+fn load_prompt_agents(ctx: &MarsContext) -> Result<Vec<PromptAgent>, MarsError> {
     let lock = crate::lock::load(&ctx.project_root)?;
     let mars_dir = ctx.project_root.join(".mars");
+    let mut agents = Vec::new();
 
     for (dest_path, item) in lock.canonical_flat_items() {
         if item.kind != ItemKind::Agent {
@@ -1999,19 +2037,25 @@ fn resolve_prompt_agent(
 
         let stem = prompt_path_stem(&disk_path);
         let agent_name = profile.name.as_deref().unwrap_or(stem.as_str());
-        if !agent_name.eq_ignore_ascii_case(lookup_name) && !stem.eq_ignore_ascii_case(lookup_name)
-        {
-            continue;
-        }
-
-        let model_token = effective_prompt_agent_model(agent_name, &profile, project_config);
-        return Ok(Some(PromptAgent {
+        agents.push(PromptAgent {
             name: agent_name.to_string(),
-            model_token,
-        }));
+            file_stem: stem,
+            profile,
+        });
     }
 
-    Ok(None)
+    Ok(agents)
+}
+
+fn prompt_agent_matches(
+    agent: &PromptAgent,
+    lookup_name: &str,
+    match_kind: PromptAgentMatch,
+) -> bool {
+    match match_kind {
+        PromptAgentMatch::FileStem => agent.file_stem.eq_ignore_ascii_case(lookup_name),
+        PromptAgentMatch::ProfileName => agent.name.eq_ignore_ascii_case(lookup_name),
+    }
 }
 
 fn agent_ref_lookup_name(input_ref: &str) -> &str {
@@ -2025,61 +2069,115 @@ fn prompt_path_stem(path: &std::path::Path) -> String {
         .to_string()
 }
 
-fn effective_prompt_agent_model(
-    agent_name: &str,
-    profile: &AgentProfile,
-    project_config: Option<&crate::config::LoadedProjectConfig>,
-) -> Option<String> {
-    project_config
-        .and_then(|loaded| loaded.effective.agents.get(agent_name))
-        .and_then(|overlay| overlay.model.as_deref())
-        .or(profile.model.as_deref())
-        .or_else(|| {
-            project_config.and_then(|loaded| loaded.effective.settings.default_model.as_deref())
-        })
-        .map(ToOwned::to_owned)
-}
-
 fn prompt_target_for_agent(
     agent: PromptAgent,
+    ctx: &MarsContext,
+    aliases: &IndexMap<String, ModelAlias>,
+    project_config: Option<&crate::config::LoadedProjectConfig>,
+    refresh: models::ModelsRefreshControl,
+) -> Result<PromptTarget, MarsError> {
+    let effective_config = project_config
+        .map(|loaded| loaded.effective.clone())
+        .unwrap_or_default();
+    let policy = resolve_policy(
+        &effective_config,
+        PolicyInput {
+            project_root: &ctx.project_root,
+            runtime_aliases: aliases,
+            agent: Some(&agent.file_stem),
+            profile: &agent.profile,
+            model_override: None,
+            harness_override: None,
+            effort_override: None,
+            approval_override: None,
+            sandbox_override: None,
+            models_refresh: refresh,
+        },
+    )?;
+
+    Ok(prompt_target_for_routing(
+        Some(agent.name),
+        PromptRefKind::Agent,
+        &policy.routing,
+        aliases,
+    ))
+}
+
+fn prompt_target_for_routing(
+    agent_name: Option<String>,
+    ref_kind: PromptRefKind,
+    routing: &crate::build::bundle::Routing,
     aliases: &IndexMap<String, ModelAlias>,
 ) -> PromptTarget {
-    let (model_alias, model_name, prompting) = agent
-        .model_token
+    let token = routing.model_token.trim();
+    let model_alias = (!token.is_empty() && aliases.contains_key(token)).then(|| token.to_string());
+    let prompting = model_alias
         .as_deref()
-        .map(|token| match aliases.get(token) {
-            Some(alias) => (
-                Some(token.to_string()),
-                Some(model_name_for_alias(token, alias)),
-                alias.prompting.clone(),
-            ),
-            None => (None, Some(token.to_string()), None),
-        })
-        .unwrap_or((None, None, None));
+        .and_then(|alias| aliases.get(alias))
+        .and_then(|alias| alias.prompting.clone());
+    let model_name = runnable_model_name(routing);
 
     PromptTarget {
         found: true,
-        ref_kind: Some(PromptRefKind::Agent),
-        agent_name: Some(agent.name),
+        ref_kind: Some(ref_kind),
+        agent_name,
         model_alias,
         model_name,
         prompting,
     }
 }
 
-fn prompt_target_for_model(alias_name: &str, alias: &ModelAlias) -> PromptTarget {
+fn runnable_model_name(routing: &crate::build::bundle::Routing) -> Option<String> {
+    let harness_model = routing.harness_model.trim();
+    if !harness_model.is_empty() {
+        return Some(harness_model.to_string());
+    }
+
+    let model = routing.model.trim();
+    (!model.is_empty()).then(|| model.to_string())
+}
+
+fn prompt_target_for_model(
+    alias_name: &str,
+    alias: &ModelAlias,
+    ctx: &MarsContext,
+    project_config: Option<&crate::config::LoadedProjectConfig>,
+    refresh: models::ModelsRefreshControl,
+) -> PromptTarget {
+    let cache = prompt_model_cache(ctx, project_config, refresh);
     PromptTarget {
         found: true,
         ref_kind: Some(PromptRefKind::Model),
         agent_name: None,
         model_alias: Some(alias_name.to_string()),
-        model_name: Some(model_name_for_alias(alias_name, alias)),
+        model_name: Some(model_name_for_alias(alias_name, alias, &cache)),
         prompting: alias.prompting.clone(),
     }
 }
 
-fn model_name_for_alias(alias_name: &str, alias: &ModelAlias) -> String {
-    alias.pinned_model_id().unwrap_or(alias_name).to_string()
+fn prompt_model_cache(
+    ctx: &MarsContext,
+    project_config: Option<&crate::config::LoadedProjectConfig>,
+    refresh: models::ModelsRefreshControl,
+) -> models::ModelsCache {
+    let mars_dir = ctx.project_root.join(".mars");
+    let ttl = models_cache_ttl_hours(project_config);
+    models::ensure_fresh(&mars_dir, ttl, refresh.catalog_mode)
+        .map(|(cache, _)| cache)
+        .or_else(|_| models::read_cache(&mars_dir))
+        .unwrap_or(models::ModelsCache {
+            models: Vec::new(),
+            fetched_at: None,
+        })
+}
+
+fn model_name_for_alias(
+    alias_name: &str,
+    alias: &ModelAlias,
+    cache: &models::ModelsCache,
+) -> String {
+    models::resolve_model_id_for_alias(alias, cache)
+        .unwrap_or_else(|| alias.pinned_model_id().unwrap_or(alias_name).to_string())
 }
 
 fn print_prompt_target(target: &PromptTarget) {

--- a/src/cli/models.rs
+++ b/src/cli/models.rs
@@ -5,12 +5,14 @@ use clap::{Parser, Subcommand};
 use indexmap::IndexMap;
 use std::collections::HashSet;
 
+use crate::compiler::agents::{AgentProfile, parse_agent_content};
 use crate::config::routing_settings::ResolvedRoutingSettings;
 use crate::diagnostic::{Diagnostic, DiagnosticCollector, DiagnosticLevel};
 use crate::error::{ConfigError, MarsError};
 use crate::harness::host::{
     CapabilityCollectionOptions, CapabilitySession, CapabilitySnapshot, collect_capability_snapshot,
 };
+use crate::lock::ItemKind;
 use crate::models::availability::{AvailabilityStatus, ModelAvailability};
 use crate::models::probes::CursorProbeResult;
 use crate::models::probes::OpenCodeProbeResult;
@@ -37,6 +39,9 @@ pub enum ModelsCommand {
     List(ListArgs),
     /// Show resolution chain for a specific alias.
     Resolve(ResolveAliasArgs),
+    /// Show prompting guidance for an agent or model alias.
+    #[command(name = "prompt", alias = "prompting")]
+    Prompt(PromptArgs),
     /// Quick-add a pinned alias to mars.toml [models].
     Alias(AddAliasArgs),
     #[command(name = "__refresh-probe", hide = true)]
@@ -90,6 +95,13 @@ pub struct RefreshProbeArgs {
 }
 
 #[derive(Debug, Parser)]
+#[command(after_help = "Examples:\n  mars models prompt @explorer\n  mars models prompt gpt55")]
+pub struct PromptArgs {
+    /// Agent name/ref or model alias to look up prompting guidance for.
+    pub reference: String,
+}
+
+#[derive(Debug, Parser)]
 pub struct AddAliasArgs {
     /// Alias name.
     pub name: String,
@@ -108,6 +120,7 @@ pub fn run(args: &ModelsArgs, ctx: &MarsContext, json: bool) -> Result<i32, Mars
         ModelsCommand::Refresh => run_refresh(ctx, json),
         ModelsCommand::List(args) => run_list(args, ctx, json),
         ModelsCommand::Resolve(a) => run_resolve(a, ctx, json),
+        ModelsCommand::Prompt(a) => run_prompt(a, ctx, json),
         ModelsCommand::Alias(a) => run_alias(a, ctx, json),
         ModelsCommand::RefreshProbe(a) => run_refresh_probe(a),
     }
@@ -1810,6 +1823,7 @@ fn run_alias(args: &AddAliasArgs, ctx: &MarsContext, json: bool) -> Result<i32, 
         ModelAlias {
             harness: Some(normalized_harness.clone()),
             description: args.description.clone(),
+            prompting: None,
             default_effort: None,
             autocompact: None,
             autocompact_pct: None,
@@ -1840,6 +1854,277 @@ fn run_alias(args: &AddAliasArgs, ctx: &MarsContext, json: bool) -> Result<i32, 
     }
 
     Ok(0)
+}
+
+fn run_prompt(args: &PromptArgs, ctx: &MarsContext, json: bool) -> Result<i32, MarsError> {
+    let project_config = load_project_config_layers_optional(&ctx.project_root)?;
+    let merged = load_merged_aliases(&ctx.project_root, project_config.as_ref())?;
+
+    let target = resolve_prompt_ref(&args.reference, ctx, &merged, project_config.as_ref())?;
+
+    if json {
+        let out = target.to_json(&args.reference);
+        println!("{}", serde_json::to_string_pretty(&out).unwrap());
+    } else if target.found {
+        print_prompt_target(&target);
+    } else {
+        eprintln!(
+            "Unknown agent or model ref `{}`. Run `mars agents` or `mars models list` to see available refs.",
+            args.reference
+        );
+        eprintln!("Examples:");
+        eprintln!("  mars models prompt @explorer");
+        eprintln!("  mars models prompt gpt55");
+        return Ok(1);
+    }
+
+    Ok(if target.found { 0 } else { 1 })
+}
+
+#[derive(Debug)]
+struct PromptTarget {
+    found: bool,
+    ref_kind: Option<PromptRefKind>,
+    agent_name: Option<String>,
+    model_alias: Option<String>,
+    model_name: Option<String>,
+    prompting: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PromptRefKind {
+    Agent,
+    Model,
+}
+
+impl PromptRefKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Agent => "agent",
+            Self::Model => "model",
+        }
+    }
+}
+
+impl PromptTarget {
+    fn unknown() -> Self {
+        Self {
+            found: false,
+            ref_kind: None,
+            agent_name: None,
+            model_alias: None,
+            model_name: None,
+            prompting: None,
+        }
+    }
+
+    fn to_json(&self, input_ref: &str) -> serde_json::Value {
+        serde_json::json!({
+            "ref": input_ref,
+            "ref_kind": self.ref_kind.map(PromptRefKind::as_str),
+            "agent_name": self.agent_name,
+            "model_alias": self.model_alias,
+            "model_name": self.model_name,
+            "found": self.found,
+            "prompting": self.prompting,
+        })
+    }
+}
+
+fn resolve_prompt_ref(
+    input_ref: &str,
+    ctx: &MarsContext,
+    aliases: &IndexMap<String, ModelAlias>,
+    project_config: Option<&crate::config::LoadedProjectConfig>,
+) -> Result<PromptTarget, MarsError> {
+    if let Some(agent) = resolve_prompt_agent(input_ref, ctx, project_config)? {
+        return Ok(prompt_target_for_agent(agent, aliases));
+    }
+
+    if input_ref.starts_with('@') {
+        return Ok(PromptTarget::unknown());
+    }
+
+    Ok(aliases
+        .get(input_ref)
+        .map(|alias| prompt_target_for_model(input_ref, alias))
+        .unwrap_or_else(PromptTarget::unknown))
+}
+
+struct PromptAgent {
+    name: String,
+    model_token: Option<String>,
+}
+
+fn resolve_prompt_agent(
+    input_ref: &str,
+    ctx: &MarsContext,
+    project_config: Option<&crate::config::LoadedProjectConfig>,
+) -> Result<Option<PromptAgent>, MarsError> {
+    let lookup_name = agent_ref_lookup_name(input_ref);
+    let lock = crate::lock::load(&ctx.project_root)?;
+    let mars_dir = ctx.project_root.join(".mars");
+
+    for (dest_path, item) in lock.canonical_flat_items() {
+        if item.kind != ItemKind::Agent {
+            continue;
+        }
+
+        let disk_path = dest_path.resolve(&mars_dir);
+        let content = match std::fs::read_to_string(&disk_path) {
+            Ok(content) => content,
+            Err(err) => {
+                eprintln!("warning: skipping {}: {err}", disk_path.display());
+                continue;
+            }
+        };
+
+        let mut diags = Vec::new();
+        let (profile, _fm) = match parse_agent_content(&content, &mut diags) {
+            Ok(parsed) => parsed,
+            Err(err) => {
+                eprintln!("warning: skipping {}: {err}", disk_path.display());
+                continue;
+            }
+        };
+        if let Some(fatal) = diags.iter().find(|diag| diag.is_error()) {
+            eprintln!(
+                "warning: skipping {}: {}",
+                disk_path.display(),
+                fatal.message()
+            );
+            continue;
+        }
+
+        let stem = prompt_path_stem(&disk_path);
+        let agent_name = profile.name.as_deref().unwrap_or(stem.as_str());
+        if !agent_name.eq_ignore_ascii_case(lookup_name) && !stem.eq_ignore_ascii_case(lookup_name)
+        {
+            continue;
+        }
+
+        let model_token = effective_prompt_agent_model(agent_name, &profile, project_config);
+        return Ok(Some(PromptAgent {
+            name: agent_name.to_string(),
+            model_token,
+        }));
+    }
+
+    Ok(None)
+}
+
+fn agent_ref_lookup_name(input_ref: &str) -> &str {
+    input_ref.strip_prefix('@').unwrap_or(input_ref)
+}
+
+fn prompt_path_stem(path: &std::path::Path) -> String {
+    path.file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+fn effective_prompt_agent_model(
+    agent_name: &str,
+    profile: &AgentProfile,
+    project_config: Option<&crate::config::LoadedProjectConfig>,
+) -> Option<String> {
+    project_config
+        .and_then(|loaded| loaded.effective.agents.get(agent_name))
+        .and_then(|overlay| overlay.model.as_deref())
+        .or(profile.model.as_deref())
+        .or_else(|| {
+            project_config.and_then(|loaded| loaded.effective.settings.default_model.as_deref())
+        })
+        .map(ToOwned::to_owned)
+}
+
+fn prompt_target_for_agent(
+    agent: PromptAgent,
+    aliases: &IndexMap<String, ModelAlias>,
+) -> PromptTarget {
+    let (model_alias, model_name, prompting) = agent
+        .model_token
+        .as_deref()
+        .map(|token| match aliases.get(token) {
+            Some(alias) => (
+                Some(token.to_string()),
+                Some(model_name_for_alias(token, alias)),
+                alias.prompting.clone(),
+            ),
+            None => (None, Some(token.to_string()), None),
+        })
+        .unwrap_or((None, None, None));
+
+    PromptTarget {
+        found: true,
+        ref_kind: Some(PromptRefKind::Agent),
+        agent_name: Some(agent.name),
+        model_alias,
+        model_name,
+        prompting,
+    }
+}
+
+fn prompt_target_for_model(alias_name: &str, alias: &ModelAlias) -> PromptTarget {
+    PromptTarget {
+        found: true,
+        ref_kind: Some(PromptRefKind::Model),
+        agent_name: None,
+        model_alias: Some(alias_name.to_string()),
+        model_name: Some(model_name_for_alias(alias_name, alias)),
+        prompting: alias.prompting.clone(),
+    }
+}
+
+fn model_name_for_alias(alias_name: &str, alias: &ModelAlias) -> String {
+    alias.pinned_model_id().unwrap_or(alias_name).to_string()
+}
+
+fn print_prompt_target(target: &PromptTarget) {
+    if let Some(text) = target.prompting.as_deref() {
+        println!("{text}");
+        return;
+    }
+
+    match target.ref_kind {
+        Some(PromptRefKind::Agent) => {
+            let agent_name = target.agent_name.as_deref().unwrap_or("unknown");
+            match target.model_alias.as_deref() {
+                Some(model_alias) => {
+                    println!(
+                        "No prompting guidance defined for agent `{agent_name}` (model alias `{model_alias}`)."
+                    );
+                    print_prompting_field_hint(model_alias);
+                }
+                None => {
+                    let model = target.model_name.as_deref().unwrap_or("no model");
+                    println!(
+                        "No prompting guidance defined for agent `{agent_name}` (model `{model}`)."
+                    );
+                    println!("Prompting guidance is read from a known model alias.");
+                }
+            }
+        }
+        Some(PromptRefKind::Model) => {
+            let model_alias = target.model_alias.as_deref().unwrap_or("unknown");
+            println!("No prompting guidance defined for model alias `{model_alias}`.");
+            print_prompting_field_hint(model_alias);
+        }
+        None => {}
+    }
+
+    println!();
+    println!("Examples:");
+    println!("  mars models prompt @explorer");
+    println!("  mars models prompt gpt55");
+}
+
+fn print_prompting_field_hint(model_alias: &str) {
+    println!("Add a `prompting` field to the alias in mars.toml:");
+    println!();
+    println!("  [models.{model_alias}]");
+    println!("  prompting = \"Prompting tips for this model.\"");
 }
 
 enum FreshOrJsonError {
@@ -2925,6 +3210,7 @@ description = "Old alias"
         ModelAlias {
             harness: None,
             description: None,
+            prompting: None,
             default_effort: None,
             autocompact: None,
             autocompact_pct: None,
@@ -2945,6 +3231,7 @@ description = "Old alias"
         ModelAlias {
             harness: None,
             description: None,
+            prompting: None,
             default_effort: None,
             autocompact: None,
             autocompact_pct: None,
@@ -2961,6 +3248,7 @@ description = "Old alias"
         ModelAlias {
             harness: None,
             description: None,
+            prompting: None,
             default_effort: None,
             autocompact: None,
             autocompact_pct: None,
@@ -2975,6 +3263,7 @@ description = "Old alias"
         ModelAlias {
             harness: None,
             description: None,
+            prompting: None,
             default_effort: None,
             autocompact: None,
             autocompact_pct: None,

--- a/src/cli/models.rs
+++ b/src/cli/models.rs
@@ -5,15 +5,12 @@ use clap::{Parser, Subcommand};
 use indexmap::IndexMap;
 use std::collections::HashSet;
 
-use crate::build::policy::{PolicyInput, resolve_policy};
-use crate::compiler::agents::{AgentProfile, parse_agent_content};
 use crate::config::routing_settings::ResolvedRoutingSettings;
 use crate::diagnostic::{Diagnostic, DiagnosticCollector, DiagnosticLevel};
 use crate::error::{ConfigError, MarsError};
 use crate::harness::host::{
     CapabilityCollectionOptions, CapabilitySession, CapabilitySnapshot, collect_capability_snapshot,
 };
-use crate::lock::ItemKind;
 use crate::models::availability::{AvailabilityStatus, ModelAvailability};
 use crate::models::probes::CursorProbeResult;
 use crate::models::probes::OpenCodeProbeResult;
@@ -24,6 +21,11 @@ use crate::models::probes::opencode_cache::{self, CachedProbeOutcome};
 use crate::models::probes::pi_cache;
 use crate::models::{self, HarnessSource, ModelAlias, ModelSpec};
 use crate::types::MarsContext;
+
+use super::models_common::{
+    load_merged_aliases, load_project_config_layers_optional, models_cache_ttl_hours,
+};
+pub use super::models_prompting::PromptingArgs;
 
 /// Manage model aliases and the models cache.
 #[derive(Debug, Parser)]
@@ -95,21 +97,6 @@ pub struct RefreshProbeArgs {
 }
 
 #[derive(Debug, Parser)]
-#[command(
-    after_help = "Examples:\n  mars models prompting @explorer\n  mars models prompting gpt55"
-)]
-pub struct PromptingArgs {
-    /// Agent name/ref or model alias to look up prompting guidance for.
-    pub reference: String,
-    /// Refresh models.dev catalog and harness probes synchronously before resolving an agent.
-    #[arg(long, conflicts_with = "no_refresh_models")]
-    refresh_models: bool,
-    /// Skip automatic models-cache refresh; use whatever is on disk.
-    #[arg(long, conflicts_with = "refresh_models")]
-    no_refresh_models: bool,
-}
-
-#[derive(Debug, Parser)]
 pub struct AddAliasArgs {
     /// Alias name.
     pub name: String,
@@ -128,7 +115,7 @@ pub fn run(args: &ModelsArgs, ctx: &MarsContext, json: bool) -> Result<i32, Mars
         ModelsCommand::Refresh => run_refresh(ctx, json),
         ModelsCommand::List(args) => run_list(args, ctx, json),
         ModelsCommand::Resolve(a) => run_resolve(a, ctx, json),
-        ModelsCommand::Prompting(a) => run_prompting(a, ctx, json),
+        ModelsCommand::Prompting(a) => super::models_prompting::run(a, ctx, json),
         ModelsCommand::Alias(a) => run_alias(a, ctx, json),
         ModelsCommand::RefreshProbe(a) => run_refresh_probe(a),
     }
@@ -1864,368 +1851,6 @@ fn run_alias(args: &AddAliasArgs, ctx: &MarsContext, json: bool) -> Result<i32, 
     Ok(0)
 }
 
-fn run_prompting(args: &PromptingArgs, ctx: &MarsContext, json: bool) -> Result<i32, MarsError> {
-    let project_config = load_project_config_layers_optional(&ctx.project_root)?;
-    let merged = load_merged_aliases(&ctx.project_root, project_config.as_ref())?;
-    let refresh =
-        models::resolve_models_refresh_control(args.refresh_models, args.no_refresh_models)?;
-
-    let target = resolve_prompt_ref(
-        &args.reference,
-        ctx,
-        &merged,
-        project_config.as_ref(),
-        refresh,
-    )?;
-
-    if json {
-        let out = target.to_json(&args.reference);
-        println!("{}", serde_json::to_string_pretty(&out).unwrap());
-    } else if target.found {
-        print_prompt_target(&target);
-    } else {
-        eprintln!(
-            "Unknown agent or model ref `{}`. Run `mars agents` or `mars models list` to see available refs.",
-            args.reference
-        );
-        eprintln!("Examples:");
-        eprintln!("  mars models prompting @explorer");
-        eprintln!("  mars models prompting gpt55");
-        return Ok(1);
-    }
-
-    Ok(if target.found { 0 } else { 1 })
-}
-
-#[derive(Debug)]
-struct PromptTarget {
-    found: bool,
-    ref_kind: Option<PromptRefKind>,
-    agent_name: Option<String>,
-    model_alias: Option<String>,
-    model_name: Option<String>,
-    prompting: Option<String>,
-}
-
-#[derive(Debug, Clone, Copy)]
-enum PromptRefKind {
-    Agent,
-    Model,
-}
-
-impl PromptRefKind {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Agent => "agent",
-            Self::Model => "model",
-        }
-    }
-}
-
-impl PromptTarget {
-    fn unknown() -> Self {
-        Self {
-            found: false,
-            ref_kind: None,
-            agent_name: None,
-            model_alias: None,
-            model_name: None,
-            prompting: None,
-        }
-    }
-
-    fn to_json(&self, input_ref: &str) -> serde_json::Value {
-        serde_json::json!({
-            "ref": input_ref,
-            "ref_kind": self.ref_kind.map(PromptRefKind::as_str),
-            "agent_name": self.agent_name,
-            "model_alias": self.model_alias,
-            "model_name": self.model_name,
-            "found": self.found,
-            "prompting": self.prompting,
-        })
-    }
-}
-
-fn resolve_prompt_ref(
-    input_ref: &str,
-    ctx: &MarsContext,
-    aliases: &IndexMap<String, ModelAlias>,
-    project_config: Option<&crate::config::LoadedProjectConfig>,
-    refresh: models::ModelsRefreshControl,
-) -> Result<PromptTarget, MarsError> {
-    if let Some(agent) = resolve_prompt_agent(input_ref, ctx)? {
-        return prompt_target_for_agent(agent, ctx, aliases, project_config, refresh);
-    }
-
-    if input_ref.starts_with('@') {
-        return Ok(PromptTarget::unknown());
-    }
-
-    Ok(aliases
-        .get(input_ref)
-        .map(|alias| prompt_target_for_model(input_ref, alias, ctx, project_config, refresh))
-        .unwrap_or_else(PromptTarget::unknown))
-}
-
-struct PromptAgent {
-    name: String,
-    file_stem: String,
-    profile: AgentProfile,
-}
-
-#[derive(Debug, Clone, Copy)]
-enum PromptAgentMatch {
-    FileStem,
-    ProfileName,
-}
-
-fn resolve_prompt_agent(
-    input_ref: &str,
-    ctx: &MarsContext,
-) -> Result<Option<PromptAgent>, MarsError> {
-    let lookup_name = agent_ref_lookup_name(input_ref);
-    let mut agents = load_prompt_agents(ctx)?;
-
-    for match_kind in [PromptAgentMatch::FileStem, PromptAgentMatch::ProfileName] {
-        if let Some(index) = agents
-            .iter()
-            .position(|agent| prompt_agent_matches(agent, lookup_name, match_kind))
-        {
-            return Ok(Some(agents.remove(index)));
-        }
-    }
-
-    Ok(None)
-}
-
-fn load_prompt_agents(ctx: &MarsContext) -> Result<Vec<PromptAgent>, MarsError> {
-    let lock = crate::lock::load(&ctx.project_root)?;
-    let mars_dir = ctx.project_root.join(".mars");
-    let mut agents = Vec::new();
-
-    for (dest_path, item) in lock.canonical_flat_items() {
-        if item.kind != ItemKind::Agent {
-            continue;
-        }
-
-        let disk_path = dest_path.resolve(&mars_dir);
-        let content = match std::fs::read_to_string(&disk_path) {
-            Ok(content) => content,
-            Err(err) => {
-                eprintln!("warning: skipping {}: {err}", disk_path.display());
-                continue;
-            }
-        };
-
-        let mut diags = Vec::new();
-        let (profile, _fm) = match parse_agent_content(&content, &mut diags) {
-            Ok(parsed) => parsed,
-            Err(err) => {
-                eprintln!("warning: skipping {}: {err}", disk_path.display());
-                continue;
-            }
-        };
-        if let Some(fatal) = diags.iter().find(|diag| diag.is_error()) {
-            eprintln!(
-                "warning: skipping {}: {}",
-                disk_path.display(),
-                fatal.message()
-            );
-            continue;
-        }
-
-        let stem = prompt_path_stem(&disk_path);
-        let agent_name = profile.name.as_deref().unwrap_or(stem.as_str());
-        agents.push(PromptAgent {
-            name: agent_name.to_string(),
-            file_stem: stem,
-            profile,
-        });
-    }
-
-    Ok(agents)
-}
-
-fn prompt_agent_matches(
-    agent: &PromptAgent,
-    lookup_name: &str,
-    match_kind: PromptAgentMatch,
-) -> bool {
-    match match_kind {
-        PromptAgentMatch::FileStem => agent.file_stem.eq_ignore_ascii_case(lookup_name),
-        PromptAgentMatch::ProfileName => agent.name.eq_ignore_ascii_case(lookup_name),
-    }
-}
-
-fn agent_ref_lookup_name(input_ref: &str) -> &str {
-    input_ref.strip_prefix('@').unwrap_or(input_ref)
-}
-
-fn prompt_path_stem(path: &std::path::Path) -> String {
-    path.file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("unknown")
-        .to_string()
-}
-
-fn prompt_target_for_agent(
-    agent: PromptAgent,
-    ctx: &MarsContext,
-    aliases: &IndexMap<String, ModelAlias>,
-    project_config: Option<&crate::config::LoadedProjectConfig>,
-    refresh: models::ModelsRefreshControl,
-) -> Result<PromptTarget, MarsError> {
-    let effective_config = project_config
-        .map(|loaded| loaded.effective.clone())
-        .unwrap_or_default();
-    let policy = resolve_policy(
-        &effective_config,
-        PolicyInput {
-            project_root: &ctx.project_root,
-            runtime_aliases: aliases,
-            agent: Some(&agent.file_stem),
-            profile: &agent.profile,
-            model_override: None,
-            harness_override: None,
-            effort_override: None,
-            approval_override: None,
-            sandbox_override: None,
-            models_refresh: refresh,
-        },
-    )?;
-
-    Ok(prompt_target_for_routing(
-        Some(agent.name),
-        PromptRefKind::Agent,
-        &policy.routing,
-        aliases,
-    ))
-}
-
-fn prompt_target_for_routing(
-    agent_name: Option<String>,
-    ref_kind: PromptRefKind,
-    routing: &crate::build::bundle::Routing,
-    aliases: &IndexMap<String, ModelAlias>,
-) -> PromptTarget {
-    let token = routing.model_token.trim();
-    let model_alias = (!token.is_empty() && aliases.contains_key(token)).then(|| token.to_string());
-    let prompting = model_alias
-        .as_deref()
-        .and_then(|alias| aliases.get(alias))
-        .and_then(|alias| alias.prompting.clone());
-    let model_name = runnable_model_name(routing);
-
-    PromptTarget {
-        found: true,
-        ref_kind: Some(ref_kind),
-        agent_name,
-        model_alias,
-        model_name,
-        prompting,
-    }
-}
-
-fn runnable_model_name(routing: &crate::build::bundle::Routing) -> Option<String> {
-    let harness_model = routing.harness_model.trim();
-    if !harness_model.is_empty() {
-        return Some(harness_model.to_string());
-    }
-
-    let model = routing.model.trim();
-    (!model.is_empty()).then(|| model.to_string())
-}
-
-fn prompt_target_for_model(
-    alias_name: &str,
-    alias: &ModelAlias,
-    ctx: &MarsContext,
-    project_config: Option<&crate::config::LoadedProjectConfig>,
-    refresh: models::ModelsRefreshControl,
-) -> PromptTarget {
-    let cache = prompt_model_cache(ctx, project_config, refresh);
-    PromptTarget {
-        found: true,
-        ref_kind: Some(PromptRefKind::Model),
-        agent_name: None,
-        model_alias: Some(alias_name.to_string()),
-        model_name: Some(model_name_for_alias(alias_name, alias, &cache)),
-        prompting: alias.prompting.clone(),
-    }
-}
-
-fn prompt_model_cache(
-    ctx: &MarsContext,
-    project_config: Option<&crate::config::LoadedProjectConfig>,
-    refresh: models::ModelsRefreshControl,
-) -> models::ModelsCache {
-    let mars_dir = ctx.project_root.join(".mars");
-    let ttl = models_cache_ttl_hours(project_config);
-    models::ensure_fresh(&mars_dir, ttl, refresh.catalog_mode)
-        .map(|(cache, _)| cache)
-        .or_else(|_| models::read_cache(&mars_dir))
-        .unwrap_or(models::ModelsCache {
-            models: Vec::new(),
-            fetched_at: None,
-        })
-}
-
-fn model_name_for_alias(
-    alias_name: &str,
-    alias: &ModelAlias,
-    cache: &models::ModelsCache,
-) -> String {
-    models::resolve_model_id_for_alias(alias, cache)
-        .unwrap_or_else(|| alias.pinned_model_id().unwrap_or(alias_name).to_string())
-}
-
-fn print_prompt_target(target: &PromptTarget) {
-    if let Some(text) = target.prompting.as_deref() {
-        println!("{text}");
-        return;
-    }
-
-    match target.ref_kind {
-        Some(PromptRefKind::Agent) => {
-            let agent_name = target.agent_name.as_deref().unwrap_or("unknown");
-            match target.model_alias.as_deref() {
-                Some(model_alias) => {
-                    println!(
-                        "No prompting guidance defined for agent `{agent_name}` (model alias `{model_alias}`)."
-                    );
-                    print_prompting_field_hint(model_alias);
-                }
-                None => {
-                    let model = target.model_name.as_deref().unwrap_or("no model");
-                    println!(
-                        "No prompting guidance defined for agent `{agent_name}` (model `{model}`)."
-                    );
-                    println!("Prompting guidance is read from a known model alias.");
-                }
-            }
-        }
-        Some(PromptRefKind::Model) => {
-            let model_alias = target.model_alias.as_deref().unwrap_or("unknown");
-            println!("No prompting guidance defined for model alias `{model_alias}`.");
-            print_prompting_field_hint(model_alias);
-        }
-        None => {}
-    }
-
-    println!();
-    println!("Examples:");
-    println!("  mars models prompting @explorer");
-    println!("  mars models prompting gpt55");
-}
-
-fn print_prompting_field_hint(model_alias: &str) {
-    println!("Add a `prompting` field to the alias in mars.toml:");
-    println!();
-    println!("  [models.{model_alias}]");
-    println!("  prompting = \"Prompting tips for this model.\"");
-}
-
 enum FreshOrJsonError {
     Fresh(models::ModelsCache, models::RefreshOutcome),
     JsonError(String),
@@ -2849,35 +2474,6 @@ fn run_output_passthrough(input: OutputPassthroughInput<'_>) -> Result<i32, Mars
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-fn load_project_config_layers_optional(
-    project_root: &std::path::Path,
-) -> Result<Option<crate::config::LoadedProjectConfig>, MarsError> {
-    match crate::config::load_project_config_layers(project_root) {
-        Ok(loaded) => Ok(Some(loaded)),
-        Err(MarsError::Config(crate::error::ConfigError::NotFound { .. })) => Ok(None),
-        Err(err) => Err(err),
-    }
-}
-
-fn models_cache_ttl_hours(project_config: Option<&crate::config::LoadedProjectConfig>) -> u32 {
-    project_config
-        .map(|loaded| loaded.effective.settings.models_cache_ttl_hours)
-        .unwrap_or_else(|| crate::config::Settings::default().models_cache_ttl_hours)
-}
-
-/// Load model aliases by combining lock-persisted dependency aliases with effective
-/// project/local consumer aliases.
-fn load_merged_aliases(
-    project_root: &std::path::Path,
-    project_config: Option<&crate::config::LoadedProjectConfig>,
-) -> Result<indexmap::IndexMap<String, ModelAlias>, MarsError> {
-    let lock = crate::lock::load_for_runtime_aliases(project_root)?;
-    Ok(models::merged_runtime_aliases(
-        &lock.dependency_model_aliases,
-        project_config.map(|loaded| &loaded.effective.models),
-    ))
-}
 
 /// Determine which layer provides an alias (consumer or dependency).
 fn determine_source(

--- a/src/cli/models_common.rs
+++ b/src/cli/models_common.rs
@@ -1,0 +1,35 @@
+//! Shared helpers for `mars models` CLI subcommands.
+
+use crate::error::MarsError;
+use crate::models::{self, ModelAlias};
+
+pub(super) fn load_project_config_layers_optional(
+    project_root: &std::path::Path,
+) -> Result<Option<crate::config::LoadedProjectConfig>, MarsError> {
+    match crate::config::load_project_config_layers(project_root) {
+        Ok(loaded) => Ok(Some(loaded)),
+        Err(MarsError::Config(crate::error::ConfigError::NotFound { .. })) => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
+pub(super) fn models_cache_ttl_hours(
+    project_config: Option<&crate::config::LoadedProjectConfig>,
+) -> u32 {
+    project_config
+        .map(|loaded| loaded.effective.settings.models_cache_ttl_hours)
+        .unwrap_or_else(|| crate::config::Settings::default().models_cache_ttl_hours)
+}
+
+/// Load model aliases by combining lock-persisted dependency aliases with effective
+/// project/local consumer aliases.
+pub(super) fn load_merged_aliases(
+    project_root: &std::path::Path,
+    project_config: Option<&crate::config::LoadedProjectConfig>,
+) -> Result<indexmap::IndexMap<String, ModelAlias>, MarsError> {
+    let lock = crate::lock::load_for_runtime_aliases(project_root)?;
+    Ok(models::merged_runtime_aliases(
+        &lock.dependency_model_aliases,
+        project_config.map(|loaded| &loaded.effective.models),
+    ))
+}

--- a/src/cli/models_prompting.rs
+++ b/src/cli/models_prompting.rs
@@ -248,7 +248,7 @@ fn prompt_target_for_agent(
         PolicyInput {
             project_root: &ctx.project_root,
             runtime_aliases: aliases,
-            agent: Some(&agent.file_stem),
+            agent: Some(&agent.name),
             profile: &agent.profile,
             model_override: None,
             harness_override: None,

--- a/src/cli/models_prompting.rs
+++ b/src/cli/models_prompting.rs
@@ -1,0 +1,391 @@
+//! CLI handler for `mars models prompting`.
+
+use clap::Parser;
+use indexmap::IndexMap;
+
+use super::models_common::{
+    load_merged_aliases, load_project_config_layers_optional, models_cache_ttl_hours,
+};
+use crate::build::policy::{PolicyInput, resolve_policy};
+use crate::compiler::agents::{AgentProfile, parse_agent_content};
+use crate::error::MarsError;
+use crate::lock::ItemKind;
+use crate::models::{self, ModelAlias};
+use crate::types::MarsContext;
+
+#[derive(Debug, Parser)]
+#[command(
+    after_help = "Examples:\n  mars models prompting @explorer\n  mars models prompting gpt55"
+)]
+pub struct PromptingArgs {
+    /// Agent name/ref or model alias to look up prompting guidance for.
+    pub reference: String,
+    /// Refresh models.dev catalog and harness probes synchronously before resolving an agent.
+    #[arg(long, conflicts_with = "no_refresh_models")]
+    refresh_models: bool,
+    /// Skip automatic models-cache refresh; use whatever is on disk.
+    #[arg(long, conflicts_with = "refresh_models")]
+    no_refresh_models: bool,
+}
+
+pub fn run(args: &PromptingArgs, ctx: &MarsContext, json: bool) -> Result<i32, MarsError> {
+    let project_config = load_project_config_layers_optional(&ctx.project_root)?;
+    let merged = load_merged_aliases(&ctx.project_root, project_config.as_ref())?;
+    let refresh =
+        models::resolve_models_refresh_control(args.refresh_models, args.no_refresh_models)?;
+
+    let target = resolve_prompt_ref(
+        &args.reference,
+        ctx,
+        &merged,
+        project_config.as_ref(),
+        refresh,
+    )?;
+
+    if json {
+        let out = target.to_json(&args.reference);
+        println!("{}", serde_json::to_string_pretty(&out).unwrap());
+    } else if target.found {
+        print_prompt_target(&target);
+    } else {
+        eprintln!(
+            "Unknown agent or model ref `{}`. Run `mars agents` or `mars models list` to see available refs.",
+            args.reference
+        );
+        eprintln!("Examples:");
+        eprintln!("  mars models prompting @explorer");
+        eprintln!("  mars models prompting gpt55");
+        return Ok(1);
+    }
+
+    Ok(if target.found { 0 } else { 1 })
+}
+
+#[derive(Debug)]
+struct PromptTarget {
+    found: bool,
+    ref_kind: Option<PromptRefKind>,
+    agent_name: Option<String>,
+    model_alias: Option<String>,
+    model_name: Option<String>,
+    prompting: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PromptRefKind {
+    Agent,
+    Model,
+}
+
+impl PromptRefKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Agent => "agent",
+            Self::Model => "model",
+        }
+    }
+}
+
+impl PromptTarget {
+    fn unknown() -> Self {
+        Self {
+            found: false,
+            ref_kind: None,
+            agent_name: None,
+            model_alias: None,
+            model_name: None,
+            prompting: None,
+        }
+    }
+
+    fn to_json(&self, input_ref: &str) -> serde_json::Value {
+        serde_json::json!({
+            "ref": input_ref,
+            "ref_kind": self.ref_kind.map(PromptRefKind::as_str),
+            "agent_name": self.agent_name,
+            "model_alias": self.model_alias,
+            "model_name": self.model_name,
+            "found": self.found,
+            "prompting": self.prompting,
+        })
+    }
+}
+
+fn resolve_prompt_ref(
+    input_ref: &str,
+    ctx: &MarsContext,
+    aliases: &IndexMap<String, ModelAlias>,
+    project_config: Option<&crate::config::LoadedProjectConfig>,
+    refresh: models::ModelsRefreshControl,
+) -> Result<PromptTarget, MarsError> {
+    if let Some(agent) = resolve_prompt_agent(input_ref, ctx)? {
+        return prompt_target_for_agent(agent, ctx, aliases, project_config, refresh);
+    }
+
+    if input_ref.starts_with('@') {
+        return Ok(PromptTarget::unknown());
+    }
+
+    Ok(aliases
+        .get(input_ref)
+        .map(|alias| prompt_target_for_model(input_ref, alias, ctx, project_config, refresh))
+        .unwrap_or_else(PromptTarget::unknown))
+}
+
+struct PromptAgent {
+    name: String,
+    file_stem: String,
+    profile: AgentProfile,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PromptAgentMatch {
+    FileStem,
+    ProfileName,
+}
+
+fn resolve_prompt_agent(
+    input_ref: &str,
+    ctx: &MarsContext,
+) -> Result<Option<PromptAgent>, MarsError> {
+    let lookup_name = agent_ref_lookup_name(input_ref);
+    let mut agents = load_prompt_agents(ctx)?;
+
+    for match_kind in [PromptAgentMatch::FileStem, PromptAgentMatch::ProfileName] {
+        if let Some(index) = agents
+            .iter()
+            .position(|agent| prompt_agent_matches(agent, lookup_name, match_kind))
+        {
+            return Ok(Some(agents.remove(index)));
+        }
+    }
+
+    Ok(None)
+}
+
+fn load_prompt_agents(ctx: &MarsContext) -> Result<Vec<PromptAgent>, MarsError> {
+    let lock = crate::lock::load(&ctx.project_root)?;
+    let mars_dir = ctx.project_root.join(".mars");
+    let mut agents = Vec::new();
+
+    for (dest_path, item) in lock.canonical_flat_items() {
+        if item.kind != ItemKind::Agent {
+            continue;
+        }
+
+        let disk_path = dest_path.resolve(&mars_dir);
+        let content = match std::fs::read_to_string(&disk_path) {
+            Ok(content) => content,
+            Err(err) => {
+                eprintln!("warning: skipping {}: {err}", disk_path.display());
+                continue;
+            }
+        };
+
+        let mut diags = Vec::new();
+        let (profile, _fm) = match parse_agent_content(&content, &mut diags) {
+            Ok(parsed) => parsed,
+            Err(err) => {
+                eprintln!("warning: skipping {}: {err}", disk_path.display());
+                continue;
+            }
+        };
+        if let Some(fatal) = diags.iter().find(|diag| diag.is_error()) {
+            eprintln!(
+                "warning: skipping {}: {}",
+                disk_path.display(),
+                fatal.message()
+            );
+            continue;
+        }
+
+        let stem = prompt_path_stem(&disk_path);
+        let agent_name = profile.name.as_deref().unwrap_or(stem.as_str());
+        agents.push(PromptAgent {
+            name: agent_name.to_string(),
+            file_stem: stem,
+            profile,
+        });
+    }
+
+    Ok(agents)
+}
+
+fn prompt_agent_matches(
+    agent: &PromptAgent,
+    lookup_name: &str,
+    match_kind: PromptAgentMatch,
+) -> bool {
+    match match_kind {
+        PromptAgentMatch::FileStem => agent.file_stem.eq_ignore_ascii_case(lookup_name),
+        PromptAgentMatch::ProfileName => agent.name.eq_ignore_ascii_case(lookup_name),
+    }
+}
+
+fn agent_ref_lookup_name(input_ref: &str) -> &str {
+    input_ref.strip_prefix('@').unwrap_or(input_ref)
+}
+
+fn prompt_path_stem(path: &std::path::Path) -> String {
+    path.file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+fn prompt_target_for_agent(
+    agent: PromptAgent,
+    ctx: &MarsContext,
+    aliases: &IndexMap<String, ModelAlias>,
+    project_config: Option<&crate::config::LoadedProjectConfig>,
+    refresh: models::ModelsRefreshControl,
+) -> Result<PromptTarget, MarsError> {
+    let effective_config = project_config
+        .map(|loaded| loaded.effective.clone())
+        .unwrap_or_default();
+    let policy = resolve_policy(
+        &effective_config,
+        PolicyInput {
+            project_root: &ctx.project_root,
+            runtime_aliases: aliases,
+            agent: Some(&agent.file_stem),
+            profile: &agent.profile,
+            model_override: None,
+            harness_override: None,
+            effort_override: None,
+            approval_override: None,
+            sandbox_override: None,
+            models_refresh: refresh,
+        },
+    )?;
+
+    Ok(prompt_target_for_routing(
+        Some(agent.name),
+        PromptRefKind::Agent,
+        &policy.routing,
+        aliases,
+    ))
+}
+
+fn prompt_target_for_routing(
+    agent_name: Option<String>,
+    ref_kind: PromptRefKind,
+    routing: &crate::build::bundle::Routing,
+    aliases: &IndexMap<String, ModelAlias>,
+) -> PromptTarget {
+    let token = routing.model_token.trim();
+    let model_alias = (!token.is_empty() && aliases.contains_key(token)).then(|| token.to_string());
+    let prompting = model_alias
+        .as_deref()
+        .and_then(|alias| aliases.get(alias))
+        .and_then(|alias| alias.prompting.clone());
+    let model_name = runnable_model_name(routing);
+
+    PromptTarget {
+        found: true,
+        ref_kind: Some(ref_kind),
+        agent_name,
+        model_alias,
+        model_name,
+        prompting,
+    }
+}
+
+fn runnable_model_name(routing: &crate::build::bundle::Routing) -> Option<String> {
+    let harness_model = routing.harness_model.trim();
+    if !harness_model.is_empty() {
+        return Some(harness_model.to_string());
+    }
+
+    let model = routing.model.trim();
+    (!model.is_empty()).then(|| model.to_string())
+}
+
+fn prompt_target_for_model(
+    alias_name: &str,
+    alias: &ModelAlias,
+    ctx: &MarsContext,
+    project_config: Option<&crate::config::LoadedProjectConfig>,
+    refresh: models::ModelsRefreshControl,
+) -> PromptTarget {
+    let cache = prompt_model_cache(ctx, project_config, refresh);
+    PromptTarget {
+        found: true,
+        ref_kind: Some(PromptRefKind::Model),
+        agent_name: None,
+        model_alias: Some(alias_name.to_string()),
+        model_name: Some(model_name_for_alias(alias_name, alias, &cache)),
+        prompting: alias.prompting.clone(),
+    }
+}
+
+fn prompt_model_cache(
+    ctx: &MarsContext,
+    project_config: Option<&crate::config::LoadedProjectConfig>,
+    refresh: models::ModelsRefreshControl,
+) -> models::ModelsCache {
+    let mars_dir = ctx.project_root.join(".mars");
+    let ttl = models_cache_ttl_hours(project_config);
+    models::ensure_fresh(&mars_dir, ttl, refresh.catalog_mode)
+        .map(|(cache, _)| cache)
+        .or_else(|_| models::read_cache(&mars_dir))
+        .unwrap_or(models::ModelsCache {
+            models: Vec::new(),
+            fetched_at: None,
+        })
+}
+
+fn model_name_for_alias(
+    alias_name: &str,
+    alias: &ModelAlias,
+    cache: &models::ModelsCache,
+) -> String {
+    models::resolve_model_id_for_alias(alias, cache)
+        .unwrap_or_else(|| alias.pinned_model_id().unwrap_or(alias_name).to_string())
+}
+
+fn print_prompt_target(target: &PromptTarget) {
+    if let Some(text) = target.prompting.as_deref() {
+        println!("{text}");
+        return;
+    }
+
+    match target.ref_kind {
+        Some(PromptRefKind::Agent) => {
+            let agent_name = target.agent_name.as_deref().unwrap_or("unknown");
+            match target.model_alias.as_deref() {
+                Some(model_alias) => {
+                    println!(
+                        "No prompting guidance defined for agent `{agent_name}` (model alias `{model_alias}`)."
+                    );
+                    print_prompting_field_hint(model_alias);
+                }
+                None => {
+                    let model = target.model_name.as_deref().unwrap_or("no model");
+                    println!(
+                        "No prompting guidance defined for agent `{agent_name}` (model `{model}`)."
+                    );
+                    println!("Prompting guidance is read from a known model alias.");
+                }
+            }
+        }
+        Some(PromptRefKind::Model) => {
+            let model_alias = target.model_alias.as_deref().unwrap_or("unknown");
+            println!("No prompting guidance defined for model alias `{model_alias}`.");
+            print_prompting_field_hint(model_alias);
+        }
+        None => {}
+    }
+
+    println!();
+    println!("Examples:");
+    println!("  mars models prompting @explorer");
+    println!("  mars models prompting gpt55");
+}
+
+fn print_prompting_field_hint(model_alias: &str) {
+    println!("Add a `prompting` field to the alias in mars.toml:");
+    println!();
+    println!("  [models.{model_alias}]");
+    println!("  prompting = \"Prompting tips for this model.\"");
+}

--- a/src/compiler/native_agents/tests.rs
+++ b/src/compiler/native_agents/tests.rs
@@ -43,6 +43,7 @@ fn pinned_alias_with_harness(
     ModelAlias {
         harness: Some(harness.to_string()),
         description: None,
+        prompting: None,
         default_effort: default_effort.map(str::to_owned),
         autocompact: None,
         autocompact_pct: None,
@@ -115,6 +116,7 @@ fn native_model_routing_sets_pinned_alias_and_clears_unresolved_candidates() {
         ModelAlias {
             harness: Some("codex".to_string()),
             description: None,
+            prompting: None,
             default_effort: None,
             autocompact: None,
             autocompact_pct: None,
@@ -167,6 +169,7 @@ fn native_model_routing_resolves_auto_aliases_from_models_cache() {
         ModelAlias {
             harness: Some("claude".to_string()),
             description: None,
+            prompting: None,
             default_effort: None,
             autocompact: None,
             autocompact_pct: None,
@@ -211,6 +214,7 @@ fn native_model_routing_does_not_linked_fallback_foreign_provider_alias() {
         ModelAlias {
             harness: None,
             description: None,
+            prompting: None,
             default_effort: None,
             autocompact: None,
             autocompact_pct: None,
@@ -344,6 +348,7 @@ fn reconcile_selective_removes_native_when_agent_stops_qualifying() {
         ModelAlias {
             harness: None,
             description: None,
+            prompting: None,
             default_effort: None,
             autocompact: None,
             autocompact_pct: None,
@@ -479,6 +484,7 @@ fn reconcile_selective_keeps_lock_when_native_remove_fails() {
         ModelAlias {
             harness: None,
             description: None,
+            prompting: None,
             default_effort: None,
             autocompact: None,
             autocompact_pct: None,
@@ -618,6 +624,7 @@ fn emit_all_emits_to_every_configured_target() {
         ModelAlias {
             harness: None,
             description: None,
+            prompting: None,
             default_effort: None,
             autocompact: None,
             autocompact_pct: None,
@@ -672,6 +679,7 @@ fn emit_all_ignores_authored_harness_pin_for_coverage() {
         ModelAlias {
             harness: None,
             description: None,
+            prompting: None,
             default_effort: None,
             autocompact: None,
             autocompact_pct: None,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1938,6 +1938,7 @@ override = { effort = "high" }
             ModelAlias {
                 harness: Some("codex".to_string()),
                 description: Some("base".to_string()),
+                prompting: None,
                 default_effort: None,
                 autocompact: None,
                 autocompact_pct: None,
@@ -1952,6 +1953,7 @@ override = { effort = "high" }
             ModelAlias {
                 harness: Some("claude".to_string()),
                 description: None,
+                prompting: None,
                 default_effort: None,
                 autocompact: None,
                 autocompact_pct: None,
@@ -1970,6 +1972,7 @@ override = { effort = "high" }
                     ModelAlias {
                         harness: Some("cursor".to_string()),
                         description: Some("local".to_string()),
+                        prompting: None,
                         default_effort: None,
                         autocompact: None,
                         autocompact_pct: None,
@@ -1984,6 +1987,7 @@ override = { effort = "high" }
                     ModelAlias {
                         harness: Some("pi".to_string()),
                         description: None,
+                        prompting: None,
                         default_effort: None,
                         autocompact: None,
                         autocompact_pct: None,

--- a/src/models/dependencies.rs
+++ b/src/models/dependencies.rs
@@ -141,6 +141,7 @@ mod tests {
         ModelAlias {
             harness: None,
             description: None,
+            prompting: None,
             default_effort: None,
             autocompact: None,
             autocompact_pct: None,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -52,6 +52,8 @@ pub struct ModelAlias {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompting: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub default_effort: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub autocompact: Option<u32>,
@@ -115,6 +117,8 @@ pub struct ResolvedAlias {
     pub harness_candidates: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompting: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_effort: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -198,6 +202,8 @@ struct RawModelAlias {
     harness: Option<String>,
     #[serde(default)]
     description: Option<String>,
+    #[serde(default)]
+    prompting: Option<String>,
     #[serde(default)]
     native: Option<toml::Value>,
     #[serde(default)]
@@ -315,6 +321,7 @@ impl<'de> Deserialize<'de> for ModelAlias {
         Ok(ModelAlias {
             harness: normalized_harness,
             description: raw.description,
+            prompting: raw.prompting,
             default_effort,
             autocompact,
             autocompact_pct,
@@ -1107,6 +1114,7 @@ pub fn resolve_with_alias_prefix_with_probe(
         harness_source,
         harness_candidates: harness::harness_candidates_for_provider(&provider),
         description: winner.description,
+        prompting: base_alias.and_then(|a| a.prompting.clone()),
         default_effort,
         autocompact,
         autocompact_pct,
@@ -1266,6 +1274,7 @@ pub fn builtin_aliases() -> IndexMap<String, ModelAlias> {
             ModelAlias {
                 harness: None,
                 description: None,
+                prompting: None,
                 default_effort: None,
                 autocompact: None,
                 autocompact_pct: None,
@@ -1444,6 +1453,7 @@ pub fn resolve_all_static(
                 harness_source: HarnessSource::Unavailable,
                 harness_candidates: Vec::new(),
                 description: alias.description.clone(),
+                prompting: alias.prompting.clone(),
                 default_effort: alias.default_effort.clone(),
                 autocompact: alias.autocompact,
                 autocompact_pct: alias.autocompact_pct,
@@ -1493,6 +1503,7 @@ pub fn resolve_all_with_probe(
                 harness_source: source,
                 harness_candidates: candidates,
                 description: alias.description.clone(),
+                prompting: alias.prompting.clone(),
                 default_effort: alias.default_effort.clone(),
                 autocompact: alias.autocompact,
                 autocompact_pct: alias.autocompact_pct,
@@ -1555,6 +1566,7 @@ pub fn resolve_one_with_probe(
         harness_source,
         harness_candidates: candidates,
         description: alias.description.clone(),
+        prompting: alias.prompting.clone(),
         default_effort: alias.default_effort.clone(),
         autocompact: alias.autocompact,
         autocompact_pct: alias.autocompact_pct,
@@ -2135,6 +2147,7 @@ mod tests {
         ModelAlias {
             harness: harness.map(|h| h.to_string()),
             description: None,
+            prompting: None,
             default_effort: None,
             autocompact: None,
             autocompact_pct: None,
@@ -2153,6 +2166,7 @@ mod tests {
         ModelAlias {
             harness: None,
             description: None,
+            prompting: None,
             default_effort: None,
             autocompact: None,
             autocompact_pct: None,
@@ -2173,6 +2187,7 @@ mod tests {
         ModelAlias {
             harness: None,
             description: None,
+            prompting: None,
             default_effort: None,
             autocompact: None,
             autocompact_pct: None,
@@ -2725,6 +2740,7 @@ mod tests {
             ModelAlias {
                 harness: None,
                 description: None,
+                prompting: None,
                 default_effort: None,
                 autocompact: None,
                 autocompact_pct: None,
@@ -2759,6 +2775,7 @@ mod tests {
             ModelAlias {
                 harness: Some("missing-harness-xyz".to_string()),
                 description: None,
+                prompting: None,
                 default_effort: None,
                 autocompact: None,
                 autocompact_pct: None,
@@ -2791,6 +2808,7 @@ mod tests {
             ModelAlias {
                 harness: Some("claude".to_string()),
                 description: None,
+                prompting: None,
                 default_effort: None,
                 autocompact: None,
                 autocompact_pct: None,
@@ -2861,6 +2879,7 @@ mod tests {
             harness_source: HarnessSource::Explicit,
             harness_candidates: vec!["codex".to_string()],
             description: None,
+            prompting: None,
             default_effort: None,
             autocompact: None,
             autocompact_pct: None,
@@ -3004,6 +3023,7 @@ mod tests {
         let alias = ModelAlias {
             harness: None,
             description: None,
+            prompting: None,
             default_effort: None,
             autocompact: None,
             autocompact_pct: None,
@@ -3029,6 +3049,7 @@ mod tests {
         let alias = ModelAlias {
             harness: None,
             description: None,
+            prompting: None,
             default_effort: None,
             autocompact: None,
             autocompact_pct: None,
@@ -3054,6 +3075,7 @@ mod tests {
         let alias = ModelAlias {
             harness: None,
             description: None,
+            prompting: None,
             default_effort: None,
             autocompact: None,
             autocompact_pct: None,
@@ -3079,6 +3101,7 @@ mod tests {
         let alias = ModelAlias {
             harness: None,
             description: None,
+            prompting: None,
             default_effort: None,
             autocompact: None,
             autocompact_pct: None,

--- a/tests/model_prompt.rs
+++ b/tests/model_prompt.rs
@@ -1,0 +1,169 @@
+mod common;
+
+use assert_fs::TempDir;
+use assert_fs::prelude::*;
+use predicates::prelude::*;
+use serde_json::Value;
+
+use common::*;
+
+const EXPLORER_AGENT: &str = "---
+name: explorer
+description: Explores code
+model: gpt55
+---
+# Explorer
+";
+
+fn setup_model_prompt_project(dir: &TempDir) -> std::path::PathBuf {
+    let source = create_source(dir, "src", &[("explorer", EXPLORER_AGENT)], &[]);
+    let project = dir.child("proj");
+    project.create_dir_all().unwrap();
+
+    let toml = format!(
+        r#"[dependencies]
+src = {{ path = "{}" }}
+
+[models.gpt55]
+harness = "codex"
+model = "gpt-5"
+prompting = "Brief GPT with tight acceptance criteria."
+
+[models.naked]
+harness = "codex"
+model = "gpt-5"
+
+[models.explorer]
+harness = "codex"
+model = "gpt-5"
+prompting = "This model alias should lose to the agent ref."
+"#,
+        source.display().to_string().replace('\\', "/")
+    );
+    project.child("mars.toml").write_str(&toml).unwrap();
+
+    mars()
+        .args(["sync", "--root", project.path().to_str().unwrap()])
+        .assert()
+        .success();
+
+    project.to_path_buf()
+}
+
+#[test]
+fn models_prompt_json_resolves_agent_first_and_uses_agent_model_guidance() {
+    let dir = TempDir::new().unwrap();
+    let project = setup_model_prompt_project(&dir);
+
+    let output = mars()
+        .args([
+            "--json",
+            "models",
+            "prompt",
+            "explorer",
+            "--root",
+            project.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("models prompt --json must be valid JSON:\n{stdout}"));
+
+    assert_eq!(json["ref"], "explorer");
+    assert_eq!(json["ref_kind"], "agent");
+    assert_eq!(json["agent_name"], "explorer");
+    assert_eq!(json["model_alias"], "gpt55");
+    assert_eq!(json["model_name"], "gpt-5");
+    assert_eq!(json["found"], true);
+    assert_eq!(
+        json["prompting"],
+        "Brief GPT with tight acceptance criteria."
+    );
+}
+
+#[test]
+fn models_prompt_json_resolves_direct_model_alias() {
+    let dir = TempDir::new().unwrap();
+    let project = setup_model_prompt_project(&dir);
+
+    let output = mars()
+        .args([
+            "--json",
+            "models",
+            "prompt",
+            "gpt55",
+            "--root",
+            project.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("models prompt --json must be valid JSON:\n{stdout}"));
+
+    assert_eq!(json["ref"], "gpt55");
+    assert_eq!(json["ref_kind"], "model");
+    assert_eq!(json["agent_name"], Value::Null);
+    assert_eq!(json["model_alias"], "gpt55");
+    assert_eq!(json["model_name"], "gpt-5");
+    assert_eq!(json["found"], true);
+    assert_eq!(
+        json["prompting"],
+        "Brief GPT with tight acceptance criteria."
+    );
+}
+
+#[test]
+fn models_prompt_known_model_without_guidance_exits_zero_and_shows_examples() {
+    let dir = TempDir::new().unwrap();
+    let project = setup_model_prompt_project(&dir);
+
+    mars()
+        .args([
+            "models",
+            "prompt",
+            "naked",
+            "--root",
+            project.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "No prompting guidance defined for model alias `naked`.",
+        ))
+        .stdout(predicate::str::contains("mars models prompt @explorer"))
+        .stdout(predicate::str::contains("mars models prompt gpt55"));
+}
+
+#[test]
+fn models_prompt_unknown_ref_json_exits_nonzero_with_found_false() {
+    let dir = TempDir::new().unwrap();
+    let project = setup_model_prompt_project(&dir);
+
+    let output = mars()
+        .args([
+            "--json",
+            "models",
+            "prompt",
+            "missing",
+            "--root",
+            project.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("models prompt --json must be valid JSON:\n{stdout}"));
+
+    assert_eq!(json["ref"], "missing");
+    assert_eq!(json["ref_kind"], Value::Null);
+    assert_eq!(json["found"], false);
+    assert_eq!(json["prompting"], Value::Null);
+}

--- a/tests/model_prompting.rs
+++ b/tests/model_prompting.rs
@@ -157,6 +157,41 @@ fn models_prompting_json_resolves_agent_first_and_uses_agent_model_guidance() {
 }
 
 #[test]
+fn models_prompting_at_agent_ref_resolves_agent() {
+    let dir = TempDir::new().unwrap();
+    let project = setup_model_prompting_project(&dir);
+    let bin_dir = install_fake_harnesses(dir.path(), &["codex"]);
+
+    let output = mars()
+        .args([
+            "--json",
+            "models",
+            "prompting",
+            "@explorer",
+            "--root",
+            project.to_str().unwrap(),
+        ])
+        .env("PATH", replace_path_with(&bin_dir))
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("models prompting --json must be valid JSON:\n{stdout}"));
+
+    assert_eq!(json["ref"], "@explorer");
+    assert_eq!(json["ref_kind"], "agent");
+    assert_eq!(json["agent_name"], "explorer");
+    assert_eq!(json["model_alias"], "gpt55");
+    assert_eq!(json["model_name"], "gpt-5");
+    assert_eq!(
+        json["prompting"],
+        "Brief GPT with tight acceptance criteria."
+    );
+}
+
+#[test]
 fn models_prompting_json_resolves_direct_model_alias() {
     let dir = TempDir::new().unwrap();
     let project = setup_model_prompting_project(&dir);
@@ -188,6 +223,24 @@ fn models_prompting_json_resolves_direct_model_alias() {
         json["prompting"],
         "Brief GPT with tight acceptance criteria."
     );
+}
+
+#[test]
+fn models_prompt_singular_subcommand_stays_rejected() {
+    let dir = TempDir::new().unwrap();
+    let project = setup_model_prompting_project(&dir);
+
+    mars()
+        .args([
+            "models",
+            "prompt",
+            "gpt55",
+            "--root",
+            project.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unrecognized subcommand 'prompt'"));
 }
 
 #[test]

--- a/tests/model_prompting.rs
+++ b/tests/model_prompting.rs
@@ -492,6 +492,80 @@ prompting = "Wrong profile-name collision guidance."
 }
 
 #[test]
+fn models_prompting_profile_name_ref_uses_profile_name_overlay() {
+    let dir = TempDir::new().unwrap();
+    let source = create_source(
+        &dir,
+        "src",
+        &[(
+            "explorer",
+            r#"---
+name: stemmed-explorer
+model: gpt55
+---
+# Renamed explorer
+"#,
+        )],
+        &[],
+    );
+    let project = dir.child("proj");
+    project.create_dir_all().unwrap();
+    let toml = format!(
+        r#"[dependencies]
+src = {{ path = "{}" }}
+
+[agents.stemmed-explorer]
+model = "sonnet"
+
+[models.gpt55]
+harness = "codex"
+model = "gpt-5"
+prompting = "Wrong profile default guidance."
+
+[models.sonnet]
+harness = "claude"
+model = "claude-opus-4-6"
+prompting = "Use the profile-name overlay guidance."
+"#,
+        source.display().to_string().replace('\\', "/")
+    );
+    project.child("mars.toml").write_str(&toml).unwrap();
+    mars()
+        .args(["sync", "--root", project.path().to_str().unwrap()])
+        .assert()
+        .success();
+    write_cache(project.path(), sample_cached_models(), &fresh_fetched_at());
+    let bin_dir = install_fake_harnesses(dir.path(), &["codex", "claude"]);
+
+    for reference in ["stemmed-explorer", "explorer"] {
+        let output = mars()
+            .args([
+                "--json",
+                "models",
+                "prompting",
+                reference,
+                "--root",
+                project.path().to_str().unwrap(),
+            ])
+            .env("PATH", replace_path_with(&bin_dir))
+            .assert()
+            .success()
+            .get_output()
+            .clone();
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        let json: Value = serde_json::from_str(&stdout)
+            .unwrap_or_else(|_| panic!("models prompting --json must be valid JSON:\n{stdout}"));
+
+        assert_eq!(json["ref"], reference);
+        assert_eq!(json["ref_kind"], "agent");
+        assert_eq!(json["agent_name"], "stemmed-explorer");
+        assert_eq!(json["model_alias"], "sonnet");
+        assert_eq!(json["model_name"], "claude-opus-4-6");
+        assert_eq!(json["prompting"], "Use the profile-name overlay guidance.");
+    }
+}
+
+#[test]
 fn models_prompting_known_model_without_guidance_exits_zero_and_shows_examples() {
     let dir = TempDir::new().unwrap();
     let project = setup_model_prompting_project(&dir);

--- a/tests/model_prompting.rs
+++ b/tests/model_prompting.rs
@@ -2,8 +2,13 @@ mod common;
 
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
+use httpmock::prelude::*;
 use predicates::prelude::*;
 use serde_json::Value;
+use serde_json::json;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use common::*;
 
@@ -46,14 +51,80 @@ prompting = "This model alias should lose to the agent ref."
         .args(["sync", "--root", project.path().to_str().unwrap()])
         .assert()
         .success();
+    write_cache(project.path(), sample_cached_models(), &fresh_fetched_at());
 
     project.to_path_buf()
+}
+
+fn install_fake_harnesses(temp_root: &Path, harnesses: &[&str]) -> PathBuf {
+    let bin_dir = temp_root.join("harness-bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+
+    for harness in harnesses {
+        #[cfg(windows)]
+        {
+            let script = if *harness == "opencode" {
+                "@echo off\r\nif \"%~1\"==\"models\" (\r\n  echo openai/gpt-5\r\n  exit /b 0\r\n)\r\nexit /b 0\r\n"
+            } else {
+                "@echo off\r\nexit /b 0\r\n"
+            };
+            fs::write(bin_dir.join(format!("{harness}.bat")), script).unwrap();
+        }
+        #[cfg(not(windows))]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let path = bin_dir.join(harness);
+            let script = if *harness == "opencode" {
+                "#!/bin/sh\nif [ \"$1\" = \"models\" ]; then\n  printf '%s\\n' 'openai/gpt-5'\n  exit 0\nfi\nexit 0\n"
+            } else {
+                "#!/bin/sh\nexit 0\n"
+            };
+            fs::write(&path, script).unwrap();
+            let mut perms = fs::metadata(&path).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(path, perms).unwrap();
+        }
+    }
+
+    bin_dir
+}
+
+fn replace_path_with(bin_dir: &Path) -> String {
+    bin_dir.to_string_lossy().into_owned()
+}
+
+fn now_unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn write_opencode_probe_cache(cache_root: &Path, model_slugs: &[&str]) {
+    let cache_path = cache_root.join("availability").join("opencode-probe.json");
+    fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
+    let now = now_unix_secs();
+    let payload = json!({
+        "schema_version": 1,
+        "fetched_at": now,
+        "last_attempt_at": now,
+        "last_error": null,
+        "result": {
+            "providers": { "openai": true },
+            "model_slugs": model_slugs,
+            "provider_probe_success": true,
+            "model_probe_success": true,
+            "error": null
+        }
+    });
+    fs::write(cache_path, serde_json::to_vec_pretty(&payload).unwrap()).unwrap();
 }
 
 #[test]
 fn models_prompting_json_resolves_agent_first_and_uses_agent_model_guidance() {
     let dir = TempDir::new().unwrap();
     let project = setup_model_prompting_project(&dir);
+    let bin_dir = install_fake_harnesses(dir.path(), &["codex"]);
 
     let output = mars()
         .args([
@@ -64,6 +135,7 @@ fn models_prompting_json_resolves_agent_first_and_uses_agent_model_guidance() {
             "--root",
             project.to_str().unwrap(),
         ])
+        .env("PATH", replace_path_with(&bin_dir))
         .assert()
         .success()
         .get_output()
@@ -116,6 +188,254 @@ fn models_prompting_json_resolves_direct_model_alias() {
         json["prompting"],
         "Brief GPT with tight acceptance criteria."
     );
+}
+
+#[test]
+fn models_prompting_direct_auto_alias_refreshes_catalog_for_model_name() {
+    let dir = TempDir::new().unwrap();
+    let source = create_source(&dir, "src", &[("fixture", "# Fixture\n")], &[]);
+    let project = dir.child("proj");
+    project.create_dir_all().unwrap();
+    let toml = format!(
+        r#"[dependencies]
+src = {{ path = "{}" }}
+
+[models.latestgpt]
+match = ["gpt-5*"]
+provider = "OpenAI"
+prompting = "Use refreshed GPT guidance."
+"#,
+        source.display().to_string().replace('\\', "/")
+    );
+    project.child("mars.toml").write_str(&toml).unwrap();
+    mars()
+        .args([
+            "sync",
+            "--no-refresh-models",
+            "--root",
+            project.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(GET).path(API_PATH);
+        then.status(200).json_body(sample_catalog_json());
+    });
+
+    let output = mars()
+        .args([
+            "--json",
+            "models",
+            "prompting",
+            "latestgpt",
+            "--refresh-models",
+            "--root",
+            project.path().to_str().unwrap(),
+        ])
+        .env("MARS_MODELS_API_URL", server.url(API_PATH))
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("models prompting --json must be valid JSON:\n{stdout}"));
+
+    assert_eq!(json["ref_kind"], "model");
+    assert_eq!(json["model_alias"], "latestgpt");
+    assert_eq!(json["model_name"], "gpt-5");
+    assert_eq!(json["prompting"], "Use refreshed GPT guidance.");
+}
+
+#[test]
+fn models_prompting_agent_uses_model_policy_fallback_result() {
+    let dir = TempDir::new().unwrap();
+    let source = create_source(
+        &dir,
+        "src",
+        &[(
+            "reviewer",
+            r#"---
+name: reviewer
+model: gpt55
+model-policies:
+  - match:
+      alias: gpt55
+  - match:
+      alias: sonnet
+---
+# Reviewer
+"#,
+        )],
+        &[],
+    );
+    let project = dir.child("proj");
+    project.create_dir_all().unwrap();
+    let toml = format!(
+        r#"[dependencies]
+src = {{ path = "{}" }}
+
+[settings]
+targets = [".claude"]
+
+[models.gpt55]
+model = "gpt-5"
+prompting = "GPT guidance should not be used after fallback."
+
+[models.sonnet]
+model = "claude-opus-4-6"
+prompting = "Use Claude-specific review guidance."
+"#,
+        source.display().to_string().replace('\\', "/")
+    );
+    project.child("mars.toml").write_str(&toml).unwrap();
+    mars()
+        .args(["sync", "--root", project.path().to_str().unwrap()])
+        .assert()
+        .success();
+    write_cache(project.path(), sample_cached_models(), &fresh_fetched_at());
+    let bin_dir = install_fake_harnesses(dir.path(), &["claude"]);
+
+    let output = mars()
+        .args([
+            "--json",
+            "models",
+            "prompting",
+            "reviewer",
+            "--root",
+            project.path().to_str().unwrap(),
+        ])
+        .env("PATH", replace_path_with(&bin_dir))
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("models prompting --json must be valid JSON:\n{stdout}"));
+
+    assert_eq!(json["ref_kind"], "agent");
+    assert_eq!(json["model_alias"], "sonnet");
+    assert_eq!(json["model_name"], "claude-opus-4-6");
+    assert_eq!(json["prompting"], "Use Claude-specific review guidance.");
+}
+
+#[test]
+fn models_prompting_agent_does_not_use_pre_routing_token_after_model_clear() {
+    let dir = TempDir::new().unwrap();
+    let project = setup_model_prompting_project(&dir);
+    let local = r#"[agents.explorer]
+harness = "opencode"
+"#;
+    fs::write(project.join("mars.local.toml"), local).unwrap();
+    let bin_dir = install_fake_harnesses(dir.path(), &["opencode"]);
+    let cache_root = dir.path().join("mars-cache");
+    write_opencode_probe_cache(&cache_root, &["openai/not-gpt-5"]);
+
+    let output = mars()
+        .args([
+            "--json",
+            "models",
+            "prompting",
+            "explorer",
+            "--root",
+            project.to_str().unwrap(),
+        ])
+        .env("PATH", replace_path_with(&bin_dir))
+        .env("MARS_CACHE_DIR", &cache_root)
+        .env("MARS_PROBE_CACHE_TTL_SECS", "60")
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("models prompting --json must be valid JSON:\n{stdout}"));
+
+    assert_eq!(json["ref_kind"], "agent");
+    assert_eq!(json["model_alias"], Value::Null);
+    assert_eq!(json["model_name"], Value::Null);
+    assert_eq!(json["prompting"], Value::Null);
+}
+
+#[test]
+fn models_prompting_file_stem_agent_match_beats_profile_name_collision() {
+    let dir = TempDir::new().unwrap();
+    let source = create_source(
+        &dir,
+        "src",
+        &[
+            (
+                "aaa",
+                r#"---
+name: explorer
+model: sonnet
+---
+# Name collision
+"#,
+            ),
+            (
+                "explorer",
+                r#"---
+name: stemmed-explorer
+model: gpt55
+---
+# Stem match
+"#,
+            ),
+        ],
+        &[],
+    );
+    let project = dir.child("proj");
+    project.create_dir_all().unwrap();
+    let toml = format!(
+        r#"[dependencies]
+src = {{ path = "{}" }}
+
+[models.gpt55]
+harness = "codex"
+model = "gpt-5"
+prompting = "Use the stem-matched agent model."
+
+[models.sonnet]
+harness = "claude"
+model = "claude-opus-4-6"
+prompting = "Wrong profile-name collision guidance."
+"#,
+        source.display().to_string().replace('\\', "/")
+    );
+    project.child("mars.toml").write_str(&toml).unwrap();
+    mars()
+        .args(["sync", "--root", project.path().to_str().unwrap()])
+        .assert()
+        .success();
+    write_cache(project.path(), sample_cached_models(), &fresh_fetched_at());
+    let bin_dir = install_fake_harnesses(dir.path(), &["codex", "claude"]);
+
+    let output = mars()
+        .args([
+            "--json",
+            "models",
+            "prompting",
+            "explorer",
+            "--root",
+            project.path().to_str().unwrap(),
+        ])
+        .env("PATH", replace_path_with(&bin_dir))
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("models prompting --json must be valid JSON:\n{stdout}"));
+
+    assert_eq!(json["ref_kind"], "agent");
+    assert_eq!(json["agent_name"], "stemmed-explorer");
+    assert_eq!(json["model_alias"], "gpt55");
+    assert_eq!(json["prompting"], "Use the stem-matched agent model.");
 }
 
 #[test]

--- a/tests/model_prompting.rs
+++ b/tests/model_prompting.rs
@@ -15,7 +15,7 @@ model: gpt55
 # Explorer
 ";
 
-fn setup_model_prompt_project(dir: &TempDir) -> std::path::PathBuf {
+fn setup_model_prompting_project(dir: &TempDir) -> std::path::PathBuf {
     let source = create_source(dir, "src", &[("explorer", EXPLORER_AGENT)], &[]);
     let project = dir.child("proj");
     project.create_dir_all().unwrap();
@@ -51,15 +51,15 @@ prompting = "This model alias should lose to the agent ref."
 }
 
 #[test]
-fn models_prompt_json_resolves_agent_first_and_uses_agent_model_guidance() {
+fn models_prompting_json_resolves_agent_first_and_uses_agent_model_guidance() {
     let dir = TempDir::new().unwrap();
-    let project = setup_model_prompt_project(&dir);
+    let project = setup_model_prompting_project(&dir);
 
     let output = mars()
         .args([
             "--json",
             "models",
-            "prompt",
+            "prompting",
             "explorer",
             "--root",
             project.to_str().unwrap(),
@@ -70,7 +70,7 @@ fn models_prompt_json_resolves_agent_first_and_uses_agent_model_guidance() {
         .clone();
     let stdout = String::from_utf8(output.stdout).unwrap();
     let json: Value = serde_json::from_str(&stdout)
-        .unwrap_or_else(|_| panic!("models prompt --json must be valid JSON:\n{stdout}"));
+        .unwrap_or_else(|_| panic!("models prompting --json must be valid JSON:\n{stdout}"));
 
     assert_eq!(json["ref"], "explorer");
     assert_eq!(json["ref_kind"], "agent");
@@ -85,15 +85,15 @@ fn models_prompt_json_resolves_agent_first_and_uses_agent_model_guidance() {
 }
 
 #[test]
-fn models_prompt_json_resolves_direct_model_alias() {
+fn models_prompting_json_resolves_direct_model_alias() {
     let dir = TempDir::new().unwrap();
-    let project = setup_model_prompt_project(&dir);
+    let project = setup_model_prompting_project(&dir);
 
     let output = mars()
         .args([
             "--json",
             "models",
-            "prompt",
+            "prompting",
             "gpt55",
             "--root",
             project.to_str().unwrap(),
@@ -104,7 +104,7 @@ fn models_prompt_json_resolves_direct_model_alias() {
         .clone();
     let stdout = String::from_utf8(output.stdout).unwrap();
     let json: Value = serde_json::from_str(&stdout)
-        .unwrap_or_else(|_| panic!("models prompt --json must be valid JSON:\n{stdout}"));
+        .unwrap_or_else(|_| panic!("models prompting --json must be valid JSON:\n{stdout}"));
 
     assert_eq!(json["ref"], "gpt55");
     assert_eq!(json["ref_kind"], "model");
@@ -119,14 +119,14 @@ fn models_prompt_json_resolves_direct_model_alias() {
 }
 
 #[test]
-fn models_prompt_known_model_without_guidance_exits_zero_and_shows_examples() {
+fn models_prompting_known_model_without_guidance_exits_zero_and_shows_examples() {
     let dir = TempDir::new().unwrap();
-    let project = setup_model_prompt_project(&dir);
+    let project = setup_model_prompting_project(&dir);
 
     mars()
         .args([
             "models",
-            "prompt",
+            "prompting",
             "naked",
             "--root",
             project.to_str().unwrap(),
@@ -136,20 +136,20 @@ fn models_prompt_known_model_without_guidance_exits_zero_and_shows_examples() {
         .stdout(predicate::str::contains(
             "No prompting guidance defined for model alias `naked`.",
         ))
-        .stdout(predicate::str::contains("mars models prompt @explorer"))
-        .stdout(predicate::str::contains("mars models prompt gpt55"));
+        .stdout(predicate::str::contains("mars models prompting @explorer"))
+        .stdout(predicate::str::contains("mars models prompting gpt55"));
 }
 
 #[test]
-fn models_prompt_unknown_ref_json_exits_nonzero_with_found_false() {
+fn models_prompting_unknown_ref_json_exits_nonzero_with_found_false() {
     let dir = TempDir::new().unwrap();
-    let project = setup_model_prompt_project(&dir);
+    let project = setup_model_prompting_project(&dir);
 
     let output = mars()
         .args([
             "--json",
             "models",
-            "prompt",
+            "prompting",
             "missing",
             "--root",
             project.to_str().unwrap(),
@@ -160,7 +160,7 @@ fn models_prompt_unknown_ref_json_exits_nonzero_with_found_false() {
         .clone();
     let stdout = String::from_utf8(output.stdout).unwrap();
     let json: Value = serde_json::from_str(&stdout)
-        .unwrap_or_else(|_| panic!("models prompt --json must be valid JSON:\n{stdout}"));
+        .unwrap_or_else(|_| panic!("models prompting --json must be valid JSON:\n{stdout}"));
 
     assert_eq!(json["ref"], "missing");
     assert_eq!(json["ref_kind"], Value::Null);


### PR DESCRIPTION
## Why

Agents and primaries need an on-demand way to see model-specific prompting guidance without carrying that guidance in every prompt. The first implementation could resolve model aliases directly, but agent refs needed to answer a stronger question: which model would this agent actually run as after Mars routing and policy resolution?

## Goal

`mars models prompting <ref>` should return prompting guidance for either a model alias or an agent ref. For agents, the guidance must come from the launch-resolved runnable model, not a shallow copy of frontmatter/default-model precedence.

## Summary

Adds `mars models prompting <ref>` with JSON output and agent-first resolution. Agent refs (`@agent` or bare names) resolve before model aliases, then use the canonical launch policy path (`build::policy::resolve_policy` with `PolicyInput`) so model policies, overlays, fallbacks, harness routing, and model clearing are reflected in the result.

The prompting implementation is extracted into `src/cli/models_prompting.rs`, with shared models CLI helpers in `src/cli/models_common.rs`, keeping `src/cli/models.rs` as the command dispatcher and existing list/resolve implementation.

## Resulting Behavior

Examples:

```bash
mars models prompting @explorer
mars models prompting gpt55
mars --json models prompting @gpt-dev --no-refresh-models
```

- Direct model aliases return that alias's `prompting` text when present.
- Agent refs resolve through launch policy and return prompting for the final resolved model alias.
- If routing clears/omits the model, the command does not return stale pre-routing guidance.
- Known refs with no prompting guidance exit 0 and explain where guidance would be defined.
- Unknown refs exit non-zero.
- `mars models prompt` remains rejected; the canonical command is `models prompting`.

## Changes

- Added optional `prompting` metadata to model aliases.
- Added `mars models prompting <ref>` and JSON shape: `ref`, `ref_kind`, `agent_name`, `model_alias`, `model_name`, `found`, `prompting`.
- Added `--refresh-models` / `--no-refresh-models` for prompting resolution.
- Agent-first ref resolution supports `@agent` and bare agent names.
- File-stem agent matches beat profile-name matches to stay aligned with launch-bundle semantics.
- Extracted prompting-specific CLI code into `src/cli/models_prompting.rs`.
- Added integration coverage in `tests/model_prompting.rs` for direct aliases, agent refs, collision behavior, policy fallback, model clearing, refresh-backed auto aliases, and rejected singular command spelling.

## Work Item

`model-alias-resolution` / active Meridian session work artifacts under `mellow-hollow-brood`.

## Verification

Passed during implementation and push preflight:

```bash
cargo fmt --check
cargo check
cargo clippy --all-targets -- -D warnings
cargo test --test model_prompting -- --nocapture
cargo test
cargo test -- --skip cli::version::tests::run
cargo build --release
```

Manual runtime checks included:

```bash
mars --json models prompting @gpt-dev --root /home/jimyao/gitrepos/meridian-cli --no-refresh-models
mars --json models prompting gpt55 --root /home/jimyao/gitrepos/prompts/meridian-base --no-refresh-models
mars models prompt gpt55 --root /home/jimyao/gitrepos/prompts/meridian-base
```

## Knowledge Updates

Updated durable KB/model-resolution docs through kb-lead captures:

- `kb: update model prompting resolution to reflect canonical launch policy path`
- structural follow-up from kb-maintainer review

Related prompt-package cleanup lives on a separate `meridian-base` branch (`cleanup-model-prompting-guidance`).

## Spawn Trace

- p4605 explorer — compared shortcut prompting resolution against canonical launch/sync resolution paths
- p4606 gpt-dev — implemented launch-policy-backed agent prompting resolution and pushed `1859a16`
- p4607 reviewer — found canonical agent lookup and refresh-control gaps
- p4608 prober — runtime-verified fallback, alias lookup, collision, and model-clearing behavior
- p4609 reviewer — found direct-alias refresh gap; implementation fixed it
- p4610 kb-lead — captured canonical launch-policy prompting behavior in KB
- p4612 kb-maintainer — checked KB structure and recommended/landed structural follow-ups
- p4613 gpt-dev — extracted prompting implementation into focused CLI module and pushed `199f018`

## Release Label Guide

Set one `release:*` label on this PR: `release:patch`.

## Post-Merge Automation

After merge to `main`, CI (`.github/workflows/release-on-main.yml`) will read the release label, compute the next version, promote the changelog, and publish from the generated release tag.

## Cleanup

After merge, clean merged worktrees with:

```bash
scripts/prune-worktrees.sh
```

