### PR TITLE
Improve constrained upgrade recovery guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `plugins/mars-<name>.ts` and `extensions/mars-<name>.ts`, respectively.
 
 ### Fixed
+- Guide consumers to use `upgrade --bump` when removed hook schemas remain
+  behind a package version constraint.
 - Preserve corrupt `mars.lock` bytes when repair halts on an unreadable legacy
   hook source; the lock is now rebuilt in memory and replaced only after a
   complete repair.

--- a/src/compiler/hooks/mod.rs
+++ b/src/compiler/hooks/mod.rs
@@ -207,7 +207,10 @@ fn contextualize_dependency_error(
         })
         .unwrap_or("unknown");
     ConfigError::Invalid {
-        message: format!("source package `{source_name}` version `{version}` {message}"),
+        message: format!(
+            "source package `{source_name}` version `{version}` {message}; \
+             suggested: `mars upgrade {source_name} --bump` or `mars remove {source_name}`"
+        ),
     }
     .into()
 }

--- a/src/compiler/hooks/mod.rs
+++ b/src/compiler/hooks/mod.rs
@@ -8,6 +8,7 @@ use serde_json::Value;
 
 use crate::diagnostic::DiagnosticCollector;
 use crate::error::{ConfigError, MarsError};
+use crate::types::managed_cmd;
 
 pub(crate) const REMOVED_HOOK_SCHEMA_MESSAGE: &str = "uses the removed v0.11.0 hook schema (`events`/`matcher`/`[action]`/`path`); \
      migrate to per-target native fragment files with `fragment = \"<target>.json\"`";
@@ -209,7 +210,9 @@ fn contextualize_dependency_error(
     ConfigError::Invalid {
         message: format!(
             "source package `{source_name}` version `{version}` {message}; \
-             suggested: `mars upgrade {source_name} --bump` or `mars remove {source_name}`"
+             suggested: `{cmd_upgrade}` or `{cmd_remove}`",
+            cmd_upgrade = managed_cmd(&format!("mars upgrade {source_name} --bump")),
+            cmd_remove = managed_cmd(&format!("mars remove {source_name}")),
         ),
     }
     .into()

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -253,7 +253,22 @@ fn build_recovery_halt(
                         format!("mars override {source_name} --path <path>"),
                     )
                 }
-                None if matches!(request.resolution, ResolutionMode::Maximize { .. }) => (
+                None if matches!(
+                    request.resolution,
+                    ResolutionMode::Maximize { bump: false, .. }
+                ) =>
+                {
+                    (
+                        format!(
+                            "newest compatible `{source_name}@{version}` still uses the removed hook schema; try --bump to escape the version constraint, or override/remove"
+                        ),
+                        format!("mars upgrade {source_name} --bump"),
+                    )
+                }
+                None if matches!(
+                    request.resolution,
+                    ResolutionMode::Maximize { bump: true, .. }
+                ) => (
                     format!(
                         "newest available `{source_name}@{version}` still uses the removed hook schema; override or remove it"
                     ),

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -250,43 +250,45 @@ fn build_recovery_halt(
                             "removed direct dependency `{name}`, but `{source_name}` is still required by {} and remains legacy; override it",
                             parents.join(", ")
                         ),
-                        format!("mars override {source_name} --path <path>"),
+                        managed_cmd(&format!("mars override {source_name} --path <path>")).into_owned(),
                     )
                 }
