### PR TITLE
Fix Claude hook event mapping: session.end compiles to SessionEnd, not nonexistent SessionStop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Claude Code hooks on `session.end` now compile to the valid `SessionEnd`
+  event, so the hooks actually fire when a session ends.
+
 ## [0.10.5] - 2026-07-10
 
 ### Fixed

--- a/docs/config/mcp-and-hooks.md
+++ b/docs/config/mcp-and-hooks.md
@@ -156,7 +156,7 @@ support all events:
 | Universal event | `.claude` | `.codex` | `.opencode` | `.cursor` | `.pi` |
 |---|---|---|---|---|---|
 | `session.start` | `SessionStart` (exact) | `SessionStart` (approx) | `session:start` (approx) | — dropped | — dropped |
-| `session.end` | `SessionStop` (approx) | `Stop` (approx) | `session:end` (approx) | — dropped | — dropped |
+| `session.end` | `SessionEnd` (exact) | `Stop` (approx) | `session:end` (approx) | — dropped | — dropped |
 | `tool.pre` | `PreToolUse` (exact) | `PreToolUse` (approx) | `tool:before` (approx) | — dropped | — dropped |
 | `tool.post` | `PostToolUse` (exact) | `PostToolUse` (approx) | `tool:after` (approx) | — dropped | — dropped |
 

--- a/src/compiler/hooks/mod.rs
+++ b/src/compiler/hooks/mod.rs
@@ -331,7 +331,7 @@ pub struct TranslatedHook {
 ///
 /// Lossiness table (Claude):
 ///   session.start → SessionStart (exact)
-///   session.end   → SessionStop  (approximate — Claude uses Stop not End)
+///   session.end   → SessionEnd   (exact)
 ///   tool.pre      → PreToolUse   (exact)
 ///   tool.post     → PostToolUse  (exact)
 ///
@@ -368,8 +368,8 @@ fn classify_for_target(
                 (LossinessKind::Exact, Some("SessionStart".to_string()))
             }
             UniversalEvent::SessionEnd => {
-                // Claude uses SessionStop, not SessionEnd — close but not exact.
-                (LossinessKind::Approximate, Some("SessionStop".to_string()))
+                // Claude's SessionEnd event exactly matches the universal session end.
+                (LossinessKind::Exact, Some("SessionEnd".to_string()))
             }
             UniversalEvent::ToolPre => (LossinessKind::Exact, Some("PreToolUse".to_string())),
             UniversalEvent::ToolPost => (LossinessKind::Exact, Some("PostToolUse".to_string())),
@@ -576,14 +576,14 @@ path = "./a.sh"
     }
 
     #[test]
