### PR TITLE
fix(opencode): drop skill model-invocable silently (no per-skill warning)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- OpenCode skills no longer emit a per-skill `model-invocable` dropped-field warning. OpenCode's skill frontmatter has no model-invocation gate, so the axis is structurally unrepresentable; the drop is uniform across every non-model-invocable skill and not actionable by the author. It is now an accepted known target limitation (silent drop) rather than per-item lossiness noise. Genuine OpenCode losses (tool gating, `user-invocable`) still warn.
+
 ## [0.10.1-rc.1] - 2026-06-24
 
 ### Fixed

--- a/src/compiler/skills/lower.rs
+++ b/src/compiler/skills/lower.rs
@@ -360,15 +360,18 @@ mod tests {
     }
 
     #[test]
-    fn opencode_drops_model_invocable_and_tools() {
+    fn opencode_silently_drops_model_invocable_but_warns_on_tools() {
+        // OpenCode has no model-invocation gate, so the dropped `model-invocable`
+        // axis is an accepted known limitation and must NOT surface as lossiness.
+        // Tool gating is genuinely lost and still warns.
         let lowered = lower_skill_to_opencode(&profile(), "Body\n");
-        assert!(has_dropped(
+        assert!(!has_dropped(
             &lowered.lossy_fields,
             "model-invocable",
             "OpenCode"
         ));
         assert!(has_dropped(&lowered.lossy_fields, "tools", "OpenCode"));
-        assert_eq!(lowered.lossy_fields.len(), 2);
+        assert_eq!(lowered.lossy_fields.len(), 1);
     }
 
     #[test]

--- a/src/compiler/skills/lower_policy.rs
+++ b/src/compiler/skills/lower_policy.rs
@@ -17,8 +17,14 @@ use crate::compiler::tool_names::{ToolProjectionStatus, project_tool_for_harness
 enum ModelInvocablePolicy {
     /// Emit `disable-model-invocation: true` when `model_invocable` is false.
     EmitDisableWhenFalse,
-    /// Warn-drop when `model_invocable` is false (implicit or explicit).
-    DropWhenFalse,
+    /// Drop silently when `model_invocable` is false — no lossiness warning.
+    ///
+    /// Used for OpenCode, whose skill frontmatter exposes no model-invocation
+    /// gate: the canonical `model-invocable` axis is structurally unrepresentable
+    /// there. The drop is uniform across every non-model-invocable skill and not
+    /// actionable by the author, so surfacing it per-skill is pure noise — it is
+    /// treated as a known, accepted target limitation rather than per-item loss.
+    DropSilentlyWhenFalse,
     /// Emit sibling `openai.yaml` when source explicitly set `model-invocable: false`.
     /// Explicit `true` and absent are no-ops: Codex defaults `allow_implicit_invocation` to true.
     EmitCodexOpenaiYamlWhenExplicitFalse,
@@ -152,7 +158,7 @@ const OPENCODE_POLICY: SkillLoweringPolicy = SkillLoweringPolicy {
         LoweringStep::McpTools,
         LoweringStep::WhenToUse,
     ],
-    model_invocable: ModelInvocablePolicy::DropWhenFalse,
+    model_invocable: ModelInvocablePolicy::DropSilentlyWhenFalse,
     user_invocable: UserInvocablePolicy::DropWhenDisabled,
     allowed_tools: AllowedToolsPolicy::DropWhenNonEmpty,
     disallowed_tools: DisallowedToolsPolicy::Drop,
@@ -353,11 +359,9 @@ impl<'a> LoweringCtx<'a> {
                         .insert(yk("disable-model-invocation"), Value::Bool(true));
                 }
             }
-            ModelInvocablePolicy::DropWhenFalse => {
-                if !profile.model_invocable {
-                    self.lossy_fields
-                        .push(dropped("model-invocable", policy.target_name));
-                }
+            ModelInvocablePolicy::DropSilentlyWhenFalse => {
+                // OpenCode has no model-invocation gate; the axis is structurally
+                // unrepresentable. Drop without lossiness — see the variant doc.
             }
             ModelInvocablePolicy::EmitCodexOpenaiYamlWhenExplicitFalse => {
                 // Codex skills are model-invocable by default; only explicit false needs

--- a/src/staging/lift.rs
+++ b/src/staging/lift.rs
@@ -514,12 +514,16 @@ when_to_use: Use when git history matters
         assert_eq!(codex.siblings.len(), 1);
 
         let opencode = lower_skill_for_harness(SkillHarness::OpenCode, &profile, body);
+        // OpenCode has no model-invocation gate: the dropped axis is an accepted
+        // known limitation and must not surface as lossiness. Tool gating is a
+        // genuine loss and still warns.
         assert!(
-            opencode
+            !opencode
                 .lossy_fields
                 .iter()
-                .any(|f| f.field == "model-invocable")
+                .any(|f| f.field == "model-invocable" && f.classification == Lossiness::Dropped)
         );
+        assert!(opencode.lossy_fields.iter().any(|f| f.field == "tools"));
 
         let cursor = lower_skill_for_harness(SkillHarness::Cursor, &profile, body);
         let cursor_out = String::from_utf8(cursor.bytes).unwrap();


### PR DESCRIPTION
## Why

`mars sync` against a project with OpenCode targets emits a per-skill warning
for every non-model-invocable skill:

```
warning: skill `reflect`: 1 field dropped for .opencode (model-invocable)
warning: skill `diagnose`: 1 field dropped for .opencode (model-invocable)
... (one per skill)
```

OpenCode's skill frontmatter has **no model-invocation gate** — the canonical
`model-invocable` axis is structurally unrepresentable there (unlike Codex,
which got a faithful `openai.yaml` sibling in #116, or Claude's
`disable-model-invocation`). The drop is uniform across every non-model-invocable
skill and not actionable by the author, so surfacing it per-skill is pure noise
that buries genuine losses.

## Goal

Stop warning about a known, accepted, unavoidable target limitation; keep
warning about genuine OpenCode losses.

## Summary

- New `ModelInvocablePolicy::DropSilentlyWhenFalse` (replaces OpenCode's
  `DropWhenFalse`, which had no other users) — drops the axis without recording
  lossiness, documented as a known structural limitation.
- Tool gating and `user-invocable` losses on OpenCode still warn.

## Resulting Behavior

`mars sync`/`check` no longer print `… dropped for .opencode (model-invocable)`
lines. Emitted `.opencode/**/SKILL.md` bytes are **unchanged** (the field was
already not written) — only the warning is removed.

## Changes

- `src/compiler/skills/lower_policy.rs` — new variant + OpenCode policy + no-op apply arm.
- `src/compiler/skills/lower.rs`, `src/staging/lift.rs` — tests updated to assert
  no `model-invocable` lossiness on OpenCode while `tools` still warns.

## Verification

- `cargo test` — **1828 passed, 0 failed**; `cargo clippy -- -D warnings` clean.
- Real-binary `mars sync` against a project with 13 affected OpenCode skills:
  warning count **13 → 0**; `git status` clean afterward (byte-identical output).

## Knowledge Updates

`CHANGELOG.md` `[Unreleased]`. Behavior is documented inline on the new policy variant.

## Release Label Guide

`release:patch` — promotes the current `0.10.1-rc.1` line to stable `0.10.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)