-                None if matches!(
-                    request.resolution,
-                    ResolutionMode::Maximize { bump: false, .. }
-                ) =>
-                {
-                    (
-                        format!(
-                            "newest compatible `{source_name}@{version}` still uses the removed hook schema; try --bump to escape the version constraint, or override/remove"
-                        ),
-                        format!("mars upgrade {source_name} --bump"),
-                    )
+                None if matches!(request.resolution, ResolutionMode::Maximize { .. }) => {
+                    let bump = matches!(
+                        request.resolution,
+                        ResolutionMode::Maximize { bump: true, .. }
+                    );
+                    if bump {
+                        (
+                            format!(
+                                "newest available `{source_name}@{version}` still uses the removed hook schema; override or remove it"
+                            ),
+                            format!(
+                                "{cmd_override} --path <path> or {cmd_remove}",
+                                cmd_override = managed_cmd(&format!("mars override {source_name}")),
+                                cmd_remove = managed_cmd(&format!("mars remove {source_name}")),
+                            ),
+                        )
+                    } else {
+                        (
+                            format!(
+                                "newest compatible `{source_name}@{version}` still uses the removed hook schema; try --bump to escape the version constraint, or override/remove"
+                            ),
+                            managed_cmd(&format!("mars upgrade {source_name} --bump")).into_owned(),
+                        )
+                    }
                 }
-                None if matches!(
-                    request.resolution,
-                    ResolutionMode::Maximize { bump: true, .. }
-                ) => (
-                    format!(
-                        "newest available `{source_name}@{version}` still uses the removed hook schema; override or remove it"
-                    ),
-                    format!(
-                        "mars override {source_name} --path <path> or mars remove {source_name}"
-                    ),
-                ),
                 None if request.options.force => (
                     format!(
                         "cannot repair while `{source_name}@{version}` uses the removed hook schema; upgrade, override, or remove it"
                     ),
-                    format!("mars upgrade {source_name}"),
+                    managed_cmd(&format!("mars upgrade {source_name}")).into_owned(),
                 ),
                 _ => (
                     format!(
                         "`{source_name}@{version}` still uses the removed hook schema; upgrade, override, or remove it"
                     ),
-                    format!("mars upgrade {source_name}"),
+                    managed_cmd(&format!("mars upgrade {source_name}")).into_owned(),
                 ),
             };
             RecoveryBlocker {

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -241,6 +241,8 @@ fn build_recovery_halt(
                 .filter(|candidate| candidate.deps.contains(source_name))
                 .map(|candidate| candidate.source_name.to_string())
                 .collect();
+            let upgrade_cmd =
+                managed_cmd(&format!("mars upgrade {source_name}")).into_owned();
             let (guidance, suggested_command) = match &request.mutation {
                 Some(ConfigMutation::RemoveDependency { name })
                     if name == source_name && !parents.is_empty() =>
@@ -282,13 +284,13 @@ fn build_recovery_halt(
                     format!(
                         "cannot repair while `{source_name}@{version}` uses the removed hook schema; upgrade, override, or remove it"
                     ),
-                    managed_cmd(&format!("mars upgrade {source_name}")).into_owned(),
+                    upgrade_cmd.clone(),
                 ),
                 _ => (
                     format!(
                         "`{source_name}@{version}` still uses the removed hook schema; upgrade, override, or remove it"
                     ),
-                    managed_cmd(&format!("mars upgrade {source_name}")).into_owned(),
+                    upgrade_cmd,
                 ),
             };
             RecoveryBlocker {

--- a/tests/config_entries/migrations.rs
+++ b/tests/config_entries/migrations.rs
@@ -176,17 +176,34 @@ fn recovery_commands_converge_or_halt_at_the_reader_compiler_boundary() {
     let legacy = write_legacy_hook_source(&dir, "base");
     let migrated = write_migrated_hook_source(&dir, "base-migrated");
 
-    for (name, args, converges) in [
-        ("upgrade", vec!["upgrade"], false),
-        ("upgrade-bump", vec!["upgrade", "--bump"], false),
-        ("repair", vec!["repair"], false),
+    // (label, cli args, converges, halt_guidance_fragment, halt_command_fragment)
+    let cases: Vec<(_, Vec<&str>, _, Option<&str>, Option<&str>)> = vec![
+        (
+            "upgrade",
+            vec!["upgrade"],
+            false,
+            Some("newest compatible"),
+            Some("mars upgrade base --bump"),
+        ),
+        (
+            "upgrade-bump",
+            vec!["upgrade", "--bump"],
+            false,
+            Some("newest available"),
+            Some("mars override base --path <path> or mars remove base"),
+        ),
+        ("repair", vec!["repair"], false, None, None),
         (
             "override",
             vec!["override", "base", "--path", migrated.to_str().unwrap()],
             true,
+            None,
+            None,
         ),
-        ("remove", vec!["remove", "base"], true),
-    ] {
+        ("remove", vec!["remove", "base"], true, None, None),
+    ];
+
+    for (name, args, converges, halt_guidance, halt_command) in cases {
         let project = dir.child(format!("project-{name}"));
         project.create_dir_all().unwrap();
         project
@@ -212,27 +229,20 @@ fn recovery_commands_converge_or_halt_at_the_reader_compiler_boundary() {
             let lock = fs::read_to_string(project.child("mars.lock").path()).unwrap();
             assert!(lock.contains("version = 3"));
         } else {
-            let assertion = assertion
+            let mut assertion = assertion
                 .code(2)
                 .stderr(predicate::str::contains(
                     "recovery halted before materialization",
                 ))
                 .stderr(predicate::str::contains("base@0.8.9"))
                 .stderr(predicate::str::contains("then run"));
-            if name == "upgrade" {
-                assertion
-                    .stderr(predicate::str::contains(
-                        "newest compatible `base@0.8.9` still uses the removed hook schema; \
-                         try --bump to escape the version constraint, or override/remove",
-                    ))
-                    .stderr(predicate::str::contains("mars upgrade base --bump"));
-            } else if name == "upgrade-bump" {
-                assertion
-                    .stderr(predicate::str::contains("newest available"))
-                    .stderr(predicate::str::contains(
-                        "mars override base --path <path> or mars remove base",
-                    ));
+            if let Some(guidance) = halt_guidance {
+                assertion = assertion.stderr(predicate::str::contains(guidance));
             }
+            if let Some(command) = halt_command {
+                assertion = assertion.stderr(predicate::str::contains(command));
+            }
+            let _ = assertion;
             assert_eq!(
                 fs::read_to_string(project.child("mars.lock").path()).unwrap(),
                 "version = 2\n"

--- a/tests/config_entries/migrations.rs
+++ b/tests/config_entries/migrations.rs
@@ -178,6 +178,7 @@ fn recovery_commands_converge_or_halt_at_the_reader_compiler_boundary() {
 
     for (name, args, converges) in [
         ("upgrade", vec!["upgrade"], false),
+        ("upgrade-bump", vec!["upgrade", "--bump"], false),
         ("repair", vec!["repair"], false),
         (
             "override",
@@ -210,13 +211,27 @@ fn recovery_commands_converge_or_halt_at_the_reader_compiler_boundary() {
             let lock = fs::read_to_string(project.child("mars.lock").path()).unwrap();
             assert!(lock.contains("version = 3"));
         } else {
-            assertion
+            let assertion = assertion
                 .code(2)
                 .stderr(predicate::str::contains(
                     "recovery halted before materialization",
                 ))
                 .stderr(predicate::str::contains("base@0.8.9"))
                 .stderr(predicate::str::contains("then run"));
+            if name == "upgrade" {
+                assertion
+                    .stderr(predicate::str::contains(
+                        "newest compatible `base@0.8.9` still uses the removed hook schema; \
+                         try --bump to escape the version constraint, or override/remove",
+                    ))
+                    .stderr(predicate::str::contains("mars upgrade base --bump"));
+            } else if name == "upgrade-bump" {
+                assertion
+                    .stderr(predicate::str::contains("newest available"))
+                    .stderr(predicate::str::contains(
+                        "mars override base --path <path> or mars remove base",
+                    ));
+            }
             assert_eq!(
                 fs::read_to_string(project.child("mars.lock").path()).unwrap(),
                 "version = 2\n"
@@ -300,6 +315,9 @@ fn normal_sync_reports_removed_hook_schema_by_source_package_and_version() {
             "source package `base` version `0.8.9`",
         ))
         .stderr(predicate::str::contains("removed v0.11.0 hook schema"))
+        .stderr(predicate::str::contains(
+            "suggested: `mars upgrade base --bump` or `mars remove base`",
+        ))
         .stderr(predicate::str::contains(".mars/staging").not());
 }
 

--- a/tests/config_entries/migrations.rs
+++ b/tests/config_entries/migrations.rs
@@ -203,6 +203,7 @@ fn recovery_commands_converge_or_halt_at_the_reader_compiler_boundary() {
         write_old_staging_fixture(&project);
 
         let assertion = mars()
+            .env_remove("MERIDIAN_MANAGED")
             .args(args)
             .args(["--root", project.path().to_str().unwrap()])
             .assert();
@@ -308,6 +309,7 @@ fn normal_sync_reports_removed_hook_schema_by_source_package_and_version() {
     write_old_staging_fixture(&project);
 
     mars()
+        .env_remove("MERIDIAN_MANAGED")
         .args(["sync", "--root", project.path().to_str().unwrap()])
         .assert()
         .failure()


### PR DESCRIPTION
## Why

Projects can be locked to a package version range whose newest compatible
release still uses the removed hook schema. Recovery currently calls that
release the "newest available" and does not tell consumers that `--bump`
can escape the constraint. Plain sync errors also give package-author
migration guidance without a consumer recovery command. Additionally, all
`suggested_command` values hardcode bare `mars` instead of using
`managed_cmd()`, so hints read wrong under `MERIDIAN_MANAGED=1`.

## Goal

Make removed-hook-schema failures tell package consumers how to recover,
and render command suggestions correctly in both standalone and managed
modes — without changing sync or recovery control flow.

## Summary

- Distinguish constrained upgrades from `--bump` upgrades in recovery halt text.
- Recommend `mars upgrade <source> --bump` for constrained upgrades.
- Add upgrade/remove suggestions to dependency hook-schema sync errors.
- Wrap all `suggested_command` values through `managed_cmd()` for correct
  rendering under `MERIDIAN_MANAGED=1`.
- Collapse two `Maximize` match arms into one with an inner branch.
- Hoist duplicate `upgrade_cmd` binding above the match.
- Data-drive test assertions instead of string-dispatching on case name.

## Resulting Behavior

A constrained `mars upgrade base` halt now reports the "newest compatible"
version and suggests `mars upgrade base --bump`. If `--bump` was already
used, the halt retains "newest available" and suggests override/remove.
Plain `mars sync` errors suggest `mars upgrade base --bump` or
`mars remove base`. All suggestions render with the `meridian ` prefix
when running under `MERIDIAN_MANAGED=1`.

## Changes

Only user-facing diagnostics and their assertions changed.
`RecoveryPolicy::Strict` and all resolution/materialization control flow
remain unchanged.

- `src/sync/mod.rs` — `build_recovery_halt`: collapse Maximize arms,
  hoist `upgrade_cmd`, wrap all suggestions through `managed_cmd()`
- `src/compiler/hooks/mod.rs` — `contextualize_dependency_error`: add
  `managed_cmd`-wrapped upgrade/remove suggestion to sync error
- `tests/config_entries/migrations.rs` — data-driven assertion tuples,
  `env_remove("MERIDIAN_MANAGED")` for deterministic output
- `CHANGELOG.md` — entry under Fixed

## Work Item

mars-upgrade-recovery

## Verification

- `cargo test` — passed (63 config_entries tests, 1463+ total)
- `cargo clippy --all-targets --all-features -- -D warnings` — passed
- `cargo fmt --check` — passed
- Pre-commit push preflight passed (tests, clippy, fmt, release build)
- Regression assertion was run before the production change and failed
  on the old "newest available" text

## Knowledge Updates

Updated `CHANGELOG.md`. No AGENTS/context/KB updates: this is localized
diagnostic wording and does not change architecture or operational policy.