### PR TITLE
fix: accept agents/skills filter flags on the list subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `mars agents list` / `mars skills list` now accept their filter flags (`--mode`, `--source`, `--type`, `--model-invocable`). The filters are global, so they work on both the bare form (`mars agents --mode subagent`) and the discoverable subcommand form (`mars agents list --mode subagent`), which previously errored with "unexpected argument".
+
 ## [0.8.11] - 2026-06-21
 
 ## [0.8.10] - 2026-06-20

--- a/src/cli/agents.rs
+++ b/src/cli/agents.rs
@@ -18,11 +18,14 @@ struct AgentEntry {
 #[derive(Debug, clap::Args)]
 pub struct AgentsArgs {
     /// Filter by mode (primary or subagent).
-    #[arg(long)]
+    ///
+    /// Global so it is accepted both as `mars agents --mode ...` and on the
+    /// `list` subcommand (`mars agents list --mode ...`).
+    #[arg(long, global = true)]
     pub mode: Option<String>,
 
     /// Filter by source name.
-    #[arg(long)]
+    #[arg(long, global = true)]
     pub source: Option<String>,
 
     #[command(subcommand)]
@@ -258,4 +261,37 @@ fn path_stem(path: &std::path::Path) -> String {
         .and_then(|s| s.to_str())
         .unwrap_or("unknown")
         .to_string()
+}
+
+#[cfg(test)]
+mod filter_flag_tests {
+    use crate::cli::{Cli, Command};
+    use clap::Parser;
+
+    fn agents_args(args: &[&str]) -> super::AgentsArgs {
+        match Cli::try_parse_from(args).expect("should parse").command {
+            Command::Agents(a) => a,
+            other => panic!("expected agents command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mode_filter_populates_on_both_bare_and_list_forms() {
+        // The `list` subcommand form is the discoverable one and must work.
+        for args in [
+            ["mars", "agents", "list", "--mode", "subagent"].as_slice(),
+            ["mars", "agents", "--mode", "subagent", "list"].as_slice(),
+            ["mars", "agents", "--mode", "subagent"].as_slice(),
+        ] {
+            let parsed = agents_args(args);
+            // Value must actually populate (run_list reads args.mode), not merely parse.
+            assert_eq!(parsed.mode.as_deref(), Some("subagent"), "args: {args:?}");
+        }
+    }
+
+    #[test]
+    fn source_filter_populates_on_list_form() {
+        let parsed = agents_args(&["mars", "agents", "list", "--source", "core"]);
+        assert_eq!(parsed.source.as_deref(), Some("core"));
+    }
 }

--- a/src/cli/skills.rs
+++ b/src/cli/skills.rs
@@ -21,15 +21,18 @@ struct SkillEntry {
 #[derive(Debug, clap::Args)]
 pub struct SkillsArgs {
     /// Filter by skill type (e.g. guardrail, reference, principle).
-    #[arg(long = "type", id = "skill_type")]
+    ///
+    /// Global so it is accepted both as `mars skills --type ...` and on the
+    /// `list` subcommand (`mars skills list --type ...`).
+    #[arg(long = "type", id = "skill_type", global = true)]
     pub skill_type: Option<String>,
 
     /// Filter to model-invocable skills only.
-    #[arg(long)]
+    #[arg(long, global = true)]
     pub model_invocable: bool,
 
     /// Filter by source name.
-    #[arg(long)]
+    #[arg(long, global = true)]
     pub source: Option<String>,
 
     #[command(subcommand)]
@@ -227,4 +230,39 @@ fn dir_name(path: &std::path::Path) -> String {
         .and_then(|s| s.to_str())
         .unwrap_or("unknown")
         .to_string()
+}
+
+#[cfg(test)]
+mod filter_flag_tests {
+    use crate::cli::{Cli, Command};
+    use clap::Parser;
+
+    fn skills_args(args: &[&str]) -> super::SkillsArgs {
+        match Cli::try_parse_from(args).expect("should parse").command {
+            Command::Skills(s) => s,
+            other => panic!("expected skills command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn type_filter_populates_on_both_bare_and_list_forms() {
+        for args in [
+            ["mars", "skills", "list", "--type", "guardrail"].as_slice(),
+            ["mars", "skills", "--type", "guardrail", "list"].as_slice(),
+            ["mars", "skills", "--type", "guardrail"].as_slice(),
+        ] {
+            let parsed = skills_args(args);
+            assert_eq!(
+                parsed.skill_type.as_deref(),
+                Some("guardrail"),
+                "args: {args:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn model_invocable_flag_populates_on_list_form() {
+        let parsed = skills_args(&["mars", "skills", "list", "--model-invocable"]);
+        assert!(parsed.model_invocable);
+    }
 }


### PR DESCRIPTION
## Why
`mars agents list --mode subagent` — the natural, discoverable form — was
rejected by clap with `unexpected argument '--mode' found`. The filter flags
were declared only on the parent `mars agents` / `mars skills`, so they parsed
solely *before* the `list` token (`mars agents --mode subagent`). A caller
reaching for the subcommand form (a human, or meridian-cli's
`mars_agent_subagents` / `mars_list_subagents` helpers) hits the wall. Surfaced
while wiring meridian's `spawn subagents` command to mars inventory.

## Goal
Both invocation forms accept the same filter flags, with `list` as the semantic
owner and bare `mars agents` / `mars skills` as a plain alias.

## Summary
Mark the agents/skills filter flags `global = true` — the same mechanism the
top-level `--root` / `--json` already use:
- agents: `--mode`, `--source`
- skills: `--type`, `--model-invocable`, `--source`

clap then accepts them at both levels and propagates the value to the `list`
(and `show`) subcommands, populating the same field `run_list` already reads —
no dispatch changes. Bare `mars agents` stays an alias of `mars agents list`;
nothing deprecated.

## Resulting Behavior
- `mars agents list --mode subagent` ✓ (was: `unexpected argument`)
- `mars agents --mode subagent` ✓ (unchanged)
- `mars agents --mode subagent list` ✓
- Same for `mars skills list --type guardrail`, `--source`, `--model-invocable`.

## Changes
- `src/cli/agents.rs`, `src/cli/skills.rs` — `global = true` on the filter args;
  parser-level regression tests (`filter_flag_tests`) asserting the value
  *populates* (not merely parses) on bare + `list` + interleaved forms.
- `CHANGELOG.md` — `[Unreleased]` Fixed entry.

## Work Item
inheritable-launch-surface (meridian-cli) — mars-side follow-up.

## Verification
- `cargo build` — clean
- `cargo clippy --tests` — clean
- `cargo fmt --check` — clean
- `cargo test` — all pass (1325 core + suites); new `filter_flag_tests` green
- Real binary: previously-rejected forms now parse to a config error, not a
  clap usage error.

## Knowledge Updates
`CHANGELOG.md` only. Behavior is now consistent with `--root`/`--json` global
semantics; no separate docs needed.

## Spawn Trace
- Direct implementation (no subagents spawned for this fix).

## Release Label
`release:patch` — additive flag-acceptance fix, backward compatible (bare form
unchanged).