-    fn translate_claude_session_end_is_approximate() {
+    fn translate_claude_session_end_is_exact() {
         let tmp = TempDir::new().unwrap();
         make_script_hook(tmp.path(), "cleanup", "session.end");
         let items = discover_hook_items(tmp.path(), "base", 0, 0).unwrap();
         let ordered = order_hooks(items);
         let translated = translate_hook_for_target(ordered.into_iter().next().unwrap(), ".claude");
-        assert_eq!(translated.lossiness, LossinessKind::Approximate);
-        assert_eq!(translated.native_event.as_deref(), Some("SessionStop"));
+        assert_eq!(translated.lossiness, LossinessKind::Exact);
+        assert_eq!(translated.native_event.as_deref(), Some("SessionEnd"));
     }
 
     #[test]

--- a/src/target/claude.rs
+++ b/src/target/claude.rs
@@ -429,7 +429,7 @@ fn remove_hook_keys_from_file(path: &Path, hook_keys: &[(String, &str)]) -> Resu
 fn claude_hook_event(event: &str) -> Option<&'static str> {
     match event {
         "session.start" => Some("SessionStart"),
-        "session.end" => Some("SessionStop"),
+        "session.end" => Some("SessionEnd"),
         "tool.pre" => Some("PreToolUse"),
         "tool.post" => Some("PostToolUse"),
         _ => None,

--- a/tests/lossiness_surfacing.rs
+++ b/tests/lossiness_surfacing.rs
@@ -430,7 +430,7 @@ fn sync_surfaces_dropped_hook_lossiness() {
 #[test]
 fn validate_suppresses_approximate_hook_lossiness() {
     let dir = TempDir::new().unwrap();
-    let project = setup_hook_project(&dir, "hooks-pkg", "cleanup", "session.end", &[".claude"]);
+    let project = setup_hook_project(&dir, "hooks-pkg", "cleanup", "session.end", &[".codex"]);
 
     let output = mars()
         .args(["validate", "--json", "--root", project.to_str().unwrap()])
@@ -452,13 +452,13 @@ fn validate_suppresses_approximate_hook_lossiness() {
 #[test]
 fn sync_surfaces_approximate_hook_lossiness() {
     let dir = TempDir::new().unwrap();
-    let project = setup_hook_project(&dir, "hooks-pkg", "cleanup", "session.end", &[".claude"]);
+    let project = setup_hook_project(&dir, "hooks-pkg", "cleanup", "session.end", &[".codex"]);
 
     mars()
         .args(["sync", "--root", project.to_str().unwrap()])
         .assert()
         .success()
         .stderr(predicate::str::contains(
-            "approximately mapped for target `.claude`",
+            "approximately mapped for target `.codex`",
         ));
 }


### PR DESCRIPTION
## Why

mars compiles the universal `session.end` hook event to the Claude Code native
event name `"SessionStop"` — an event that does not exist in Claude Code (valid
names: `SessionStart`, `SessionEnd`, `Stop`, `SubagentStop`, ...). Every package
hook declared on `session.end` and targeted at `.claude` lands in settings under
a key Claude Code never fires: silently dead. Found while building a
`context-autosync` hook for meridian-base.

## Goal

Hooks declared on `session.end` actually fire when a Claude Code session ends.

## Summary

- `src/target/claude.rs`: `session.end` → `SessionEnd` (was `SessionStop`)
- `src/compiler/hooks/mod.rs`: mapping value corrected; reclassified
  `LossinessKind::Approximate` → `Exact` (the old comment asserted the inverse
  of reality: "Claude uses SessionStop, not SessionEnd"); doc table fixed
- `docs/config/mcp-and-hooks.md`: same wrong mapping fixed in user docs
- `tests/lossiness_surfacing.rs`: two fixtures asserted the wrong name /
  approximate classification — updated (lossiness-surfacing coverage now uses
  Codex's genuinely-approximate mapping instead)
- CHANGELOG entry under `[Unreleased]`

## Resulting Behavior

A package hook with `event = "session.end"`, `targets = [".claude"]` compiles to
a `SessionEnd` hook entry that Claude Code recognizes and fires. Previously it
produced an inert `SessionStop` key.

## Changes

One-line behavioral fix plus the comment/doc/test sites that encoded the wrong
belief. No schema or vocabulary changes. Note: a broader audit of the hook event
vocabulary across all targets (and a review of whether the universal-event
compilation layer should exist at all) is in flight as a separate design effort;
this PR is the minimal correctness hotfix.

## Work Item

reaper-scope-regression (follow-up chain; surfaced while closing the KB
autosync gap)

## Verification

- `cargo build` — passed
- `cargo test` — 1,540 unit tests + integration/doc tests passed
- `cargo clippy -- -D warnings` — passed
- `cargo fmt --check` — passed
- `rg -n "SessionStop"` — zero hits repo-wide

## Knowledge Updates

`docs/config/mcp-and-hooks.md` corrected in this PR. Broader vocab audit +
authoring-model design doc lands with the separate design effort.

## Spawn Trace

- p5694 coder — implemented the fix and found the three additional wrong sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)
