### PR TITLE
fix(lift): rewrite foreign MCP tokens in map-form tools: keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Inbound lift now rewrites foreign MCP tokens in **map-form** `tools:` keys (e.g. Claude `{ mcp__github__delete_repo: deny }`, Cursor `{ Mcp(github:delete_repo): deny }`). Previously only string/sequence tool values were lifted, so map-form MCP keys leaked foreign wire tokens into canonical `.mars/` unchanged or were reparsed as whole-server refs — silently changing per-tool allow/deny semantics. Non-MCP keys and each entry's allow/deny value are preserved.
+
 ## [0.10.1] - 2026-06-25
 
 ### Fixed

--- a/src/staging/lift.rs
+++ b/src/staging/lift.rs
@@ -34,6 +34,31 @@ fn lift_foreign_mcp_tokens_in_value(value: &Value, dialect: Dialect) -> (Value, 
                 .collect();
             (Value::Sequence(lifted), changed)
         }
+        Value::Mapping(map) => {
+            // Map-form `tools:` (e.g. `{ mcp__server__tool: deny }`) carries the
+            // MCP token in the mapping KEY, not the value, so the String/Sequence
+            // arms above never see it. Rewrite MCP-shaped keys through the same
+            // foreign-token parser; preserve each entry's allow/deny value and the
+            // original key order. Without this, foreign wire tokens leak into
+            // canonical `.mars/` unchanged (or get reparsed as whole-server refs),
+            // silently changing per-tool allow/deny semantics.
+            let mut changed = false;
+            let mut lifted = serde_yaml::Mapping::new();
+            for (key, entry) in map {
+                let new_key = match key
+                    .as_str()
+                    .and_then(|raw| parse_foreign_mcp_token(raw, dialect))
+                {
+                    Some(mcp_ref) => {
+                        changed = true;
+                        Value::String(mcp_ref.to_canonical())
+                    }
+                    None => key.clone(),
+                };
+                lifted.insert(new_key, entry.clone());
+            }
+            (Value::Mapping(lifted), changed)
+        }
         other => (other.clone(), false),
     }
 }
@@ -666,6 +691,41 @@ when_to_use: Use when git history matters
             profile.tools,
             vec!["mcp(GitHub/CreateIssue)", "mcp(context7/*)"]
         );
+    }
+
+    #[test]
+    fn claude_lifts_foreign_mcp_token_in_map_form_tools_key() {
+        // Map-form `tools:` carries the MCP token in the key. The deny value and
+        // any non-MCP key must survive unchanged.
+        let lifted = lift(
+            Dialect::Claude,
+            ItemKind::Agent,
+            &fm(
+                "name: a\ndescription: d\ntools:\n  mcp__github__delete_repo: deny\n  Read: allow\n",
+            ),
+        );
+        let mut expected = serde_yaml::Mapping::new();
+        expected.insert(
+            Value::String("mcp(github/delete_repo)".into()),
+            Value::String("deny".into()),
+        );
+        expected.insert(Value::String("Read".into()), Value::String("allow".into()));
+        assert_eq!(lifted.get("tools"), Some(&Value::Mapping(expected)));
+    }
+
+    #[test]
+    fn cursor_lifts_foreign_mcp_token_in_map_form_tools_key() {
+        let lifted = lift(
+            Dialect::Cursor,
+            ItemKind::Skill,
+            &fm("description: rule\ntools:\n  Mcp(github:delete_repo): deny\n"),
+        );
+        let mut expected = serde_yaml::Mapping::new();
+        expected.insert(
+            Value::String("mcp(github/delete_repo)".into()),
+            Value::String("deny".into()),
+        );
+        assert_eq!(lifted.get("tools"), Some(&Value::Mapping(expected)));
     }
 
     #[test]


### PR DESCRIPTION
## Why
High-severity finding from the #119 post-merge review (#122): `lift_foreign_mcp_tokens_in_value` lifted foreign MCP tokens in string/sequence tool values but passed `Mapping` through unchanged. Map-form `tools:` carries the MCP token in the **key** (`{ mcp__github__delete_repo: deny }`), so foreign wire tokens leaked into canonical `.mars/` untouched — or were later reparsed as whole-server refs — **silently changing per-tool allow/deny semantics**.

## Summary
Add a `Value::Mapping` arm that rewrites MCP-shaped keys through `parse_foreign_mcp_token`, preserving non-MCP keys, each entry's allow/deny value, and key order.

## Verification
- `cargo test` **1830 passed, 0 failed** (+2 regression tests: Claude `mcp__…` and Cursor `Mcp(…:…)` map-form deny); `cargo clippy -- -D warnings` clean; `cargo fmt`.

## Release Label Guide
`release:patch` — next stable `0.10.2`.

Fixes #122 (high-severity item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)