### PR TITLE
ci: pin npm 11 for provenance publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -339,7 +339,12 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Ensure npm supports trusted publishing
-        run: npm install -g npm@latest
+        run: |
+          # npm 12.0.0 omits sigstore from its published bundle (npm/cli#9722).
+          # Keep provenance publishing on the latest verified npm 11 release.
+          npm install -g npm@11.18.0
+          npm --version
+          test -f "$(npm root -g)/npm/node_modules/sigstore/package.json"
 
       - uses: actions/download-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- npm publishing stays on npm 11.18.0 until npm 12 restores the missing
+  `sigstore` provenance dependency, preventing release jobs from failing before
+  the first platform package is published.
+
 ## [0.10.4] - 2026-07-10
 
 ### Fixed

--- a/tests/release_metadata.rs
+++ b/tests/release_metadata.rs
@@ -310,6 +310,15 @@ fn release_workflow_marks_rc_prerelease_and_uses_npm_dist_tags() {
 }
 
 #[test]
+fn release_workflow_pins_known_good_npm_for_provenance() {
+    let workflow = read(".github/workflows/release.yml");
+
+    assert!(workflow.contains("npm install -g npm@11.18.0"));
+    assert!(workflow.contains("npm/node_modules/sigstore/package.json"));
+    assert!(!workflow.contains("npm install -g npm@latest"));
+}
+
+#[test]
 fn release_workflow_pypi_publish_uses_trusted_publisher_with_required_inputs() {
     let workflow = read(".github/workflows/release.yml");
 


### PR DESCRIPTION
## Why

Mars v0.10.4 published to PyPI, crates.io, and GitHub, but every npm package remained at v0.10.3. The npm job upgraded to npm 12.0.0, whose published bundle omits `sigstore`, so provenance publishing failed before the first platform package.

## Goal

Restore trusted npm publishing without disabling provenance and publish a complete v0.10.5 patch release.

## Summary

Pin the release job to the latest verified npm 11 release and fail early if its bundled provenance dependency is absent.

## Resulting Behavior

Tag-triggered releases install npm 11.18.0, verify the bundled `sigstore` package, and publish all platform and stub packages with OIDC provenance.

## Changes

- Replace the unbounded `npm@latest` self-upgrade with exact `npm@11.18.0`.
- Preflight the global npm bundle for `sigstore` before any package publish.
- Add a release-workflow regression test and changelog entry.

## Work Item

npm-provenance-publish

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` — 1540 unit tests plus integration suites passed; one pre-existing ignored test
- `cargo test --test release_metadata` — 14 passed
- Isolated npm runtime replay — npm 11.18.0 installed, bundled `sigstore@4.1.1` found, provenance module loaded
- `actionlint .github/workflows/release.yml` — passed in reviewer lane
- Reviewer p5026 — approved with no findings
- Prober p5027 — passed with no blockers

## Knowledge Updates

No durable architecture or context update required. The release-specific behavior is recorded in `CHANGELOG.md` and the workflow comment links the upstream npm defect.

## Spawn Trace

- p5026 reviewer — release safety, provenance, and regression-test review
- p5027 prober — isolated runtime replay of the npm setup and provenance module

## Cleanup

No debug files or source-tree artifacts remain. The worktree will be pruned after merge and release verification.
