### PR TITLE
ci: harden PyPI release stage against transient flakes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,23 @@ jobs:
   pypi-wheels:
     name: Build PyPI wheels (${{ matrix.target }})
     runs-on: ${{ matrix.runner }}
+    env:
+      # crates.io downloads have intermittently failed with HTTP/2 framing
+      # errors ("[16] Error in the HTTP2 framing layer") during maturin's
+      # `cargo metadata`. Force HTTP/1.1 and raise the retry count. These are
+      # CARGO_*-prefixed, which maturin-action forwards into the manylinux
+      # build container automatically.
+      CARGO_HTTP_MULTIPLEXING: "false"
+      CARGO_NET_RETRY: "10"
     strategy:
+      # Releases are infrequent and gated on full preflight (fmt/clippy/test/
+      # build) before the tag exists, so a wheel-leg failure here is an
+      # infra/network flake, never broken code. Don't cancel the sibling legs:
+      # cancellation buries the one real failure under "cancelled" noise and
+      # balloons the `gh run rerun --failed` surface (which re-runs cancelled
+      # jobs too). PyPI publish is gated on all legs regardless, so letting
+      # them finish costs only cheap CI minutes.
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
@@ -217,6 +233,10 @@ jobs:
   pypi-sdist:
     name: Build PyPI sdist
     runs-on: ubuntu-latest
+    env:
+      # Same crates.io HTTP/2 flake mitigation as pypi-wheels.
+      CARGO_HTTP_MULTIPLEXING: "false"
+      CARGO_NET_RETRY: "10"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -256,6 +276,12 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist
+          # Make the publish rerunnable. If a prior attempt uploaded some files
+          # for this version (or a sibling channel split a release), `gh run
+          # rerun --failed` should complete cleanly instead of erroring on
+          # already-present artifacts. Matches the already-published guards npm
+          # and cargo publish already have.
+          skip-existing: true
 
   github-release:
     name: GitHub Release


### PR DESCRIPTION
## Why

The `v0.8.12` release stalled in the PyPI stage. One wheel leg
(`aarch64-unknown-linux-gnu`) hit a transient crates.io download error during
maturin's `cargo metadata`:

```
download of an/st/anstream failed
curl failed: [16] Error in the HTTP2 framing layer
💥 maturin failed
```

Matrix `fail-fast` (default `true`) then cancelled the sibling x86_64 wheel
legs and skipped `Publish PyPI`. Two `gh run rerun --failed` attempts were
needed to land — cancellation had inflated the retry surface, so a second
flake/cancel bit the retry too. Meanwhile crate, npm, and GitHub Release had
already published, leaving PyPI behind on the same version.

## Goal

The PyPI release stage shrugs off transient registry/network flakes: one leg's
hiccup neither cancels its siblings nor forces a manual multi-attempt rerun,
and a rerun completes cleanly instead of erroring on already-uploaded files.

## Summary

Three scoped changes to `.github/workflows/release.yml`:

- **`fail-fast: false`** on the `pypi-wheels` matrix — a single leg's flake no
  longer cancels the others. `pypi-publish` is gated on all legs (`needs:`)
  regardless, so atomicity is unchanged; this only stops cancellation from
  burying the one real failure under "cancelled" noise and bloating
  `rerun --failed` (which re-runs cancelled jobs too).
- **`CARGO_HTTP_MULTIPLEXING=false` + `CARGO_NET_RETRY=10`** on the wheel/sdist
  build `env:` — forces HTTP/1.1 (sidesteps the exact HTTP/2 framing error) and
  raises cargo's retry count. `CARGO_*` vars are forwarded into the manylinux
  container automatically by maturin-action's prefix allowlist, so they reach
  the environment that actually flaked.
- **`skip-existing: true`** on the PyPI publish — makes the publish rerunnable,
  matching the already-published guards npm and cargo publish already have.

## Resulting Behavior

- A flaky wheel leg retries in-place (cargo) and, if it still fails, leaves its
  siblings green — so `rerun --failed` re-runs just the one leg.
- Re-running a partially-published release no longer errors on existing PyPI
  artifacts.
- No change to what gets published or to release atomicity.

## Changes

- `.github/workflows/release.yml`: `pypi-wheels` (`fail-fast: false`, build
  env), `pypi-sdist` (build env), `pypi-publish` (`skip-existing: true`).
- Deliberately **not** included: `--locked` on the maturin build args (marginal
  benefit — the tag checkout already pins a committed `Cargo.lock` — and not
  locally verifiable, so not worth the all-platforms-break risk in a release
  path) and an all-channel barrier job (we keep the existing split-release model
  on purpose; see below).

**Design note — split releases are intentional.** Release tags are created only
after `scripts/preflight.sh full` (fmt/clippy/test/build) passes, so a failure
in this tag-triggered workflow is always infra/network, never broken code. A
channel split therefore only ever means "catch the lagging channel up," which
per-channel idempotency (this PR) handles — no all-or-nothing barrier needed.

## Work Item

inheritable-launch-surface

## Verification

- `actionlint .github/workflows/release.yml` → clean (exit 0).
- Root cause confirmed from the failed run's logs (HTTP/2 framing error in
  `cargo metadata`) and job graph (fail-fast cancellation → `pypi-publish`
  skipped).
- maturin-action `CARGO_*` container forwarding confirmed against its source
  (`ALLOWED_ENV_PREFIXES` includes `CARGO_`; only `CARGO_HOME` is excluded).
- `v0.8.12` itself is already fully published on all channels (resolved by a
  clean `rerun --failed`); this PR prevents the manual-rerun toil next time.

## Knowledge Updates

None — CI-internal resilience change, no user-facing behavior or new concepts.

## Spawn Trace

- p4668 reviewer — adversarial review of the fail-fast/retry decision; surfaced
  the cross-channel split and PyPI-not-rerun-safe findings this PR acts on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)