### PR TITLE
Lowering fidelity: faithful Cursor/Codex/OpenCode skill+agent mappings + consequence-tiered lossiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Cursor skill `model-invocable` now maps to native rule modes — `true`/default → Apply Intelligently (`alwaysApply: false` + `description`), explicit `false` → Manual (`alwaysApply: false`, no `description`) — instead of the old `alwaysApply: true` (which forced always-on context) and silent drop on `false`.
+- Codex skills with explicit `model-invocable: true` no longer emit a spurious dropped-field warning — Codex is model-invocable by default, so explicit-true loses nothing.
+- Lossiness warnings are tiered by behavioral consequence: launch-time/meridian-enforced agent fields (`approval`, `sandbox`, `mode`, `model-policies`, `autocompact`, `fanout`, …) are no longer warned per-agent — they collapse into one summary line, since Meridian applies them at spawn. Genuine target-enforced losses stay loud. `--verbose` restores full per-item detail.
+- Inbound lift no longer infers `user-invocable: false` from an OpenCode agent's `mode` (the axes are independent now that `mode` lowers exactly).
+- Inbound lift round-trips Cursor Manual skills: an `alwaysApply: false` rule with no `description` restores canonical `model-invocable: false` (and re-emits the Codex `openai.yaml` sibling) instead of erroring.
+
+### Added
+- Codex `openai.yaml` sibling (`policy.allow_implicit_invocation: false`) emitted for skills with explicit `model-invocable: false` — closes the Codex skill-invocation gating gap (#116). `LoweredOutput` now carries `siblings` written atomically alongside the primary artifact.
+- OpenCode agents emit native `mode: primary|subagent` instead of approximate lossiness.
+- `when_to_use` folds into native `description` for Cursor / OpenCode / Codex (which use `description` as the selection hook) instead of being dropped.
+- `LossinessMode::Verbose` plus a `--verbose` flag on `sync` / `check` to surface meridian-only/launch-time field detail.
+
+### Changed
+- Skill `description` is required only at authored-source validation (MarsNative staging + `mars check`); canonical re-parse tolerates an absent description so lifted Cursor Manual imports stay valid without a fabricated description.
+- **Breaking (Cursor output):** Cursor skill `.mdc` frontmatter changes (`alwaysApply`/`description` from the rule-mode + `when_to_use` mapping). Existing Cursor projections are reprojected once on next sync.
+
 ## [0.10.0] - 2026-06-24
 
 ### Fixed

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
+use crate::dialect::Dialect;
 use crate::discover;
 use crate::error::MarsError;
 use crate::frontmatter;
@@ -112,6 +113,7 @@ pub(crate) fn check_dir(base: &Path) -> Result<CheckReport, MarsError> {
     let mut warnings: Vec<String> = Vec::new();
 
     let discovered = discover::discover_resolved_source(base, None)?;
+    let dialect = Dialect::resolve_local(None, base);
 
     // ── Validate discovered agents/skills ────────────────────────────
     let mut agent_names: HashMap<String, PathBuf> = HashMap::new();
@@ -232,6 +234,13 @@ pub(crate) fn check_dir(base: &Path) -> Result<CheckReport, MarsError> {
                             &mut skill_diags,
                         ) {
                             Ok((profile, fm)) => {
+                                if dialect == Dialect::MarsNative {
+                                    crate::compiler::skills::push_authored_skill_schema_diags(
+                                        &fm,
+                                        &mut skill_diags,
+                                    );
+                                }
+
                                 let name = profile
                                     .name
                                     .clone()
@@ -272,10 +281,9 @@ pub(crate) fn check_dir(base: &Path) -> Result<CheckReport, MarsError> {
 
                                 if fm.get("description").and_then(|v| v.as_str()).is_none()
                                     && !schema_missing_description
-                                    && fm
-                                        .get(crate::compiler::skills::IMPORTED_WITHOUT_DESCRIPTION)
-                                        .and_then(|v| v.as_bool())
-                                        != Some(true)
+                                    && dialect != Dialect::MarsNative
+                                    && !(dialect == Dialect::Cursor
+                                        && crate::staging::cursor_manual_rule_shape(&fm))
                                 {
                                     warnings.push(format!("skill `{name}` has no `description`"));
                                 }

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -272,6 +272,10 @@ pub(crate) fn check_dir(base: &Path) -> Result<CheckReport, MarsError> {
 
                                 if fm.get("description").and_then(|v| v.as_str()).is_none()
                                     && !schema_missing_description
+                                    && fm
+                                        .get(crate::compiler::skills::IMPORTED_WITHOUT_DESCRIPTION)
+                                        .and_then(|v| v.as_bool())
+                                        != Some(true)
                                 {
                                     warnings.push(format!("skill `{name}` has no `description`"));
                                 }

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -21,6 +21,10 @@ use super::output;
 pub struct CheckArgs {
     /// Directory to validate as a source package (default: current directory).
     pub path: Option<PathBuf>,
+
+    /// Show per-item detail for launch-time fields handled by meridian at spawn.
+    #[arg(long)]
+    pub verbose: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -51,7 +55,7 @@ pub fn run(args: &CheckArgs, json: bool) -> Result<i32, MarsError> {
     }
 
     let report = check_dir(&base)?;
-    let lossiness = lossiness_diagnostics_for_check(&base)?;
+    let lossiness = lossiness_diagnostics_for_check(&base, args.verbose)?;
     let clean = report.errors.is_empty();
 
     if json {
@@ -89,13 +93,16 @@ pub fn run(args: &CheckArgs, json: bool) -> Result<i32, MarsError> {
 
 fn lossiness_diagnostics_for_check(
     base: &std::path::Path,
+    verbose: bool,
 ) -> Result<Vec<crate::diagnostic::Diagnostic>, MarsError> {
     use crate::diagnostic::LossinessMode;
 
-    crate::compiler::lossiness_preview::collect_source_lossiness_diagnostics(
-        base,
-        LossinessMode::Surface,
-    )
+    let mode = if verbose {
+        LossinessMode::Verbose
+    } else {
+        LossinessMode::Surface
+    };
+    crate::compiler::lossiness_preview::collect_source_lossiness_diagnostics(base, mode)
 }
 
 pub(crate) fn check_dir(base: &Path) -> Result<CheckReport, MarsError> {
@@ -569,6 +576,7 @@ mod tests {
 
         let args = super::CheckArgs {
             path: Some(dir.path().to_path_buf()),
+            verbose: false,
         };
         let code = super::run(&args, true).unwrap();
         assert_eq!(code, 0);
@@ -598,6 +606,7 @@ mod tests {
 
         let args = super::CheckArgs {
             path: Some(dir.path().to_path_buf()),
+            verbose: false,
         };
         let code = super::run(&args, true).unwrap();
         assert_eq!(code, 0);
@@ -614,6 +623,7 @@ mod tests {
 
         let args = super::CheckArgs {
             path: Some(dir.path().to_path_buf()),
+            verbose: false,
         };
         let code = super::run(&args, true).unwrap();
         assert_eq!(code, 0);

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -31,6 +31,10 @@ pub struct SyncArgs {
     /// Suppress the post-sync upgrade hint line.
     #[arg(long)]
     pub no_upgrade_hint: bool,
+
+    /// Show per-item detail for launch-time fields handled by meridian at spawn.
+    #[arg(long)]
+    pub verbose: bool,
 }
 
 /// Run `mars sync`.
@@ -47,7 +51,11 @@ pub fn run(args: &SyncArgs, ctx: &super::MarsContext, json: bool) -> Result<i32,
             no_refresh_models: args.no_refresh_models,
             check_upgrades: !no_upgrade_hint,
         },
-        lossiness_mode: crate::diagnostic::LossinessMode::Surface,
+        lossiness_mode: if args.verbose {
+            crate::diagnostic::LossinessMode::Verbose
+        } else {
+            crate::diagnostic::LossinessMode::Surface
+        },
     };
 
     let report = crate::sync::execute(ctx, &request)?;
@@ -102,5 +110,14 @@ mod tests {
             panic!("expected sync command");
         };
         assert!(args.no_upgrade_hint);
+    }
+
+    #[test]
+    fn parses_verbose() {
+        let cli = Cli::try_parse_from(["mars", "sync", "--verbose"]).unwrap();
+        let Command::Sync(args) = cli.command else {
+            panic!("expected sync command");
+        };
+        assert!(args.verbose);
     }
 }

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -15,6 +15,10 @@ pub struct UpgradeArgs {
     /// Bump direct dependency version constraints to resolved latest tags.
     #[arg(long)]
     pub bump: bool,
+
+    /// Show per-item detail for launch-time fields handled by meridian at spawn.
+    #[arg(long)]
+    pub verbose: bool,
 }
 
 /// Run `mars upgrade`.
@@ -30,7 +34,11 @@ pub fn run(args: &UpgradeArgs, ctx: &super::MarsContext, json: bool) -> Result<i
         },
         mutation: None,
         options: SyncOptions::default(),
-        lossiness_mode: crate::diagnostic::LossinessMode::Surface,
+        lossiness_mode: if args.verbose {
+            crate::diagnostic::LossinessMode::Verbose
+        } else {
+            crate::diagnostic::LossinessMode::Surface
+        },
     };
 
     let report = crate::sync::execute(ctx, &request)?;

--- a/src/compiler/agents/lower.rs
+++ b/src/compiler/agents/lower.rs
@@ -428,6 +428,49 @@ mod tests {
         assert!(text.contains("description: Reviewer"), "desc missing");
         assert!(text.contains("model: gpt55"), "model missing");
         assert!(text.contains("mode: primary"), "mode missing");
+        assert!(
+            !out.lossy_fields.iter().any(|f| f.field == "mode"),
+            "mode should be exact, not lossy: {:?}",
+            out.lossy_fields
+        );
+    }
+
+    #[test]
+    fn opencode_subagent_mode_emits_without_lossiness() {
+        let content = "---\nname: sub\ndescription: Sub\nmode: subagent\nharness: opencode\n---\n# body";
+        let (profile, fm, _) = profile_from(content);
+        let out = lower_to_opencode(&profile, fm.body(), &NativeModel::Inherit);
+        let text = String::from_utf8(out.bytes).unwrap();
+        assert!(text.contains("mode: subagent"));
+        assert!(
+            !out.lossy_fields.iter().any(|f| f.field == "mode"),
+            "mode should not be dropped or approximate: {:?}",
+            out.lossy_fields
+        );
+    }
+
+    #[test]
+    fn claude_still_drops_mode() {
+        let content = "---\nname: coder\nmode: subagent\nharness: claude\n---\n# body";
+        let (profile, fm, _) = profile_from(content);
+        let out = lower_for_harness_with_model(
+            &HarnessKind::Claude,
+            &profile,
+            &fm,
+            fm.body(),
+            &NativeModel::Inherit,
+        );
+        let text = String::from_utf8(out.bytes).unwrap();
+        assert!(!text.contains("mode:"));
+        assert!(
+            out.lossy_fields.iter().any(|f| {
+                f.field == "mode"
+                    && f.target == "Claude"
+                    && f.classification == Lossiness::Dropped
+            }),
+            "Claude should warn-drop mode: {:?}",
+            out.lossy_fields
+        );
     }
 
     #[test]

--- a/src/compiler/agents/lower.rs
+++ b/src/compiler/agents/lower.rs
@@ -134,23 +134,32 @@ mod tests {
         assert!(!text.contains("approval:"), "approval leaked: {text}");
         assert!(!text.contains("sandbox:"), "sandbox leaked: {text}");
         assert!(!text.contains("autocompact:"), "autocompact leaked: {text}");
-        // Lossiness should report dropped fields
-        let dropped: Vec<_> = out.lossy_fields.iter().map(|f| f.field.as_str()).collect();
+        // Launch-time fields are meridian-only, not target-enforced drops.
+        let meridian_only: Vec<_> = out
+            .lossy_fields
+            .iter()
+            .filter(|f| matches!(f.classification, Lossiness::MeridianOnly))
+            .map(|f| f.field.as_str())
+            .collect();
         assert!(
-            dropped.contains(&"approval"),
-            "approval not in lossy: {dropped:?}"
+            meridian_only.contains(&"approval"),
+            "approval not in lossy: {meridian_only:?}"
         );
         assert!(
-            dropped.contains(&"sandbox"),
-            "sandbox not in lossy: {dropped:?}"
+            meridian_only.contains(&"sandbox"),
+            "sandbox not in lossy: {meridian_only:?}"
         );
         assert!(
-            dropped.contains(&"autocompact"),
-            "autocompact not in lossy: {dropped:?}"
+            meridian_only.contains(&"mode"),
+            "mode not in lossy: {meridian_only:?}"
         );
         assert!(
-            dropped.contains(&"autocompact_pct"),
-            "autocompact_pct not in lossy: {dropped:?}"
+            meridian_only.contains(&"autocompact"),
+            "autocompact not in lossy: {meridian_only:?}"
+        );
+        assert!(
+            meridian_only.contains(&"autocompact_pct"),
+            "autocompact_pct not in lossy: {meridian_only:?}"
         );
     }
 
@@ -437,7 +446,8 @@ mod tests {
 
     #[test]
     fn opencode_subagent_mode_emits_without_lossiness() {
-        let content = "---\nname: sub\ndescription: Sub\nmode: subagent\nharness: opencode\n---\n# body";
+        let content =
+            "---\nname: sub\ndescription: Sub\nmode: subagent\nharness: opencode\n---\n# body";
         let (profile, fm, _) = profile_from(content);
         let out = lower_to_opencode(&profile, fm.body(), &NativeModel::Inherit);
         let text = String::from_utf8(out.bytes).unwrap();
@@ -450,7 +460,7 @@ mod tests {
     }
 
     #[test]
-    fn claude_still_drops_mode() {
+    fn claude_still_omits_mode_as_meridian_only() {
         let content = "---\nname: coder\nmode: subagent\nharness: claude\n---\n# body";
         let (profile, fm, _) = profile_from(content);
         let out = lower_for_harness_with_model(
@@ -466,9 +476,9 @@ mod tests {
             out.lossy_fields.iter().any(|f| {
                 f.field == "mode"
                     && f.target == "Claude"
-                    && f.classification == Lossiness::Dropped
+                    && f.classification == Lossiness::MeridianOnly
             }),
-            "Claude should warn-drop mode: {:?}",
+            "Claude mode is launch-time meridian-only: {:?}",
             out.lossy_fields
         );
     }

--- a/src/compiler/agents/lower_policy.rs
+++ b/src/compiler/agents/lower_policy.rs
@@ -265,7 +265,7 @@ const CLAUDE_AGENT_POLICY: AgentLoweringPolicy = AgentLoweringPolicy {
 const OPENCODE_AGENT_POLICY: AgentLoweringPolicy = AgentLoweringPolicy {
     target_name: "OpenCode",
     description: DescriptionPolicy::Preserve,
-    mode_note: Some("OpenCode uses the same mode concept"),
+    mode_note: None,
     fields: &[
         AgentMarkdownField::Identity,
         AgentMarkdownField::Model,

--- a/src/compiler/agents/lower_policy.rs
+++ b/src/compiler/agents/lower_policy.rs
@@ -12,6 +12,11 @@ use crate::compiler::harness_descriptor::{self, AgentLoweringPolicyKind};
 /// - **meridian-only** — consumed exclusively by Meridian; never lowered
 ///
 /// Dropped fields with non-default values emit [`LossyField`] diagnostics.
+///
+/// Launch-time fields (approval, sandbox, mode where not emitted, autocompact, …) are
+/// classified [`Lossiness::MeridianOnly`] — Meridian enforces them at spawn, so omitting
+/// them from native artifacts is not a behavioral loss. Target-enforced gaps stay
+/// [`Lossiness::Dropped`] or [`Lossiness::Approximate`] and warn loudly.
 pub use crate::compiler::lossiness::{Lossiness, LossyField, LoweredOutput};
 use crate::compiler::mcp_ref::{McpRef, McpUnsupportedReason, project_mcp_refs_for_emission};
 use crate::compiler::tool_names::{ToolProjectionStatus, project_tool_for_harness};
@@ -472,7 +477,7 @@ impl<'a> AgentLoweringCtx<'a> {
             AgentLossinessStep::Approval => self.record_approval(),
             AgentLossinessStep::Sandbox => self.record_sandbox(),
             AgentLossinessStep::ModeDropped => {
-                self.record_if_present("mode", self.profile.mode.is_some(), Lossiness::Dropped)
+                self.record_if_present("mode", self.profile.mode.is_some(), Lossiness::MeridianOnly)
             }
             AgentLossinessStep::ToolsDropped => {
                 self.record_if_present("tools", !self.eff.tools().is_empty(), Lossiness::Dropped)
@@ -520,11 +525,13 @@ impl<'a> AgentLoweringCtx<'a> {
             return;
         };
         let classification = if self.harness == HarnessKind::Cursor {
+            // Cursor maps approval to CLI flags — approximate, target-enforced gap.
             Lossiness::Approximate {
                 note: "auto maps to --force, yolo to --yolo; confirm has no Cursor equivalent and falls back to default",
             }
         } else {
-            Lossiness::Dropped
+            // Launch-time: Meridian applies approval at spawn via harness projection.
+            Lossiness::MeridianOnly
         };
         self.lossy.push(LossyField {
             field: "approval".into(),
@@ -538,11 +545,13 @@ impl<'a> AgentLoweringCtx<'a> {
             return;
         };
         let classification = if self.harness == HarnessKind::Cursor {
+            // Cursor sandbox is a coarse enabled/disabled mapping — target-enforced gap.
             Lossiness::Approximate {
                 note: "Cursor only supports enabled/disabled; workspace-write and danger-full-access both map to disabled",
             }
         } else {
-            Lossiness::Dropped
+            // Launch-time: Meridian applies sandbox at spawn via harness projection.
+            Lossiness::MeridianOnly
         };
         self.lossy.push(LossyField {
             field: "sandbox".into(),
@@ -725,7 +734,7 @@ pub fn lower_to_codex(
         lossy.push(LossyField {
             field: "mode".into(),
             target: target.into(),
-            classification: Lossiness::Dropped,
+            classification: Lossiness::MeridianOnly,
         });
     }
     if profile.autocompact.is_some() {

--- a/src/compiler/agents/lower_policy.rs
+++ b/src/compiler/agents/lower_policy.rs
@@ -593,6 +593,7 @@ impl<'a> AgentLoweringCtx<'a> {
         LoweredOutput {
             bytes: render_markdown(self.yaml, body),
             lossy_fields: self.lossy,
+            siblings: Vec::new(),
         }
     }
 }
@@ -797,6 +798,7 @@ pub fn lower_to_codex(
     LoweredOutput {
         bytes: out.into_bytes(),
         lossy_fields: lossy,
+        siblings: Vec::new(),
     }
 }
 

--- a/src/compiler/lossiness.rs
+++ b/src/compiler/lossiness.rs
@@ -23,12 +23,22 @@ pub enum Lossiness {
     MeridianOnly,
 }
 
+/// A secondary artifact emitted alongside the primary lowered file (e.g. Codex `openai.yaml`).
+#[derive(Debug, Clone)]
+pub struct LoweredSibling {
+    /// Path relative to the skill directory root (e.g. `openai.yaml`).
+    pub rel_path: String,
+    pub bytes: Vec<u8>,
+}
+
 /// Output from a single lowering pass.
 pub struct LoweredOutput {
     /// Serialized bytes for the native artifact.
     pub bytes: Vec<u8>,
     /// Lossiness findings for fields that were dropped or approximated.
     pub lossy_fields: Vec<LossyField>,
+    /// Extra files written next to the primary artifact (skills only today).
+    pub siblings: Vec<LoweredSibling>,
 }
 
 fn target_label(target: &str) -> String {

--- a/src/compiler/lossiness.rs
+++ b/src/compiler/lossiness.rs
@@ -2,6 +2,10 @@
 //!
 //! Lowerers record per-field [`LossyField`] entries; callers aggregate by
 //! `(item, target)` before emitting so re-sync does not spam one line per field.
+//!
+//! **Consequence tiers:** target-enforced losses (`Dropped`, `Approximate`) warn loudly
+//! in default `Surface` mode. Launch-time fields enforced by Meridian at spawn
+//! (`MeridianOnly`) roll into one summary line unless `--verbose` is set.
 
 use std::collections::BTreeMap;
 
@@ -87,7 +91,7 @@ fn emit_item_lossiness_warnings(
     item_kind: &str,
     item_name: &str,
     dropped_code: &'static str,
-    meridian_code: &'static str,
+    _meridian_code: &'static str,
     approximate_code: &'static str,
     lossy_fields: &[LossyField],
     diag: &mut DiagnosticCollector,
@@ -130,14 +134,11 @@ fn emit_item_lossiness_warnings(
         dropped_by_target,
         diag,
     );
-    emit_grouped_warnings(
-        item_kind,
-        item_name,
-        meridian_code,
-        "not lowered (meridian-only)",
-        meridian_by_target,
-        diag,
-    );
+    for (target, fields) in meridian_by_target {
+        for field in fields {
+            diag.record_meridian_only_field(item_kind, item_name, &target, &field);
+        }
+    }
 }
 
 fn emit_grouped_warnings(
@@ -250,5 +251,73 @@ mod tests {
         let warnings = diag.drain();
         assert_eq!(warnings.len(), 1);
         assert_eq!(warnings[0].code, "agent-field-approximate");
+    }
+
+    #[test]
+    fn meridian_only_surface_emits_summary_not_per_item() {
+        let lossy = vec![LossyField {
+            field: "approval".into(),
+            target: "Claude".into(),
+            classification: Lossiness::MeridianOnly,
+        }];
+        let mut diag = DiagnosticCollector::with_lossiness_mode(LossinessMode::Surface);
+        emit_agent_lossiness_warnings("coder", &lossy, &mut diag);
+        let warnings = diag.drain();
+        assert!(
+            !warnings
+                .iter()
+                .any(|d| d.code == "agent-field-meridian-only"),
+            "surface must not emit per-item meridian-only warnings"
+        );
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].code, "launch-time-field-summary");
+        assert!(
+            warnings[0]
+                .message
+                .contains("launch-time field mapping handled by meridian at spawn")
+        );
+    }
+
+    #[test]
+    fn meridian_only_verbose_emits_per_item_detail() {
+        let lossy = vec![
+            LossyField {
+                field: "approval".into(),
+                target: "Claude".into(),
+                classification: Lossiness::MeridianOnly,
+            },
+            LossyField {
+                field: "sandbox".into(),
+                target: "Claude".into(),
+                classification: Lossiness::MeridianOnly,
+            },
+        ];
+        let mut diag = DiagnosticCollector::with_lossiness_mode(LossinessMode::Verbose);
+        emit_agent_lossiness_warnings("coder", &lossy, &mut diag);
+        let warnings = diag.drain();
+        assert!(
+            !warnings
+                .iter()
+                .any(|d| d.code == "launch-time-field-summary"),
+            "verbose must not emit summary line"
+        );
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].code, "agent-field-meridian-only");
+        assert!(warnings[0].message.contains("approval"));
+        assert!(warnings[0].message.contains("sandbox"));
+    }
+
+    #[test]
+    fn dropped_warnings_stay_loud_in_surface_mode() {
+        let lossy = vec![LossyField {
+            field: "user-invocable".into(),
+            target: "Claude".into(),
+            classification: Lossiness::Dropped,
+        }];
+        let mut diag = DiagnosticCollector::with_lossiness_mode(LossinessMode::Surface);
+        emit_skill_lossiness_warnings("planning", &lossy, &mut diag);
+        let warnings = diag.drain();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].code, "skill-field-dropped");
     }
 }

--- a/src/compiler/lossiness_preview.rs
+++ b/src/compiler/lossiness_preview.rs
@@ -337,10 +337,44 @@ mod tests {
             collect_source_lossiness_diagnostics(dir.path(), LossinessMode::Surface).unwrap();
         assert!(
             diags.iter().any(|d| {
+                d.code == "launch-time-field-summary"
+                    && d.message.contains("launch-time field mapping")
+            }),
+            "expected meridian-only summary diagnostic: {diags:?}"
+        );
+        assert!(
+            !diags.iter().any(|d| d.code == "agent-field-meridian-only"),
+            "surface must not emit per-item meridian-only warnings: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn collect_source_lossiness_verbose_shows_meridian_only_detail() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("mars.toml"),
+            "[settings]\ntargets = [\".cursor\"]\nagent_emission = \"always\"\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(dir.path().join("agents")).unwrap();
+        std::fs::write(
+            dir.path().join("agents/worker.md"),
+            "---\nname: worker\ndescription: test\nharness-overrides:\n  cursor:\n    native-config:\n      cursor.only: true\n---\n# Worker",
+        )
+        .unwrap();
+
+        let diags =
+            collect_source_lossiness_diagnostics(dir.path(), LossinessMode::Verbose).unwrap();
+        assert!(
+            diags.iter().any(|d| {
                 d.category == Some(DiagnosticCategory::Lossiness)
                     && d.message.contains("native-config")
             }),
-            "expected lossiness diagnostic: {diags:?}"
+            "expected verbose meridian-only diagnostic: {diags:?}"
+        );
+        assert!(
+            !diags.iter().any(|d| d.code == "launch-time-field-summary"),
+            "verbose must not emit summary: {diags:?}"
         );
     }
 

--- a/src/compiler/lossiness_preview.rs
+++ b/src/compiler/lossiness_preview.rs
@@ -376,7 +376,7 @@ mod tests {
         std::fs::create_dir_all(&skill).unwrap();
         std::fs::write(
             skill.join("SKILL.md"),
-            "---\nname: demo\ndescription: d\nmodel-invocable: false\n---\n# Body\n",
+            "---\nname: demo\ndescription: d\nmodel-invocable: false\ntools: [Bash(git *)]\n---\n# Body\n",
         )
         .unwrap();
         std::fs::write(
@@ -390,10 +390,14 @@ mod tests {
         assert!(
             diags.iter().any(|d| {
                 d.category == Some(DiagnosticCategory::Lossiness)
-                    && d.message.contains("model-invocable")
+                    && d.message.contains("tools")
                     && d.message.contains(".codex")
             }),
-            "expected codex lossiness for staged skill: {diags:?}"
+            "expected codex tools lossiness for staged skill: {diags:?}"
+        );
+        assert!(
+            !diags.iter().any(|d| d.message.contains("model-invocable")),
+            "model-invocable is exact on Codex via openai.yaml sibling: {diags:?}"
         );
     }
 
@@ -461,7 +465,7 @@ mod tests {
         std::fs::create_dir_all(&flat_pkg).unwrap();
         std::fs::write(
             flat_pkg.join("SKILL.md"),
-            "---\nname: flat-skill\ndescription: flat layout\nmodel-invocable: false\n---\n# Flat\n",
+            "---\nname: flat-skill\ndescription: flat layout\nmodel-invocable: false\ntools: [Bash(git *)]\n---\n# Flat\n",
         )
         .unwrap();
         std::fs::write(
@@ -476,9 +480,9 @@ mod tests {
             diags.iter().any(|d| {
                 d.category == Some(DiagnosticCategory::Lossiness)
                     && d.message.contains("flat-skill")
-                    && d.message.contains("model-invocable")
+                    && d.message.contains("tools")
             }),
-            "expected flat-skill lossiness diagnostic, not temp dir name: {diags:?}"
+            "expected flat-skill tools lossiness diagnostic, not temp dir name: {diags:?}"
         );
         assert!(
             !diags.iter().any(|d| d.message.contains(".tmp")),

--- a/src/compiler/skills/lower.rs
+++ b/src/compiler/skills/lower.rs
@@ -388,29 +388,70 @@ mod tests {
         assert!(!has_dropped(&lowered.lossy_fields, "user-invocable", "Pi"));
     }
 
+    fn assert_folds_when_to_use(out: &str, identity_desc: &str, when_to_use: &str) {
+        assert!(!out.contains("when_to_use:"));
+        assert!(
+            out.contains(identity_desc) && out.contains(when_to_use),
+            "expected folded description containing both parts: {out}"
+        );
+        let desc_pos = out.find("description:").expect("missing description key");
+        let after_desc = &out[desc_pos..];
+        assert!(
+            after_desc.contains(identity_desc) && after_desc.contains(when_to_use),
+            "expected both strings under description: {out}"
+        );
+    }
+
     #[test]
-    fn codex_warn_drops_when_to_use_without_emitting() {
+    fn codex_folds_when_to_use_into_description() {
         let profile = parse_profile(
             "---\nname: skill\ndescription: desc\nwhen_to_use: Use for git\n---\nBody\n",
         );
         let lowered = lower_skill_to_codex(&profile, "Body\n");
         let out = String::from_utf8(lowered.bytes).unwrap();
-        assert!(!out.contains("when_to_use"));
-        assert!(has_dropped(&lowered.lossy_fields, "when_to_use", "Codex"));
+        assert_folds_when_to_use(&out, "desc", "Use for git");
+        assert!(!has_dropped(&lowered.lossy_fields, "when_to_use", "Codex"));
     }
 
     #[test]
-    fn cursor_drops_tools() {
+    fn codex_folds_when_to_use_only_into_description() {
+        let profile = parse_profile("---\nname: skill\nwhen_to_use: Use for git\n---\nBody\n");
+        let lowered = lower_skill_to_codex(&profile, "Body\n");
+        let out = String::from_utf8(lowered.bytes).unwrap();
+        assert!(out.contains("description: Use for git"));
+        assert!(!has_dropped(&lowered.lossy_fields, "when_to_use", "Codex"));
+    }
+
+    #[test]
+    fn opencode_folds_when_to_use_into_description() {
+        let profile = parse_profile(
+            "---\nname: skill\ndescription: desc\nwhen_to_use: Use for git\n---\nBody\n",
+        );
+        let lowered = lower_skill_to_opencode(&profile, "Body\n");
+        let out = String::from_utf8(lowered.bytes).unwrap();
+        assert_folds_when_to_use(&out, "desc", "Use for git");
+        assert!(!has_dropped(
+            &lowered.lossy_fields,
+            "when_to_use",
+            "OpenCode"
+        ));
+    }
+
+    #[test]
+    fn cursor_drops_tools_not_model_invocable() {
         let lowered = lower_skill_to_cursor(&profile(), "Body\n");
         let out = String::from_utf8(lowered.bytes).unwrap();
         assert!(!out.contains("disable-model-invocation"));
         assert!(!out.contains("allowed-tools"));
-        assert!(has_dropped(
+        assert!(out.contains("alwaysApply: false"));
+        assert!(!out.contains("description:"));
+        assert!(!has_dropped(
             &lowered.lossy_fields,
             "model-invocable",
             "Cursor"
         ));
-        assert_eq!(lowered.lossy_fields.len(), 2);
+        assert!(has_dropped(&lowered.lossy_fields, "tools", "Cursor"));
+        assert_eq!(lowered.lossy_fields.len(), 1);
     }
 
     #[test]
@@ -426,17 +467,80 @@ mod tests {
     }
 
     #[test]
-    fn cursor_model_true_emits_always_apply_not_claude_keys() {
+    fn cursor_intelligent_emits_always_apply_false_with_description() {
         let lowered = lower_skill_to_cursor(&explicit_true_profile(), "Body\n");
         let out = String::from_utf8(lowered.bytes).unwrap();
-        assert!(out.contains("alwaysApply: true"));
+        assert!(out.contains("alwaysApply: false"));
+        assert!(out.contains("description: desc"));
+        assert!(!out.contains("alwaysApply: true"));
         assert!(!out.contains("disable-model-invocation"));
         assert!(!out.contains("user-invocable"));
+        assert!(!has_dropped(
+            &lowered.lossy_fields,
+            "model-invocable",
+            "Cursor"
+        ));
         assert!(!has_dropped(
             &lowered.lossy_fields,
             "user-invocable",
             "Cursor"
         ));
+    }
+
+    #[test]
+    fn cursor_intelligent_default_emits_always_apply_false_with_description() {
+        let lowered = lower_skill_to_cursor(&identity_profile(), "Body\n");
+        let out = String::from_utf8(lowered.bytes).unwrap();
+        assert!(out.contains("alwaysApply: false"));
+        assert!(out.contains("description: desc"));
+        assert!(!has_dropped(
+            &lowered.lossy_fields,
+            "model-invocable",
+            "Cursor"
+        ));
+    }
+
+    #[test]
+    fn cursor_manual_strips_description() {
+        let lowered = lower_skill_to_cursor(&profile(), "Body\n");
+        let out = String::from_utf8(lowered.bytes).unwrap();
+        assert!(out.contains("alwaysApply: false"));
+        assert!(!out.contains("description:"));
+        assert!(!has_dropped(
+            &lowered.lossy_fields,
+            "model-invocable",
+            "Cursor"
+        ));
+    }
+
+    #[test]
+    fn cursor_manual_with_when_to_use_omits_description() {
+        let profile = parse_profile(
+            "---\nname: skill\ndescription: desc\nwhen_to_use: Use for git\nmodel-invocable: false\n---\nBody\n",
+        );
+        let lowered = lower_skill_to_cursor(&profile, "Body\n");
+        let out = String::from_utf8(lowered.bytes).unwrap();
+        assert!(out.contains("alwaysApply: false"));
+        assert!(!out.contains("description:"));
+        assert!(!out.contains("when_to_use"));
+        assert!(!has_dropped(&lowered.lossy_fields, "when_to_use", "Cursor"));
+        assert!(!has_dropped(
+            &lowered.lossy_fields,
+            "model-invocable",
+            "Cursor"
+        ));
+    }
+
+    #[test]
+    fn cursor_intelligent_folds_when_to_use_into_description() {
+        let profile = parse_profile(
+            "---\nname: skill\ndescription: desc\nwhen_to_use: Use for git\n---\nBody\n",
+        );
+        let lowered = lower_skill_to_cursor(&profile, "Body\n");
+        let out = String::from_utf8(lowered.bytes).unwrap();
+        assert!(out.contains("alwaysApply: false"));
+        assert_folds_when_to_use(&out, "desc", "Use for git");
+        assert!(!has_dropped(&lowered.lossy_fields, "when_to_use", "Cursor"));
     }
 
     #[test]

--- a/src/compiler/skills/lower.rs
+++ b/src/compiler/skills/lower.rs
@@ -321,12 +321,13 @@ mod tests {
     }
 
     #[test]
-    fn codex_explicit_true_warn_drops_model_invocable() {
+    fn codex_explicit_true_is_no_op() {
         let lowered = lower_skill_to_codex(&explicit_true_profile(), "Body\n");
         let out = String::from_utf8(lowered.bytes).unwrap();
         assert!(!out.contains("allow_implicit_invocation"));
         assert!(!out.contains("disable-model-invocation"));
-        assert!(has_dropped(
+        assert!(lowered.siblings.is_empty());
+        assert!(!has_dropped(
             &lowered.lossy_fields,
             "model-invocable",
             "Codex"

--- a/src/compiler/skills/lower.rs
+++ b/src/compiler/skills/lower.rs
@@ -265,18 +265,50 @@ mod tests {
     }
 
     #[test]
-    fn codex_warn_drops_model_invocable_and_tools() {
+    fn codex_emits_openai_yaml_sibling_and_warn_drops_tools() {
         let lowered = lower_skill_to_codex(&profile(), "Body\n");
         let out = String::from_utf8(lowered.bytes).unwrap();
         assert!(!out.contains("allow_implicit_invocation"));
         assert!(!out.contains("disable-model-invocation"));
         assert!(!out.contains("allowed-tools"));
-        assert!(has_dropped(
+        assert!(!has_dropped(
             &lowered.lossy_fields,
             "model-invocable",
             "Codex"
         ));
         assert!(has_dropped(&lowered.lossy_fields, "tools", "Codex"));
+        assert_eq!(lowered.siblings.len(), 1);
+        assert_eq!(lowered.siblings[0].rel_path, "openai.yaml");
+        let sibling = String::from_utf8(lowered.siblings[0].bytes.clone()).unwrap();
+        assert!(sibling.contains("allow_implicit_invocation: false"));
+    }
+
+    #[test]
+    fn codex_explicit_false_emits_openai_yaml_no_lossiness() {
+        let profile = parse_profile(
+            "---\nname: skill\ndescription: desc\nmodel-invocable: false\n---\nBody\n",
+        );
+        let lowered = lower_skill_to_codex(&profile, "Body\n");
+        assert!(!has_dropped(
+            &lowered.lossy_fields,
+            "model-invocable",
+            "Codex"
+        ));
+        assert_eq!(lowered.siblings.len(), 1);
+        let sibling = String::from_utf8(lowered.siblings[0].bytes.clone()).unwrap();
+        assert!(sibling.contains("policy:"));
+        assert!(sibling.contains("allow_implicit_invocation: false"));
+    }
+
+    #[test]
+    fn codex_default_or_absent_model_invocable_emits_no_sibling() {
+        let lowered = lower_skill_to_codex(&identity_profile(), "Body\n");
+        assert!(lowered.siblings.is_empty());
+        assert!(!has_dropped(
+            &lowered.lossy_fields,
+            "model-invocable",
+            "Codex"
+        ));
     }
 
     #[test]

--- a/src/compiler/skills/lower_policy.rs
+++ b/src/compiler/skills/lower_policy.rs
@@ -13,7 +13,7 @@ use crate::compiler::tool_names::{ToolProjectionStatus, project_tool_for_harness
 // Policy axes
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 enum ModelInvocablePolicy {
     /// Emit `disable-model-invocation: true` when `model_invocable` is false.
     EmitDisableWhenFalse,
@@ -21,8 +21,8 @@ enum ModelInvocablePolicy {
     DropWhenFalse,
     /// Warn-drop only when the source explicitly set `model-invocable` (any value).
     DropWhenExplicit,
-    /// Cursor: emit `alwaysApply: true` when explicit+true; drop when explicit+false.
-    CursorAlwaysApply,
+    /// Cursor: handled by [`LoweringStep::CursorRuleMode`], not this step.
+    CursorRuleMode,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -58,8 +58,10 @@ enum McpToolsPolicy {
 
 #[derive(Debug, Clone, Copy)]
 enum WhenToUsePolicy {
+    /// Emit native `when_to_use` (Claude, Pi).
     Emit,
-    Drop,
+    /// Fold into native `description` (Cursor Apply Intelligently, Codex, OpenCode).
+    FoldIntoDescription,
 }
 
 /// Ordered lowering phases — sequence differs per harness (lossiness order matters).
@@ -76,8 +78,8 @@ enum LoweringStep {
     WhenToUse,
     /// Pi records user-invocable lossiness after passthrough is inserted.
     UserInvocableLossinessLate,
-    /// Cursor-only `alwaysApply` hook.
-    CursorAlwaysApply,
+    /// Cursor-only rule mode: `alwaysApply` + reconcile `description` for Manual vs Intelligent.
+    CursorRuleMode,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -133,7 +135,7 @@ const CODEX_POLICY: SkillLoweringPolicy = SkillLoweringPolicy {
     allowed_tools: AllowedToolsPolicy::DropWhenNonEmpty,
     disallowed_tools: DisallowedToolsPolicy::Drop,
     mcp: McpToolsPolicy::Approximate("Codex uses -c mcp.servers.<name>.command"),
-    when_to_use: WhenToUsePolicy::Drop,
+    when_to_use: WhenToUsePolicy::FoldIntoDescription,
 };
 
 const OPENCODE_POLICY: SkillLoweringPolicy = SkillLoweringPolicy {
@@ -156,7 +158,7 @@ const OPENCODE_POLICY: SkillLoweringPolicy = SkillLoweringPolicy {
     mcp: McpToolsPolicy::Approximate(
         "MCP grants on subprocess errors; streaming uses session payload",
     ),
-    when_to_use: WhenToUsePolicy::Drop,
+    when_to_use: WhenToUsePolicy::FoldIntoDescription,
 };
 
 const PI_POLICY: SkillLoweringPolicy = SkillLoweringPolicy {
@@ -188,21 +190,21 @@ const CURSOR_POLICY: SkillLoweringPolicy = SkillLoweringPolicy {
         LoweringStep::Identity,
         LoweringStep::LicenseMetadata,
         LoweringStep::Passthrough,
-        LoweringStep::CursorAlwaysApply,
+        LoweringStep::CursorRuleMode,
         LoweringStep::AllowedTools,
         LoweringStep::DisallowedTools,
         LoweringStep::McpTools,
         LoweringStep::UserInvocable,
         LoweringStep::WhenToUse,
     ],
-    model_invocable: ModelInvocablePolicy::CursorAlwaysApply,
+    model_invocable: ModelInvocablePolicy::CursorRuleMode,
     user_invocable: UserInvocablePolicy::DropWhenDisabled,
     allowed_tools: AllowedToolsPolicy::DropWhenNonEmpty,
     disallowed_tools: DisallowedToolsPolicy::Drop,
     mcp: McpToolsPolicy::Approximate(
         "MCP grants on subprocess errors; streaming uses session payload",
     ),
-    when_to_use: WhenToUsePolicy::Drop,
+    when_to_use: WhenToUsePolicy::FoldIntoDescription,
 };
 
 fn policy_for(harness: HarnessKind) -> &'static SkillLoweringPolicy {
@@ -230,6 +232,21 @@ fn ys(s: &str) -> Value {
 // lowering, it does not need to remember whether the source field was explicit.
 fn user_invocation_disabled(profile: &SkillProfile) -> bool {
     !profile.user_invocable
+}
+
+/// Cursor Manual: explicit `model-invocable: false` — @-mention only, no auto-selection hook.
+fn cursor_manual_mode(profile: &SkillProfile) -> bool {
+    profile.had_model_invocable_field && !profile.model_invocable
+}
+
+/// Selection guidance for harnesses that fold `when_to_use` into native `description`.
+fn selection_description(profile: &SkillProfile) -> Option<String> {
+    match (&profile.description, &profile.when_to_use) {
+        (Some(desc), Some(wtu)) => Some(format!("{desc}\n\n{wtu}")),
+        (Some(desc), None) => Some(desc.clone()),
+        (None, Some(wtu)) => Some(wtu.clone()),
+        (None, None) => None,
+    }
 }
 
 fn dropped(field: &str, target: &str) -> LossyField {
@@ -293,7 +310,7 @@ impl<'a> LoweringCtx<'a> {
             LoweringStep::McpTools => self.apply_mcp(),
             LoweringStep::WhenToUse => self.apply_when_to_use(),
             LoweringStep::UserInvocableLossinessLate => self.apply_user_invocable_lossiness(),
-            LoweringStep::CursorAlwaysApply => self.apply_cursor_always_apply(),
+            LoweringStep::CursorRuleMode => self.apply_cursor_rule_mode(),
         }
     }
 
@@ -347,7 +364,7 @@ impl<'a> LoweringCtx<'a> {
                         .push(dropped("model-invocable", policy.target_name));
                 }
             }
-            ModelInvocablePolicy::CursorAlwaysApply => {}
+            ModelInvocablePolicy::CursorRuleMode => {}
         }
     }
 
@@ -523,24 +540,31 @@ impl<'a> LoweringCtx<'a> {
                     self.yaml.insert(yk("when_to_use"), ys(when_to_use));
                 }
             }
-            WhenToUsePolicy::Drop => {
-                if profile.when_to_use.is_some() {
-                    self.lossy_fields
-                        .push(dropped("when_to_use", self.policy.target_name));
+            WhenToUsePolicy::FoldIntoDescription => {
+                // Manual Cursor skills must not carry a description selection hook.
+                if self.policy.model_invocable == ModelInvocablePolicy::CursorRuleMode
+                    && cursor_manual_mode(profile)
+                {
+                    return;
+                }
+                if let Some(description) = selection_description(profile) {
+                    self.yaml.insert(yk("description"), ys(&description));
                 }
             }
         }
     }
 
-    fn apply_cursor_always_apply(&mut self) {
-        let profile = self.profile;
-        if profile.had_model_invocable_field {
-            if profile.model_invocable {
-                self.yaml.insert(yk("alwaysApply"), Value::Bool(true));
-            } else {
-                self.lossy_fields
-                    .push(dropped("model-invocable", self.policy.target_name));
-            }
+    fn apply_cursor_rule_mode(&mut self) {
+        if !self.profile.has_frontmatter {
+            return;
+        }
+        // Cursor rule modes (2026): alwaysApply + description/globs control activation.
+        // Never emit alwaysApply: true — that is Always-on, not model-invocable.
+        // Intelligent (default or explicit true): alwaysApply:false + description hook.
+        // Manual (explicit false): alwaysApply:false, strip description so Cursor won't auto-select.
+        self.yaml.insert(yk("alwaysApply"), Value::Bool(false));
+        if cursor_manual_mode(self.profile) {
+            self.yaml.remove(yk("description"));
         }
     }
 

--- a/src/compiler/skills/lower_policy.rs
+++ b/src/compiler/skills/lower_policy.rs
@@ -20,6 +20,7 @@ enum ModelInvocablePolicy {
     /// Warn-drop when `model_invocable` is false (implicit or explicit).
     DropWhenFalse,
     /// Emit sibling `openai.yaml` when source explicitly set `model-invocable: false`.
+    /// Explicit `true` and absent are no-ops: Codex defaults `allow_implicit_invocation` to true.
     EmitCodexOpenaiYamlWhenExplicitFalse,
     /// Cursor: handled by [`LoweringStep::CursorRuleMode`], not this step.
     CursorRuleMode,
@@ -359,11 +360,10 @@ impl<'a> LoweringCtx<'a> {
                 }
             }
             ModelInvocablePolicy::EmitCodexOpenaiYamlWhenExplicitFalse => {
+                // Codex skills are model-invocable by default; only explicit false needs
+                // the openai.yaml sibling to set allow_implicit_invocation: false.
                 if profile.had_model_invocable_field && !profile.model_invocable {
                     self.siblings.push(codex_openai_yaml_sibling());
-                } else if profile.had_model_invocable_field {
-                    self.lossy_fields
-                        .push(dropped("model-invocable", policy.target_name));
                 }
             }
             ModelInvocablePolicy::CursorRuleMode => {}

--- a/src/compiler/skills/lower_policy.rs
+++ b/src/compiler/skills/lower_policy.rs
@@ -4,7 +4,7 @@ use serde_yaml::{Mapping, Value};
 
 use crate::compiler::agents::HarnessKind;
 use crate::compiler::harness_descriptor::{self, SkillLoweringPolicyKind};
-use crate::compiler::lossiness::{Lossiness, LossyField, LoweredOutput};
+use crate::compiler::lossiness::{Lossiness, LossyField, LoweredOutput, LoweredSibling};
 use crate::compiler::mcp_ref::project_mcp_refs_for_emission;
 use crate::compiler::skills::SkillProfile;
 use crate::compiler::tool_names::{ToolProjectionStatus, project_tool_for_harness};
@@ -19,8 +19,8 @@ enum ModelInvocablePolicy {
     EmitDisableWhenFalse,
     /// Warn-drop when `model_invocable` is false (implicit or explicit).
     DropWhenFalse,
-    /// Warn-drop only when the source explicitly set `model-invocable` (any value).
-    DropWhenExplicit,
+    /// Emit sibling `openai.yaml` when source explicitly set `model-invocable: false`.
+    EmitCodexOpenaiYamlWhenExplicitFalse,
     /// Cursor: handled by [`LoweringStep::CursorRuleMode`], not this step.
     CursorRuleMode,
 }
@@ -130,7 +130,7 @@ const CODEX_POLICY: SkillLoweringPolicy = SkillLoweringPolicy {
         LoweringStep::UserInvocable,
         LoweringStep::WhenToUse,
     ],
-    model_invocable: ModelInvocablePolicy::DropWhenExplicit,
+    model_invocable: ModelInvocablePolicy::EmitCodexOpenaiYamlWhenExplicitFalse,
     user_invocable: UserInvocablePolicy::DropWhenDisabled,
     allowed_tools: AllowedToolsPolicy::DropWhenNonEmpty,
     disallowed_tools: DisallowedToolsPolicy::Drop,
@@ -281,6 +281,7 @@ struct LoweringCtx<'a> {
     profile: &'a SkillProfile,
     yaml: Mapping,
     lossy_fields: Vec<LossyField>,
+    siblings: Vec<LoweredSibling>,
 }
 
 impl<'a> LoweringCtx<'a> {
@@ -295,6 +296,7 @@ impl<'a> LoweringCtx<'a> {
             profile,
             yaml: Mapping::new(),
             lossy_fields: Vec::new(),
+            siblings: Vec::new(),
         }
     }
 
@@ -356,10 +358,10 @@ impl<'a> LoweringCtx<'a> {
                         .push(dropped("model-invocable", policy.target_name));
                 }
             }
-            ModelInvocablePolicy::DropWhenExplicit => {
-                if profile.had_model_invocable_field {
-                    // TODO(#116): emit Codex sibling `policy` file for faithful
-                    // invocation/tool gating — see https://github.com/haowjy/mars-agents/issues/116
+            ModelInvocablePolicy::EmitCodexOpenaiYamlWhenExplicitFalse => {
+                if profile.had_model_invocable_field && !profile.model_invocable {
+                    self.siblings.push(codex_openai_yaml_sibling());
+                } else if profile.had_model_invocable_field {
                     self.lossy_fields
                         .push(dropped("model-invocable", policy.target_name));
                 }
@@ -572,7 +574,30 @@ impl<'a> LoweringCtx<'a> {
         LoweredOutput {
             bytes: render(self.yaml, body),
             lossy_fields: self.lossy_fields,
+            siblings: self.siblings,
         }
+    }
+}
+
+fn codex_openai_yaml_sibling() -> LoweredSibling {
+    #[derive(serde::Serialize)]
+    struct Policy {
+        allow_implicit_invocation: bool,
+    }
+    #[derive(serde::Serialize)]
+    struct OpenaiYaml {
+        policy: Policy,
+    }
+    let doc = OpenaiYaml {
+        policy: Policy {
+            allow_implicit_invocation: false,
+        },
+    };
+    LoweredSibling {
+        rel_path: "openai.yaml".into(),
+        bytes: serde_yaml::to_string(&doc)
+            .expect("Codex openai.yaml policy should serialize")
+            .into_bytes(),
     }
 }
 

--- a/src/compiler/skills/mod.rs
+++ b/src/compiler/skills/mod.rs
@@ -11,9 +11,8 @@ use crate::compiler::tool_policy::{self, EffectiveToolPolicy, ParsedToolsField};
 use crate::diagnostic::{DiagnosticCategory, DiagnosticCollector};
 use crate::frontmatter::{Frontmatter, FrontmatterError};
 
-/// Staging-only marker: Cursor Manual imports cannot store a description.
-/// Consumed at parse time; never lowered to harness artifacts.
-pub(crate) const IMPORTED_WITHOUT_DESCRIPTION: &str = "mars.imported-without-description";
+/// Reserved lift-internal key; must not appear in user-authored MarsNative packages.
+const RESERVED_IMPORT_MARKER: &str = "mars.imported-without-description";
 
 #[derive(Debug, Clone)]
 pub struct SkillProfile {
@@ -109,6 +108,21 @@ impl SkillDiagnostic {
                 format!("skill frontmatter is malformed; raw fallback used: {message}")
             }
         }
+    }
+}
+
+/// Authored MarsNative skill schema: required fields and reserved keys.
+///
+/// Runs on raw source frontmatter before lift. Lifted foreign imports (e.g. Cursor
+/// Manual rules) never hit this path.
+pub(crate) fn push_authored_skill_schema_diags(fm: &Frontmatter, diags: &mut Vec<SkillDiagnostic>) {
+    if fm.has_frontmatter() {
+        validate_required_string("description", fm.get("description"), diags);
+    }
+    if fm.get(RESERVED_IMPORT_MARKER).is_some() {
+        diags.push(SkillDiagnostic::RemovedField {
+            field: RESERVED_IMPORT_MARKER.to_string(),
+        });
     }
 }
 
@@ -233,17 +247,9 @@ pub fn parse_skill_profile(fm: &Frontmatter, diags: &mut Vec<SkillDiagnostic>) -
             allowed: "string",
         });
     }
-    consumed_keys.push(IMPORTED_WITHOUT_DESCRIPTION.to_string());
-    let imported_without_description = fm
-        .get(IMPORTED_WITHOUT_DESCRIPTION)
-        .and_then(Value::as_bool)
-        == Some(true);
-
+    consumed_keys.push(RESERVED_IMPORT_MARKER.to_string());
     if fm.has_frontmatter() {
         validate_required_string("name", name_raw, diags);
-        if !imported_without_description {
-            validate_required_string("description", description_raw, diags);
-        }
     }
     consumed_keys.push("tools".to_string());
     let parsed_tools = fm
@@ -551,40 +557,48 @@ body",
     }
 
     #[test]
-    fn frontmatter_requires_name_and_description() {
+    fn frontmatter_requires_name() {
         let (_, d, _) = parse("---\nname: a\n---\nbody");
+        assert!(d.is_empty());
+        let (_, d, _) = parse("---\ndescription: b\n---\nbody");
         assert!(d.iter().any(|d| matches!(
             d,
             SkillDiagnostic::InvalidFieldValue { field, value, .. }
-                if field == "description" && value == "missing"
+                if field == "name" && value == "missing"
         )));
     }
 
     #[test]
-    fn authored_skill_without_description_still_requires_description() {
-        let (_, d, _) = parse("---\nname: a\nmodel-invocable: false\n---\nbody");
-        assert!(d.iter().any(|d| matches!(
-            d,
-            SkillDiagnostic::InvalidFieldValue { field, value, .. }
-                if field == "description" && value == "missing"
-        )));
-    }
-
-    #[test]
-    fn imported_without_description_marker_skips_description_validation() {
-        let (profile, d, _) = parse(
-            "---\nname: a\nmodel-invocable: false\nmars.imported-without-description: true\n---\nbody",
-        );
+    fn canonical_parse_allows_missing_description() {
+        let (profile, d, _) = parse("---\nname: a\nmodel-invocable: false\n---\nbody");
         assert!(d.is_empty());
         assert!(profile.description.is_none());
-        assert!(!profile.model_invocable);
-        assert!(profile.had_model_invocable_field);
-        assert!(
-            !profile
-                .passthrough_fields
-                .iter()
-                .any(|(k, _)| k == IMPORTED_WITHOUT_DESCRIPTION)
-        );
+    }
+
+    #[test]
+    fn authored_skill_requires_description() {
+        let fm = Frontmatter::parse("---\nname: a\nmodel-invocable: false\n---\nbody").unwrap();
+        let mut d = Vec::new();
+        push_authored_skill_schema_diags(&fm, &mut d);
+        assert!(d.iter().any(|d| matches!(
+            d,
+            SkillDiagnostic::InvalidFieldValue { field, value, .. }
+                if field == "description" && value == "missing"
+        )));
+    }
+
+    #[test]
+    fn authored_skill_rejects_reserved_import_marker() {
+        let fm = Frontmatter::parse(
+            "---\nname: a\ndescription: b\nmars.imported-without-description: true\n---\nbody",
+        )
+        .unwrap();
+        let mut d = Vec::new();
+        push_authored_skill_schema_diags(&fm, &mut d);
+        assert!(d.iter().any(|d| matches!(
+            d,
+            SkillDiagnostic::RemovedField { field } if field == RESERVED_IMPORT_MARKER
+        )));
     }
 
     #[test]

--- a/src/compiler/skills/mod.rs
+++ b/src/compiler/skills/mod.rs
@@ -11,6 +11,10 @@ use crate::compiler::tool_policy::{self, EffectiveToolPolicy, ParsedToolsField};
 use crate::diagnostic::{DiagnosticCategory, DiagnosticCollector};
 use crate::frontmatter::{Frontmatter, FrontmatterError};
 
+/// Staging-only marker: Cursor Manual imports cannot store a description.
+/// Consumed at parse time; never lowered to harness artifacts.
+pub(crate) const IMPORTED_WITHOUT_DESCRIPTION: &str = "mars.imported-without-description";
+
 #[derive(Debug, Clone)]
 pub struct SkillProfile {
     pub name: Option<String>,
@@ -229,9 +233,17 @@ pub fn parse_skill_profile(fm: &Frontmatter, diags: &mut Vec<SkillDiagnostic>) -
             allowed: "string",
         });
     }
+    consumed_keys.push(IMPORTED_WITHOUT_DESCRIPTION.to_string());
+    let imported_without_description = fm
+        .get(IMPORTED_WITHOUT_DESCRIPTION)
+        .and_then(Value::as_bool)
+        == Some(true);
+
     if fm.has_frontmatter() {
         validate_required_string("name", name_raw, diags);
-        validate_required_string("description", description_raw, diags);
+        if !imported_without_description {
+            validate_required_string("description", description_raw, diags);
+        }
     }
     consumed_keys.push("tools".to_string());
     let parsed_tools = fm
@@ -546,6 +558,33 @@ body",
             SkillDiagnostic::InvalidFieldValue { field, value, .. }
                 if field == "description" && value == "missing"
         )));
+    }
+
+    #[test]
+    fn authored_skill_without_description_still_requires_description() {
+        let (_, d, _) = parse("---\nname: a\nmodel-invocable: false\n---\nbody");
+        assert!(d.iter().any(|d| matches!(
+            d,
+            SkillDiagnostic::InvalidFieldValue { field, value, .. }
+                if field == "description" && value == "missing"
+        )));
+    }
+
+    #[test]
+    fn imported_without_description_marker_skips_description_validation() {
+        let (profile, d, _) = parse(
+            "---\nname: a\nmodel-invocable: false\nmars.imported-without-description: true\n---\nbody",
+        );
+        assert!(d.is_empty());
+        assert!(profile.description.is_none());
+        assert!(!profile.model_invocable);
+        assert!(profile.had_model_invocable_field);
+        assert!(
+            !profile
+                .passthrough_fields
+                .iter()
+                .any(|(k, _)| k == IMPORTED_WITHOUT_DESCRIPTION)
+        );
     }
 
     #[test]

--- a/src/compiler/variants.rs
+++ b/src/compiler/variants.rs
@@ -265,8 +265,11 @@ fn compile_projected_skill_frontmatter(
     let projected_skill = projected_dir.join("SKILL.md");
     let lowered =
         lower_projected_skill_for_harness(source, &projected_skill, harness_key, skill_name, diag)?;
-    if let Some(bytes) = lowered {
-        fs::write(projected_skill, bytes)?;
+    if let Some(lowered) = lowered {
+        fs::write(projected_skill, lowered.bytes)?;
+        for sibling in lowered.siblings {
+            fs::write(projected_dir.join(&sibling.rel_path), sibling.bytes)?;
+        }
     }
     Ok(())
 }
@@ -299,7 +302,7 @@ fn lower_projected_skill_for_harness(
     harness_key: &str,
     skill_name: &str,
     diag: &mut crate::diagnostic::DiagnosticCollector,
-) -> Result<Option<Vec<u8>>, MarsError> {
+) -> Result<Option<crate::compiler::lossiness::LoweredOutput>, MarsError> {
     use crate::compiler::skills::lower::{lower_skill_for_harness, skill_harness_from_variant_key};
     use crate::compiler::skills::parse_skill_content;
 
@@ -364,7 +367,7 @@ fn lower_projected_skill_for_harness(
         diag,
     );
 
-    Ok(Some(lowered.bytes))
+    Ok(Some(lowered))
 }
 
 fn copy_dir_following_symlinks_excluding_top_level_variants(
@@ -573,8 +576,11 @@ mod tests {
             .collect();
         assert_eq!(warnings.len(), 1);
         assert!(warnings[0].message.contains("tools"));
-        assert!(warnings[0].message.contains("model-invocable"));
+        assert!(!warnings[0].message.contains("model-invocable"));
         assert!(warnings[0].message.contains(".codex"));
+
+        let openai_yaml = std::fs::read_to_string(dest.join("openai.yaml")).unwrap();
+        assert!(openai_yaml.contains("allow_implicit_invocation: false"));
     }
 
     #[test]

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -33,14 +33,29 @@ pub enum LossinessMode {
     /// Suppress lossiness warnings (validate, export, add, repair, …).
     #[default]
     Hidden,
-    /// Surface lossiness warnings (sync, upgrade, check, init).
+    /// Surface consequential lossiness warnings plus one meridian-only summary line.
     Surface,
+    /// Surface all lossiness warnings, including per-item meridian-only detail.
+    Verbose,
 }
 
 impl LossinessMode {
     pub fn surfaces_lossiness(self) -> bool {
-        matches!(self, LossinessMode::Surface)
+        matches!(self, LossinessMode::Surface | LossinessMode::Verbose)
     }
+
+    pub fn shows_meridian_only_detail(self) -> bool {
+        matches!(self, LossinessMode::Verbose)
+    }
+}
+
+/// One launch-time field omitted from a native artifact but enforced by Meridian at spawn.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MeridianOnlyRecord {
+    item_kind: String,
+    item_name: String,
+    target: String,
+    field: String,
 }
 
 /// Broad category for a diagnostic — used in structured output and validation gates.
@@ -61,6 +76,8 @@ pub enum DiagnosticCategory {
 pub struct DiagnosticCollector {
     diagnostics: Vec<Diagnostic>,
     lossiness_mode: LossinessMode,
+    /// Launch-time / meridian-enforced field mappings accumulated for summary or verbose detail.
+    meridian_only_records: Vec<MeridianOnlyRecord>,
 }
 
 impl DiagnosticCollector {
@@ -72,7 +89,27 @@ impl DiagnosticCollector {
         Self {
             diagnostics: Vec::new(),
             lossiness_mode,
+            meridian_only_records: Vec::new(),
         }
+    }
+
+    /// Record a launch-time field mapping for meridian-only summary or verbose detail.
+    pub fn record_meridian_only_field(
+        &mut self,
+        item_kind: &str,
+        item_name: &str,
+        target: &str,
+        field: &str,
+    ) {
+        if !self.lossiness_mode.surfaces_lossiness() {
+            return;
+        }
+        self.meridian_only_records.push(MeridianOnlyRecord {
+            item_kind: item_kind.to_string(),
+            item_name: item_name.to_string(),
+            target: target.to_string(),
+            field: field.to_string(),
+        });
     }
 
     pub fn lossiness_mode(&self) -> LossinessMode {
@@ -191,7 +228,64 @@ impl DiagnosticCollector {
     }
 
     pub fn drain(&mut self) -> Vec<Diagnostic> {
+        self.flush_meridian_only_lossiness();
         std::mem::take(&mut self.diagnostics)
+    }
+
+    fn flush_meridian_only_lossiness(&mut self) {
+        if self.meridian_only_records.is_empty() || !self.lossiness_mode.surfaces_lossiness() {
+            return;
+        }
+        match self.lossiness_mode {
+            LossinessMode::Surface => {
+                let count = self.meridian_only_records.len();
+                let noun = if count == 1 { "mapping" } else { "mappings" };
+                self.info_with_category(
+                    "launch-time-field-summary",
+                    format!(
+                        "{count} launch-time field {noun} handled by meridian at spawn — run with --verbose for detail"
+                    ),
+                    DiagnosticCategory::Lossiness,
+                );
+            }
+            LossinessMode::Verbose => {
+                use std::collections::BTreeMap;
+                let mut grouped: BTreeMap<(String, String, String), Vec<String>> = BTreeMap::new();
+                for record in &self.meridian_only_records {
+                    grouped
+                        .entry((
+                            record.item_kind.clone(),
+                            record.item_name.clone(),
+                            record.target.clone(),
+                        ))
+                        .or_default()
+                        .push(record.field.clone());
+                }
+                for ((item_kind, item_name, target), mut fields) in grouped {
+                    fields.sort();
+                    fields.dedup();
+                    let field_refs: Vec<&str> = fields.iter().map(String::as_str).collect();
+                    let count = field_refs.len();
+                    let noun = if count == 1 { "field" } else { "fields" };
+                    let target_label = format!(".{}", target.to_lowercase());
+                    let code = if item_kind == "skill" {
+                        "skill-field-meridian-only"
+                    } else {
+                        "agent-field-meridian-only"
+                    };
+                    self.warn_with_category(
+                        code,
+                        format!(
+                            "{item_kind} `{item_name}`: {count} {noun} not lowered (meridian-only) for {target_label} ({})",
+                            field_refs.join(", ")
+                        ),
+                        DiagnosticCategory::Lossiness,
+                    );
+                }
+            }
+            LossinessMode::Hidden => {}
+        }
+        self.meridian_only_records.clear();
     }
 
     pub fn is_empty(&self) -> bool {
@@ -398,6 +492,24 @@ mod tests {
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].level, DiagnosticLevel::Info);
         assert_eq!(diags[0].category, Some(DiagnosticCategory::Lossiness));
+    }
+
+    #[test]
+    fn collector_verbose_surfaces_meridian_only_detail() {
+        let mut coll = DiagnosticCollector::with_lossiness_mode(LossinessMode::Verbose);
+        coll.record_meridian_only_field("agent", "coder", "Claude", "approval");
+        let diags = coll.drain();
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].code, "agent-field-meridian-only");
+    }
+
+    #[test]
+    fn collector_surface_emits_meridian_only_summary() {
+        let mut coll = DiagnosticCollector::with_lossiness_mode(LossinessMode::Surface);
+        coll.record_meridian_only_field("agent", "coder", "Claude", "approval");
+        let diags = coll.drain();
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].code, "launch-time-field-summary");
     }
 
     #[test]

--- a/src/staging/lift.rs
+++ b/src/staging/lift.rs
@@ -412,12 +412,13 @@ when_to_use: Use when git history matters
 
         let codex = lower_skill_for_harness(SkillHarness::Codex, &profile, body);
         assert!(
-            codex
+            !codex
                 .lossy_fields
                 .iter()
                 .any(|f| f.field == "model-invocable" && f.classification == Lossiness::Dropped)
         );
         assert!(codex.lossy_fields.iter().any(|f| f.field == "tools"));
+        assert_eq!(codex.siblings.len(), 1);
 
         let opencode = lower_skill_for_harness(SkillHarness::OpenCode, &profile, body);
         assert!(

--- a/src/staging/lift.rs
+++ b/src/staging/lift.rs
@@ -432,11 +432,18 @@ when_to_use: Use when git history matters
         assert!(cursor.lossy_fields.iter().any(|f| f.field == "tools"));
         assert!(!cursor_out.contains("when_to_use"));
         assert!(!cursor_out.contains("disable-model-invocation"));
+        assert!(!cursor_out.contains("description:"));
         assert!(
             cursor
                 .lossy_fields
                 .iter()
-                .any(|f| f.field == "when_to_use" || f.field == "user-invocable")
+                .any(|f| f.field == "user-invocable")
+        );
+        assert!(
+            !cursor
+                .lossy_fields
+                .iter()
+                .any(|f| f.field == "when_to_use" || f.field == "model-invocable")
         );
     }
 

--- a/src/staging/lift.rs
+++ b/src/staging/lift.rs
@@ -204,13 +204,43 @@ fn lift_cursor(item_kind: ItemKind, fm: &mut Frontmatter) -> bool {
     }
 }
 
+fn cursor_manual_rule_shape(fm: &Frontmatter) -> bool {
+    fm.get("alwaysApply").and_then(Value::as_bool) == Some(false)
+        && fm.get("description").is_none()
+        && fm.get("globs").is_none()
+}
+
+/// Canonical skills require `description` when frontmatter exists; Cursor Manual rules
+/// cannot store one. Use the skill name as a minimal placeholder for staging only —
+/// Cursor lowering strips it again for explicit `model-invocable: false`.
+fn derive_canonical_description_for_cursor_manual(fm: &Frontmatter) -> String {
+    fm.get("name")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .unwrap_or_else(|| "Cursor manual rule".to_string())
+}
+
 fn lift_cursor_rule(fm: &mut Frontmatter) -> bool {
     let mut changed = false;
-    if find_invocability_field(fm, "model-invocable").is_none()
-        && fm.get("alwaysApply").and_then(Value::as_bool) == Some(true)
-    {
-        fm.insert("model-invocable", Value::Bool(true));
-        changed = true;
+    if find_invocability_field(fm, "model-invocable").is_none() {
+        match fm.get("alwaysApply").and_then(Value::as_bool) {
+            Some(true) => {
+                fm.insert("model-invocable", Value::Bool(true));
+                changed = true;
+            }
+            Some(false) if cursor_manual_rule_shape(fm) => {
+                fm.insert("model-invocable", Value::Bool(false));
+                changed = true;
+                if fm.get("description").is_none() {
+                    fm.insert(
+                        "description",
+                        Value::String(derive_canonical_description_for_cursor_manual(fm)),
+                    );
+                    changed = true;
+                }
+            }
+            _ => {}
+        }
     }
     if fm.remove("alwaysApply").is_some() {
         changed = true;
@@ -369,6 +399,51 @@ mod tests {
         assert_eq!(lifted.get("model-invocable"), Some(&Value::Bool(true)));
         assert!(lifted.get("alwaysApply").is_none());
         assert!(lifted.get("globs").is_none());
+    }
+
+    #[test]
+    fn cursor_manual_rule_restores_model_invocable_false_and_description() {
+        let lifted = lift(
+            Dialect::Cursor,
+            ItemKind::Skill,
+            &fm("name: demo\nalwaysApply: false\n"),
+        );
+        assert_eq!(lifted.get("model-invocable"), Some(&Value::Bool(false)));
+        assert_eq!(
+            lifted.get("description"),
+            Some(&Value::String("demo".into()))
+        );
+        assert!(lifted.get("alwaysApply").is_none());
+
+        let mut diags = Vec::new();
+        let (profile, _) = parse_skill_content(&lifted.render(), &mut diags).unwrap();
+        assert!(diags.is_empty(), "{diags:?}");
+        assert!(!profile.model_invocable);
+        assert!(profile.had_model_invocable_field);
+
+        let codex = lower_skill_for_harness(SkillHarness::Codex, &profile, "# Demo\n");
+        assert_eq!(codex.siblings.len(), 1);
+        assert!(
+            !codex
+                .lossy_fields
+                .iter()
+                .any(|f| f.field == "model-invocable" && f.classification == Lossiness::Dropped)
+        );
+    }
+
+    #[test]
+    fn cursor_apply_intelligently_does_not_set_model_invocable_false() {
+        let lifted = lift(
+            Dialect::Cursor,
+            ItemKind::Skill,
+            &fm("name: demo\ndescription: Pick me\nalwaysApply: false\n"),
+        );
+        assert!(lifted.get("model-invocable").is_none());
+        assert_eq!(
+            lifted.get("description"),
+            Some(&Value::String("Pick me".into()))
+        );
+        assert!(lifted.get("alwaysApply").is_none());
     }
 
     #[test]

--- a/src/staging/lift.rs
+++ b/src/staging/lift.rs
@@ -4,7 +4,6 @@ use serde_yaml::Value;
 
 use crate::compiler::invocability::find_invocability_field;
 use crate::compiler::mcp_ref::parse_foreign_mcp_token;
-use crate::compiler::skills::IMPORTED_WITHOUT_DESCRIPTION;
 use crate::compiler::tool_policy;
 use crate::dialect::Dialect;
 use crate::frontmatter::Frontmatter;
@@ -205,7 +204,7 @@ fn lift_cursor(item_kind: ItemKind, fm: &mut Frontmatter) -> bool {
     }
 }
 
-fn cursor_manual_rule_shape(fm: &Frontmatter) -> bool {
+pub(crate) fn cursor_manual_rule_shape(fm: &Frontmatter) -> bool {
     fm.get("alwaysApply").and_then(Value::as_bool) == Some(false)
         && fm.get("description").is_none()
         && fm.get("globs").is_none()
@@ -221,7 +220,6 @@ fn lift_cursor_rule(fm: &mut Frontmatter) -> bool {
             }
             Some(false) if cursor_manual_rule_shape(fm) => {
                 fm.insert("model-invocable", Value::Bool(false));
-                fm.insert(IMPORTED_WITHOUT_DESCRIPTION, Value::Bool(true));
                 changed = true;
             }
             _ => {}
@@ -395,10 +393,6 @@ mod tests {
         );
         assert_eq!(lifted.get("model-invocable"), Some(&Value::Bool(false)));
         assert!(lifted.get("description").is_none());
-        assert_eq!(
-            lifted.get(IMPORTED_WITHOUT_DESCRIPTION),
-            Some(&Value::Bool(true))
-        );
         assert!(lifted.get("alwaysApply").is_none());
 
         let mut diags = Vec::new();
@@ -436,10 +430,6 @@ mod tests {
         let cursor_out = String::from_utf8(cursor.bytes).unwrap();
         assert!(!cursor_out.contains("description:"));
         assert!(cursor_out.contains("alwaysApply: false"));
-        assert!(
-            !cursor_out.contains(IMPORTED_WITHOUT_DESCRIPTION),
-            "internal sentinel must not leak to Cursor: {cursor_out}"
-        );
 
         let round_trip_lifted = lift(
             Dialect::Cursor,

--- a/src/staging/lift.rs
+++ b/src/staging/lift.rs
@@ -4,6 +4,7 @@ use serde_yaml::Value;
 
 use crate::compiler::invocability::find_invocability_field;
 use crate::compiler::mcp_ref::parse_foreign_mcp_token;
+use crate::compiler::skills::IMPORTED_WITHOUT_DESCRIPTION;
 use crate::compiler::tool_policy;
 use crate::dialect::Dialect;
 use crate::frontmatter::Frontmatter;
@@ -210,16 +211,6 @@ fn cursor_manual_rule_shape(fm: &Frontmatter) -> bool {
         && fm.get("globs").is_none()
 }
 
-/// Canonical skills require `description` when frontmatter exists; Cursor Manual rules
-/// cannot store one. Use the skill name as a minimal placeholder for staging only —
-/// Cursor lowering strips it again for explicit `model-invocable: false`.
-fn derive_canonical_description_for_cursor_manual(fm: &Frontmatter) -> String {
-    fm.get("name")
-        .and_then(Value::as_str)
-        .map(str::to_owned)
-        .unwrap_or_else(|| "Cursor manual rule".to_string())
-}
-
 fn lift_cursor_rule(fm: &mut Frontmatter) -> bool {
     let mut changed = false;
     if find_invocability_field(fm, "model-invocable").is_none() {
@@ -230,14 +221,8 @@ fn lift_cursor_rule(fm: &mut Frontmatter) -> bool {
             }
             Some(false) if cursor_manual_rule_shape(fm) => {
                 fm.insert("model-invocable", Value::Bool(false));
+                fm.insert(IMPORTED_WITHOUT_DESCRIPTION, Value::Bool(true));
                 changed = true;
-                if fm.get("description").is_none() {
-                    fm.insert(
-                        "description",
-                        Value::String(derive_canonical_description_for_cursor_manual(fm)),
-                    );
-                    changed = true;
-                }
             }
             _ => {}
         }
@@ -402,26 +387,29 @@ mod tests {
     }
 
     #[test]
-    fn cursor_manual_rule_restores_model_invocable_false_and_description() {
+    fn cursor_manual_rule_restores_model_invocable_false_without_description() {
         let lifted = lift(
             Dialect::Cursor,
             ItemKind::Skill,
             &fm("name: demo\nalwaysApply: false\n"),
         );
         assert_eq!(lifted.get("model-invocable"), Some(&Value::Bool(false)));
+        assert!(lifted.get("description").is_none());
         assert_eq!(
-            lifted.get("description"),
-            Some(&Value::String("demo".into()))
+            lifted.get(IMPORTED_WITHOUT_DESCRIPTION),
+            Some(&Value::Bool(true))
         );
         assert!(lifted.get("alwaysApply").is_none());
 
         let mut diags = Vec::new();
         let (profile, _) = parse_skill_content(&lifted.render(), &mut diags).unwrap();
         assert!(diags.is_empty(), "{diags:?}");
+        assert!(profile.description.is_none());
         assert!(!profile.model_invocable);
         assert!(profile.had_model_invocable_field);
 
-        let codex = lower_skill_for_harness(SkillHarness::Codex, &profile, "# Demo\n");
+        let body = "# Demo\n";
+        let codex = lower_skill_for_harness(SkillHarness::Codex, &profile, body);
         assert_eq!(codex.siblings.len(), 1);
         assert!(
             !codex
@@ -429,6 +417,40 @@ mod tests {
                 .iter()
                 .any(|f| f.field == "model-invocable" && f.classification == Lossiness::Dropped)
         );
+
+        let claude = lower_skill_for_harness(SkillHarness::Claude, &profile, body);
+        let claude_out = String::from_utf8(claude.bytes).unwrap();
+        assert!(
+            !claude_out.contains("description:"),
+            "fabricated description must not leak to Claude: {claude_out}"
+        );
+
+        let opencode = lower_skill_for_harness(SkillHarness::OpenCode, &profile, body);
+        let opencode_out = String::from_utf8(opencode.bytes).unwrap();
+        assert!(
+            !opencode_out.contains("description:"),
+            "fabricated description must not leak to OpenCode: {opencode_out}"
+        );
+
+        let cursor = lower_skill_for_harness(SkillHarness::Cursor, &profile, body);
+        let cursor_out = String::from_utf8(cursor.bytes).unwrap();
+        assert!(!cursor_out.contains("description:"));
+        assert!(cursor_out.contains("alwaysApply: false"));
+        assert!(
+            !cursor_out.contains(IMPORTED_WITHOUT_DESCRIPTION),
+            "internal sentinel must not leak to Cursor: {cursor_out}"
+        );
+
+        let round_trip_lifted = lift(
+            Dialect::Cursor,
+            ItemKind::Skill,
+            &Frontmatter::parse(&cursor_out).unwrap(),
+        );
+        assert_eq!(
+            round_trip_lifted.get("model-invocable"),
+            Some(&Value::Bool(false))
+        );
+        assert!(round_trip_lifted.get("description").is_none());
     }
 
     #[test]

--- a/src/staging/lift.rs
+++ b/src/staging/lift.rs
@@ -252,12 +252,6 @@ fn lift_opencode(item_kind: ItemKind, fm: &mut Frontmatter) -> bool {
 
 fn lift_opencode_agent(fm: &mut Frontmatter) -> bool {
     let mut changed = false;
-    if find_invocability_field(fm, "user-invocable").is_none()
-        && fm.get("mode").and_then(Value::as_str) == Some("primary")
-    {
-        fm.insert("user-invocable", Value::Bool(false));
-        changed = true;
-    }
 
     if let Some(tools) = fm.remove("disallowedTools") {
         if fm.get("disallowed-tools").is_none() && fm.get("disallowed_tools").is_none() {
@@ -344,13 +338,25 @@ mod tests {
     }
 
     #[test]
-    fn opencode_primary_mode_sets_user_invocable_false() {
+    fn opencode_primary_mode_preserves_mode_without_inferring_user_invocable() {
         let lifted = lift(
             Dialect::OpenCode,
             ItemKind::Agent,
             &fm("name: a\ndescription: d\nmode: primary\n"),
         );
+        assert_eq!(lifted.get("mode"), Some(&Value::String("primary".into())));
+        assert!(lifted.get("user-invocable").is_none());
+    }
+
+    #[test]
+    fn opencode_agent_lifts_literal_user_invocable_only() {
+        let lifted = lift(
+            Dialect::OpenCode,
+            ItemKind::Agent,
+            &fm("name: a\ndescription: d\nmode: subagent\nuser-invocable: false\n"),
+        );
         assert_eq!(lifted.get("user-invocable"), Some(&Value::Bool(false)));
+        assert_eq!(lifted.get("mode"), Some(&Value::String("subagent".into())));
     }
 
     #[test]

--- a/src/staging/mod.rs
+++ b/src/staging/mod.rs
@@ -7,6 +7,8 @@
 mod lift;
 mod overlay;
 
+pub(crate) use lift::cursor_manual_rule_shape;
+
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -268,6 +270,7 @@ fn process_markdown_file(
     if let Ok(parsed) = Frontmatter::parse(&original) {
         if ctx.dialect == Dialect::MarsNative && kind == ItemKind::Skill {
             let mut skill_diags = Vec::new();
+            crate::compiler::skills::push_authored_skill_schema_diags(&parsed, &mut skill_diags);
             crate::compiler::skills::push_non_canonical_tool_field_diags(&parsed, &mut skill_diags);
             if !skill_diags.is_empty() {
                 let skill_name = parsed

--- a/tests/lossiness_surfacing.rs
+++ b/tests/lossiness_surfacing.rs
@@ -18,7 +18,8 @@ harness-overrides:
 # Cursor body
 "#;
 
-const LOSSINESS_SNIPPET: &str = "not lowered (meridian-only) for .cursor (native-config)";
+const LOSSINESS_SUMMARY_SNIPPET: &str = "launch-time field mapping handled by meridian at spawn";
+const LOSSINESS_VERBOSE_SNIPPET: &str = "not lowered (meridian-only) for .cursor (native-config)";
 
 fn setup_lossy_synced_project(dir: &TempDir) -> std::path::PathBuf {
     let source = create_source(dir, "base", &[("cursor-worker", LOSSY_CURSOR_AGENT)], &[]);
@@ -42,7 +43,7 @@ path = "{}"
         .args(["sync", "--root", project.path().to_str().unwrap()])
         .assert()
         .success()
-        .stderr(predicate::str::contains(LOSSINESS_SNIPPET));
+        .stderr(predicate::str::contains(LOSSINESS_SUMMARY_SNIPPET));
 
     project.to_path_buf()
 }
@@ -56,7 +57,7 @@ fn sync_surfaces_lossiness_warnings() {
         .args(["sync", "--root", project.to_str().unwrap()])
         .assert()
         .success()
-        .stderr(predicate::str::contains(LOSSINESS_SNIPPET));
+        .stderr(predicate::str::contains(LOSSINESS_SUMMARY_SNIPPET));
 }
 
 #[test]
@@ -81,8 +82,12 @@ fn validate_suppresses_lossiness_warnings() {
     );
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(
-        !stderr.contains(LOSSINESS_SNIPPET),
+        !stderr.contains(LOSSINESS_VERBOSE_SNIPPET),
         "validate stderr must not contain lossiness warning: {stderr}"
+    );
+    assert!(
+        !stderr.contains(LOSSINESS_SUMMARY_SNIPPET),
+        "validate stderr must not contain lossiness summary: {stderr}"
     );
 }
 
@@ -137,7 +142,7 @@ agent_emission = "always"
         ])
         .assert()
         .success()
-        .stderr(predicate::str::contains(LOSSINESS_SNIPPET).not());
+        .stderr(predicate::str::contains(LOSSINESS_VERBOSE_SNIPPET).not());
 }
 
 #[test]
@@ -154,7 +159,7 @@ fn check_surfaces_lossiness_for_configured_targets() {
         .args(["check", pkg.to_str().unwrap()])
         .assert()
         .success()
-        .stderr(predicate::str::contains(LOSSINESS_SNIPPET));
+        .stderr(predicate::str::contains(LOSSINESS_SUMMARY_SNIPPET));
 }
 
 #[test]
@@ -285,7 +290,36 @@ fn check_skips_agent_lossiness_when_emission_suppressed() {
         .args(["check", pkg.to_str().unwrap()])
         .assert()
         .success()
-        .stderr(predicate::str::contains(LOSSINESS_SNIPPET).not());
+        .stderr(predicate::str::contains(LOSSINESS_SUMMARY_SNIPPET).not());
+}
+
+#[test]
+fn sync_verbose_surfaces_meridian_only_detail() {
+    let dir = TempDir::new().unwrap();
+    let project = setup_lossy_synced_project(&dir);
+
+    mars()
+        .args(["sync", "--verbose", "--root", project.to_str().unwrap()])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(LOSSINESS_VERBOSE_SNIPPET));
+}
+
+#[test]
+fn check_verbose_surfaces_meridian_only_detail() {
+    let dir = TempDir::new().unwrap();
+    let pkg = create_source(&dir, "pkg", &[("cursor-worker", LOSSY_CURSOR_AGENT)], &[]);
+    std::fs::write(
+        pkg.join("mars.toml"),
+        "[settings]\ntargets = [\".cursor\"]\nagent_emission = \"always\"\n",
+    )
+    .unwrap();
+
+    mars()
+        .args(["check", "--verbose", pkg.to_str().unwrap()])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(LOSSINESS_VERBOSE_SNIPPET));
 }
 
 fn create_hook_source(

--- a/tests/lossiness_surfacing.rs
+++ b/tests/lossiness_surfacing.rs
@@ -165,7 +165,7 @@ fn check_and_sync_agree_on_foreign_claude_skill_lossiness() {
     skill.create_dir_all().unwrap();
     skill
         .child("SKILL.md")
-        .write_str("---\nname: demo\ndescription: d\nmodel-invocable: false\n---\n# Body\n")
+        .write_str("---\nname: demo\ndescription: d\nmodel-invocable: false\ntools: [Bash(git *)]\n---\n# Body\n")
         .unwrap();
     source
         .child("mars.toml")
@@ -190,7 +190,7 @@ fn check_and_sync_agree_on_foreign_claude_skill_lossiness() {
     let sync_stderr_text = String::from_utf8_lossy(&sync_stderr.stderr);
     let sync_lossiness: Vec<_> = sync_stderr_text
         .lines()
-        .filter(|line| line.contains("skill-field-dropped") || line.contains("model-invocable"))
+        .filter(|line| line.contains("field dropped") && line.contains(".codex"))
         .collect();
     assert!(
         !sync_lossiness.is_empty(),
@@ -205,7 +205,7 @@ fn check_and_sync_agree_on_foreign_claude_skill_lossiness() {
     let check_stderr_text = String::from_utf8_lossy(&check_stderr.stderr);
     let check_lossiness: Vec<_> = check_stderr_text
         .lines()
-        .filter(|line| line.contains("skill-field-dropped") || line.contains("model-invocable"))
+        .filter(|line| line.contains("field dropped") && line.contains(".codex"))
         .collect();
     assert_eq!(
         sync_lossiness, check_lossiness,

--- a/tests/sync_behavior.rs
+++ b/tests/sync_behavior.rs
@@ -710,6 +710,56 @@ description = "Local overlay"
 }
 
 #[test]
+fn sync_codex_skill_emits_openai_yaml_sibling_for_explicit_model_invocable_false() {
+    let dir = TempDir::new().unwrap();
+    let source_skill =
+        "---\nname: planning\ndescription: base skill\nmodel-invocable: false\n---\n# Base\n";
+    let source = create_source(&dir, "base", &[], &[("planning", source_skill)]);
+
+    let project = dir.child("project");
+    mars()
+        .args(["init", ".codex", "--root", project.path().to_str().unwrap()])
+        .assert()
+        .success();
+
+    mars()
+        .args([
+            "add",
+            source.to_str().unwrap(),
+            "--root",
+            project.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let openai_yaml = project.child(".codex/skills/planning/openai.yaml");
+    assert!(openai_yaml.exists(), "expected Codex openai.yaml sibling");
+    let yaml_bytes = fs::read_to_string(openai_yaml.path()).unwrap();
+    assert!(yaml_bytes.contains("allow_implicit_invocation: false"));
+
+    let native_skill = project.child(".codex/skills/planning/SKILL.md");
+    let native_bytes = fs::read_to_string(native_skill.path()).unwrap();
+    assert!(!native_bytes.contains("allow_implicit_invocation"));
+
+    // Flip to model-invocable: true — sibling must be removed on re-sync.
+    fs::write(
+        source.join("skills").join("planning").join("SKILL.md"),
+        "---\nname: planning\ndescription: base skill\nmodel-invocable: true\n---\n# Base\n",
+    )
+    .unwrap();
+
+    mars()
+        .args(["sync", "--root", project.path().to_str().unwrap()])
+        .assert()
+        .success();
+
+    assert!(
+        !openai_yaml.exists(),
+        "openai.yaml should be removed when model-invocable becomes true"
+    );
+}
+
+#[test]
 fn sync_codex_projection_omits_allow_implicit_invocation_when_model_invocable_is_absent() {
     let dir = TempDir::new().unwrap();
     let source_skill = "---

--- a/tests/sync_behavior.rs
+++ b/tests/sync_behavior.rs
@@ -970,7 +970,7 @@ path = "{}"
         .assert()
         .success()
         .stderr(predicate::str::contains(
-            "agent `cursor-worker`: 1 field not lowered (meridian-only) for .cursor (native-config)",
+            "launch-time field mapping handled by meridian at spawn",
         ));
 
     assert!(project.child(".mars/agents/cursor-worker.md").exists());


### PR DESCRIPTION
Closes the lossiness/fidelity gaps surfaced after the v0.10.0 upgrade — skills/agents now translate to each harness's native capability instead of dropping, and warnings fire only on *consequential* loss.

## Why
After bumping a consumer to mars 0.10.0, every `sync` emitted pages of lossiness warnings. Most were either (a) faithful translations that mars *could* do but was dropping, or (b) launch-time fields Meridian already enforces at spawn (so the drop is behaviorally meaningless). This PR fixes the real translations and tiers the reporting.

## Outbound lowering (translate, don't drop)
- **Cursor `model-invocable`** → native rule modes: `true`/default = Apply Intelligently (`alwaysApply:false` + `description`), explicit `false` = Manual (`alwaysApply:false`, no `description`). Removes both the old silent drop *and* the wrong `alwaysApply:true` always-on over-injection.
- **Codex `model-invocable:false`** → sibling `.codex/skills/<n>/openai.yaml` with `policy.allow_implicit_invocation:false` (closes #116). Explicit-`true` is now a no-op (Codex default), not a warn-drop.
- **OpenCode agent `mode`** → native `mode: primary|subagent`.
- **`when_to_use`** → folded into native `description` for Cursor/OpenCode/Codex.

## Consequence-tiered lossiness reporting
- Launch-time / meridian-enforced agent fields (`approval`, `sandbox`, `mode`, `model-policies`, …) collapse into a single summary line instead of per-agent spam — Meridian applies them at spawn, so omitting them from the artifact changes nothing.
- Genuine **target-enforced** losses (e.g. OpenCode can't gate per-skill invocation) stay loud.
- New `--verbose` (`LossinessMode::Verbose`) restores full per-item detail.

## Inbound lift (round-trip fidelity)
- No longer infers `user-invocable:false` from OpenCode `mode` (independent axes now).
- Cursor Manual rules round-trip: `alwaysApply:false` + no description restores canonical `model-invocable:false`.
- Skill `description` required only at **authored-source** validation; lifted foreign skills tolerate absent description, and no fabricated description leaks to any harness.

## Real-world impact
A `mars sync` over the meridian agent/skill set dropped from ~75+ warning lines to **13 truthful OpenCode forced-drops + 1 summary line** (the rest now translated or correctly silent).

## Verification
- Full `cargo test` green (1500+ lib tests), `clippy -D warnings` + `fmt` clean.
- 3 review rounds (correctness/regression); each finding fixed and re-reviewed to convergence (the inbound-lift round-trip + description-leak + validation-scoping chain).
- Live smoke against real meridian agents confirms the noise reduction with byte evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)