### PR TITLE
Enforce requires-mars / requires-meridian engine constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - Reject a malformed `MERIDIAN_VERSION` instead of silently disabling
   `requires-meridian` enforcement.
+- Give direction-neutral engine-version remediation when a package requirement
+  may require upgrading or downgrading the running engine.
 - Preserve corrupt `mars.lock` bytes when repair halts on an unreadable legacy
   hook source; the lock is now rebuilt in memory and replaced only after a
   complete repair.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Same-name hook collisions are scoped per target.
 
 ### Added
+- Package manifests can declare strict `requires-mars` and
+  `requires-meridian` engine version constraints.
 - Cursor native hook fragments emit flat entries under a Mars-owned version 1
   wrapper with strict validation against its 21 camelCase events.
 - OpenCode and Pi hooks place substituted TypeScript file fragments at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `plugins/mars-<name>.ts` and `extensions/mars-<name>.ts`, respectively.
 
 ### Fixed
+- Report the final selected package version after an engine fallback triggers
+  further constraint-driven resolution restarts.
 - Reject a malformed `MERIDIAN_VERSION` instead of silently disabling
   `requires-meridian` enforcement.
 - Give direction-neutral engine-version remediation when a package requirement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - Package manifests can declare strict `requires-mars` and
-  `requires-meridian` engine version constraints.
+  `requires-meridian` engine version constraints. Sync, upgrade, add, and
+  repair enforce them with explicit ignore flags; `mars check` validates their
+  syntax, and JSON sync reports describe engine-driven version fallbacks.
 - Cursor native hook fragments emit flat entries under a Mars-owned version 1
   wrapper with strict validation against its 21 camelCase events.
 - OpenCode and Pi hooks place substituted TypeScript file fragments at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - Report the final selected package version after an engine fallback triggers
   further constraint-driven resolution restarts.
+- Ignore a malformed ambient `MERIDIAN_VERSION` when a package does not declare
+  `requires-meridian`.
 - Reject a malformed `MERIDIAN_VERSION` instead of silently disabling
   `requires-meridian` enforcement.
 - Give direction-neutral engine-version remediation when a package requirement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `plugins/mars-<name>.ts` and `extensions/mars-<name>.ts`, respectively.
 
 ### Fixed
+- Reject a malformed `MERIDIAN_VERSION` instead of silently disabling
+  `requires-meridian` enforcement.
 - Preserve corrupt `mars.lock` bytes when repair halts on an unreadable legacy
   hook source; the lock is now rebuilt in memory and replaced only after a
   complete repair.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ flowchart TD
 
 Mars resolves the full dependency graph before touching any files. Writes are atomic. The lock file tracks what mars manages so it never touches your files. Each linked target gets harness-native artifacts — agents, skills, MCP servers, and hooks compiled to match what that tool expects.
 
+Published packages can declare `requires-mars` and `requires-meridian` under
+`[package]`. Mars automatically falls back to the newest compatible package
+release; see the [`mars.toml` reference](docs/config/mars-toml.md#package-optional).
+
 Use `mars adopt` to bring an existing unmanaged file into `.mars-src/` in one step.
 
 ## Docs

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -450,6 +450,7 @@ mars check [path]
 | `path` | Directory to validate (default: current directory) |
 
 Does not require a mars project (no `mars.toml` needed). Validates:
+- `requires-mars` and `requires-meridian` syntax when `[package]` is present
 - Package structure: convention folders named `agents/`, `skills/`, or `bootstrap/` at non-hidden depth up to `MAX_DISCOVERY_WALK_DEPTH = 5`, plus package-root `SKILL.md` fallback
 - Frontmatter: name, description presence and consistency
 - Duplicate `(kind, name)` discoveries within the package

--- a/docs/config/mars-toml.md
+++ b/docs/config/mars-toml.md
@@ -47,6 +47,8 @@ To keep project-local agents and skills without publishing, use `.mars-src/` ins
 name = "meridian-base"
 version = "1.2.0"
 description = "Core agents and skills for meridian"  # optional
+requires-mars = ">=0.11.0"                           # optional
+requires-meridian = ">=0.20.0"                       # optional
 ```
 
 | Field | Type | Required | Description |
@@ -54,6 +56,19 @@ description = "Core agents and skills for meridian"  # optional
 | `name` | string | yes | Package name, used for dependency resolution |
 | `version` | string | yes | Semver version of this package |
 | `description` | string | no | Human-readable description |
+| `requires-mars` | semver requirement | no | Mars versions that can consume this package |
+| `requires-meridian` | semver requirement | no | Meridian versions that can consume this package; skipped when Mars runs standalone |
+
+Bare engine versions such as `"0.11"` mean a minimum (`">=0.11.0"`).
+Full semver ranges are also accepted. During dependency resolution Mars skips
+incompatible releases and selects the newest compatible older release. If no
+release is compatible, sync stops before writing. The consumer project's own
+`[package]` requirements are hard errors because there is no version to fall
+back to. `mars check` validates both fields before publishing.
+
+`--ignore-requires-mars` and `--ignore-requires-meridian` disable the
+corresponding check for `sync`, `upgrade`, `add`, and `repair`, and always emit
+a warning.
 
 Project-local agents and skills are read from `.mars-src/` during sync. Repo-root `agents/` and `skills/` directories are package contents for downstream consumers, not local `_self` discovery roots. Source-package discovery walks the rooted package tree and includes convention folders named `agents/`, `skills/`, and `bootstrap/` at non-hidden depth up to `MAX_DISCOVERY_WALK_DEPTH = 5`, grounded to the shallowest discovered package layer. Duplicate `(kind, name)` items in one source fail with `DiscoveryCollision`.
 

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -40,6 +40,14 @@ pub struct AddArgs {
     /// Install only agents (plus their transitive skill deps) from this source.
     #[arg(long)]
     pub only_agents: bool,
+
+    /// Ignore package `requires-mars` version constraints.
+    #[arg(long)]
+    pub ignore_requires_mars: bool,
+
+    /// Ignore package `requires-meridian` version constraints.
+    #[arg(long)]
+    pub ignore_requires_meridian: bool,
 }
 
 /// Parsed dependency specifier.
@@ -102,7 +110,11 @@ pub fn run(args: &AddArgs, ctx: &super::MarsContext, json: bool) -> Result<i32, 
                 name: name.clone(),
                 entry,
             }),
-            options: SyncOptions::default(),
+            options: SyncOptions {
+                ignore_requires_mars: args.ignore_requires_mars,
+                ignore_requires_meridian: args.ignore_requires_meridian,
+                ..SyncOptions::default()
+            },
             recovery: Default::default(),
             lossiness_mode: crate::diagnostic::LossinessMode::Hidden,
         };
@@ -121,7 +133,11 @@ pub fn run(args: &AddArgs, ctx: &super::MarsContext, json: bool) -> Result<i32, 
     let request = SyncRequest {
         resolution: ResolutionMode::Normal,
         mutation: Some(ConfigMutation::BatchUpsert(mutations)),
-        options: SyncOptions::default(),
+        options: SyncOptions {
+            ignore_requires_mars: args.ignore_requires_mars,
+            ignore_requires_meridian: args.ignore_requires_meridian,
+            ..SyncOptions::default()
+        },
         recovery: Default::default(),
         lossiness_mode: crate::diagnostic::LossinessMode::Hidden,
     };

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -112,6 +112,13 @@ pub(crate) fn check_dir(base: &Path) -> Result<CheckReport, MarsError> {
     let mut errors: Vec<String> = Vec::new();
     let mut warnings: Vec<String> = Vec::new();
 
+    if let Ok(config) = crate::config::load(base)
+        && let Some(package) = config.package.as_ref()
+        && let Err(error) = crate::resolve::validate_package_requirement_syntax(package)
+    {
+        errors.push(error.to_string());
+    }
+
     let discovered = discover::discover_resolved_source(base, None)?;
     let dialect = Dialect::resolve_local(None, base);
 

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -173,6 +173,7 @@ pub fn sync_report_json(report: &SyncReport) -> serde_json::Value {
         upgrades_available: usize,
         targets: Vec<JsonTargetOutcome>,
         diagnostics: Vec<Diagnostic>,
+        engine_fallbacks: Vec<crate::resolve::EngineFallback>,
         #[serde(skip_serializing_if = "Option::is_none")]
         recovery_halt: Option<crate::sync::RecoveryHalt>,
     }
@@ -217,6 +218,7 @@ pub fn sync_report_json(report: &SyncReport) -> serde_json::Value {
         upgrades_available: report.upgrades_available,
         targets,
         diagnostics: report.diagnostics.clone(),
+        engine_fallbacks: report.engine_fallbacks.clone(),
         recovery_halt: report.recovery_halt.clone(),
     })
     .unwrap_or_else(|_| serde_json::json!({}))
@@ -552,4 +554,63 @@ pub fn print_error(msg: &str) {
 /// Print an info message.
 pub fn print_info(msg: &str) {
     println!("  {msg}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn report(engine_fallbacks: Vec<crate::resolve::EngineFallback>) -> SyncReport {
+        SyncReport {
+            applied: crate::sync::apply::ApplyResult {
+                outcomes: Vec::new(),
+            },
+            diagnostics: Vec::new(),
+            dependency_changes: Vec::new(),
+            upgrades_available: 0,
+            target_outcomes: Vec::new(),
+            dry_run: false,
+            native_emitted: Vec::new(),
+            native_removed: Vec::new(),
+            recovery_halt: None,
+            engine_fallbacks,
+        }
+    }
+
+    #[test]
+    fn sync_json_reports_engine_fallback_details() {
+        let fallback = crate::resolve::EngineFallback {
+            source: "base".into(),
+            skipped: vec![crate::resolve::EngineFallbackSkippedVersion {
+                version: "2.0.0".into(),
+                requirements: vec![crate::resolve::EngineFallbackRequirement {
+                    engine: "mars".into(),
+                    requirement: ">=0.12".into(),
+                }],
+            }],
+            selected_version: "1.5.0".into(),
+            engines: vec!["mars".into()],
+        };
+
+        assert_eq!(
+            sync_report_json(&report(vec![fallback]))["engine_fallbacks"],
+            serde_json::json!([{
+                "source": "base",
+                "skipped": [{
+                    "version": "2.0.0",
+                    "requirements": [{"engine": "mars", "requirement": ">=0.12"}]
+                }],
+                "selected_version": "1.5.0",
+                "engines": ["mars"]
+            }])
+        );
+    }
+
+    #[test]
+    fn sync_json_has_empty_engine_fallbacks_without_fallback() {
+        assert_eq!(
+            sync_report_json(&report(Vec::new()))["engine_fallbacks"],
+            serde_json::json!([])
+        );
+    }
 }

--- a/src/cli/repair.rs
+++ b/src/cli/repair.rs
@@ -7,14 +7,22 @@ use super::output;
 
 /// Arguments for `mars repair`.
 #[derive(Debug, clap::Args)]
-pub struct RepairArgs {}
+pub struct RepairArgs {
+    /// Ignore package `requires-mars` version constraints.
+    #[arg(long)]
+    pub ignore_requires_mars: bool,
+
+    /// Ignore package `requires-meridian` version constraints.
+    #[arg(long)]
+    pub ignore_requires_meridian: bool,
+}
 
 /// Run `mars repair`.
 ///
 /// Re-syncs everything from config. This is effectively a forced sync
 /// that rebuilds the state. If lock exists, items are re-installed from
 /// dependencies to match it. If lock is missing, a fresh sync is performed.
-pub fn run(_args: &RepairArgs, ctx: &super::MarsContext, json: bool) -> Result<i32, MarsError> {
+pub fn run(args: &RepairArgs, ctx: &super::MarsContext, json: bool) -> Result<i32, MarsError> {
     if !json {
         output::print_info("repairing — re-syncing from dependencies...");
     }
@@ -24,6 +32,8 @@ pub fn run(_args: &RepairArgs, ctx: &super::MarsContext, json: bool) -> Result<i
         mutation: None,
         options: SyncOptions {
             force: true,
+            ignore_requires_mars: args.ignore_requires_mars,
+            ignore_requires_meridian: args.ignore_requires_meridian,
             ..SyncOptions::default()
         },
         recovery: crate::sync::RecoveryPolicy::Repair,

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -35,6 +35,14 @@ pub struct SyncArgs {
     /// Show per-item detail for launch-time fields handled by meridian at spawn.
     #[arg(long)]
     pub verbose: bool,
+
+    /// Ignore package `requires-mars` version constraints.
+    #[arg(long)]
+    pub ignore_requires_mars: bool,
+
+    /// Ignore package `requires-meridian` version constraints.
+    #[arg(long)]
+    pub ignore_requires_meridian: bool,
 }
 
 /// Run `mars sync`.
@@ -50,6 +58,8 @@ pub fn run(args: &SyncArgs, ctx: &super::MarsContext, json: bool) -> Result<i32,
             refresh_models: args.refresh_models,
             no_refresh_models: args.no_refresh_models,
             check_upgrades: !no_upgrade_hint,
+            ignore_requires_mars: args.ignore_requires_mars,
+            ignore_requires_meridian: args.ignore_requires_meridian,
         },
         recovery: Default::default(),
         lossiness_mode: if args.verbose {
@@ -120,5 +130,36 @@ mod tests {
             panic!("expected sync command");
         };
         assert!(args.verbose);
+    }
+
+    #[test]
+    fn engine_ignore_flags_parse_on_all_syncing_commands() {
+        for command in ["sync", "upgrade", "add", "repair"] {
+            let mut argv = vec!["mars", command];
+            if command == "add" {
+                argv.push("owner/repo");
+            }
+            argv.extend(["--ignore-requires-mars", "--ignore-requires-meridian"]);
+            let cli = Cli::try_parse_from(argv).unwrap();
+            match cli.command {
+                Command::Sync(args) => {
+                    assert!(args.ignore_requires_mars);
+                    assert!(args.ignore_requires_meridian);
+                }
+                Command::Upgrade(args) => {
+                    assert!(args.ignore_requires_mars);
+                    assert!(args.ignore_requires_meridian);
+                }
+                Command::Add(args) => {
+                    assert!(args.ignore_requires_mars);
+                    assert!(args.ignore_requires_meridian);
+                }
+                Command::Repair(args) => {
+                    assert!(args.ignore_requires_mars);
+                    assert!(args.ignore_requires_meridian);
+                }
+                _ => panic!("unexpected command"),
+            }
+        }
     }
 }

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -19,6 +19,14 @@ pub struct UpgradeArgs {
     /// Show per-item detail for launch-time fields handled by meridian at spawn.
     #[arg(long)]
     pub verbose: bool,
+
+    /// Ignore package `requires-mars` version constraints.
+    #[arg(long)]
+    pub ignore_requires_mars: bool,
+
+    /// Ignore package `requires-meridian` version constraints.
+    #[arg(long)]
+    pub ignore_requires_meridian: bool,
 }
 
 /// Run `mars upgrade`.
@@ -33,7 +41,11 @@ pub fn run(args: &UpgradeArgs, ctx: &super::MarsContext, json: bool) -> Result<i
             bump: args.bump,
         },
         mutation: None,
-        options: SyncOptions::default(),
+        options: SyncOptions {
+            ignore_requires_mars: args.ignore_requires_mars,
+            ignore_requires_meridian: args.ignore_requires_meridian,
+            ..SyncOptions::default()
+        },
         recovery: crate::sync::RecoveryPolicy::DeferOnUnreadable,
         lossiness_mode: if args.verbose {
             crate::diagnostic::LossinessMode::Verbose

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -57,6 +57,18 @@ pub struct PackageInfo {
     pub version: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    #[serde(
+        default,
+        rename = "requires-mars",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub requires_mars: Option<String>,
+    #[serde(
+        default,
+        rename = "requires-meridian",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub requires_meridian: Option<String>,
 }
 
 mod toml_path_serde {

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -117,18 +117,20 @@ impl DiagnosticCollector {
         }
     }
 
-    pub(crate) fn update_engine_fallback_selection(
-        &mut self,
-        source: &str,
-        selected_version: String,
-    ) {
-        if let Some(existing) = self
-            .engine_fallbacks
-            .iter_mut()
-            .find(|existing| existing.source == source)
-        {
-            existing.selected_version = selected_version;
-        }
+    pub(crate) fn reconcile_engine_fallbacks(&mut self, graph: &crate::resolve::ResolvedGraph) {
+        self.engine_fallbacks.retain_mut(|fallback| {
+            let Some(node) = graph.nodes.get(fallback.source.as_str()) else {
+                return false;
+            };
+            fallback.selected_version = node
+                .resolved_ref
+                .version
+                .as_ref()
+                .map(ToString::to_string)
+                .or_else(|| node.resolved_ref.version_tag.clone())
+                .unwrap_or_else(|| "HEAD/path".to_string());
+            true
+        });
     }
 
     pub(crate) fn take_engine_fallbacks(&mut self) -> Vec<crate::resolve::EngineFallback> {
@@ -483,6 +485,62 @@ mod tests {
             DiagnosticCategory::Lossiness,
         );
         assert_eq!(coll.drain().len(), 1);
+    }
+
+    #[test]
+    fn collector_merges_engine_fallbacks_by_source_and_deduplicates_details() {
+        use crate::resolve::{
+            EngineFallback, EngineFallbackRequirement, EngineFallbackSkippedVersion,
+        };
+
+        let mut coll = DiagnosticCollector::new();
+        coll.record_engine_fallback(EngineFallback {
+            source: "pkg".to_string(),
+            skipped: vec![EngineFallbackSkippedVersion {
+                version: "3.0.0".to_string(),
+                requirements: vec![EngineFallbackRequirement {
+                    engine: "mars".to_string(),
+                    requirement: ">=3".to_string(),
+                }],
+            }],
+            selected_version: "2.0.0".to_string(),
+            engines: vec!["mars".to_string()],
+        });
+        coll.record_engine_fallback(EngineFallback {
+            source: "pkg".to_string(),
+            skipped: vec![
+                EngineFallbackSkippedVersion {
+                    version: "3.0.0".to_string(),
+                    requirements: vec![EngineFallbackRequirement {
+                        engine: "mars".to_string(),
+                        requirement: ">=4".to_string(),
+                    }],
+                },
+                EngineFallbackSkippedVersion {
+                    version: "2.0.0".to_string(),
+                    requirements: vec![EngineFallbackRequirement {
+                        engine: "meridian".to_string(),
+                        requirement: ">=2".to_string(),
+                    }],
+                },
+            ],
+            selected_version: "1.0.0".to_string(),
+            engines: vec!["mars".to_string(), "meridian".to_string()],
+        });
+
+        let fallbacks = coll.take_engine_fallbacks();
+        assert_eq!(fallbacks.len(), 1);
+        assert_eq!(fallbacks[0].selected_version, "1.0.0");
+        assert_eq!(
+            fallbacks[0]
+                .skipped
+                .iter()
+                .map(|skipped| skipped.version.as_str())
+                .collect::<Vec<_>>(),
+            vec!["3.0.0", "2.0.0"]
+        );
+        assert_eq!(fallbacks[0].skipped[0].requirements[0].requirement, ">=4");
+        assert_eq!(fallbacks[0].engines, vec!["mars", "meridian"]);
     }
 
     #[test]

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -95,7 +95,6 @@ impl DiagnosticCollector {
             .iter_mut()
             .find(|existing| existing.source == fallback.source)
         {
-            existing.selected_version = fallback.selected_version;
             for skipped in fallback.skipped {
                 if let Some(recorded) = existing
                     .skipped
@@ -530,7 +529,6 @@ mod tests {
 
         let fallbacks = coll.take_engine_fallbacks();
         assert_eq!(fallbacks.len(), 1);
-        assert_eq!(fallbacks[0].selected_version, "1.0.0");
         assert_eq!(
             fallbacks[0]
                 .skipped

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -69,6 +69,7 @@ pub enum DiagnosticCategory {
 /// Collects diagnostics during pipeline execution.
 pub struct DiagnosticCollector {
     diagnostics: Vec<Diagnostic>,
+    engine_fallbacks: Vec<crate::resolve::EngineFallback>,
     lossiness_mode: LossinessMode,
     /// Launch-time / meridian-enforced field mappings accumulated for summary or verbose detail.
     meridian_only_records: Vec<MeridianOnlyRecord>,
@@ -82,9 +83,26 @@ impl DiagnosticCollector {
     pub fn with_lossiness_mode(lossiness_mode: LossinessMode) -> Self {
         Self {
             diagnostics: Vec::new(),
+            engine_fallbacks: Vec::new(),
             lossiness_mode,
             meridian_only_records: Vec::new(),
         }
+    }
+
+    pub(crate) fn record_engine_fallback(&mut self, fallback: crate::resolve::EngineFallback) {
+        if let Some(existing) = self
+            .engine_fallbacks
+            .iter_mut()
+            .find(|existing| existing.source == fallback.source)
+        {
+            *existing = fallback;
+        } else {
+            self.engine_fallbacks.push(fallback);
+        }
+    }
+
+    pub(crate) fn take_engine_fallbacks(&mut self) -> Vec<crate::resolve::EngineFallback> {
+        std::mem::take(&mut self.engine_fallbacks)
     }
 
     /// Record a launch-time field mapping for meridian-only summary or verbose detail.

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -95,9 +95,39 @@ impl DiagnosticCollector {
             .iter_mut()
             .find(|existing| existing.source == fallback.source)
         {
-            *existing = fallback;
+            existing.selected_version = fallback.selected_version;
+            for skipped in fallback.skipped {
+                if let Some(recorded) = existing
+                    .skipped
+                    .iter_mut()
+                    .find(|recorded| recorded.version == skipped.version)
+                {
+                    *recorded = skipped;
+                } else {
+                    existing.skipped.push(skipped);
+                }
+            }
+            for engine in fallback.engines {
+                if !existing.engines.contains(&engine) {
+                    existing.engines.push(engine);
+                }
+            }
         } else {
             self.engine_fallbacks.push(fallback);
+        }
+    }
+
+    pub(crate) fn update_engine_fallback_selection(
+        &mut self,
+        source: &str,
+        selected_version: String,
+    ) {
+        if let Some(existing) = self
+            .engine_fallbacks
+            .iter_mut()
+            .find(|existing| existing.source == source)
+        {
+            existing.selected_version = selected_version;
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,6 +62,13 @@ pub enum ResolutionError {
         message: String,
     },
 
+    #[error("invalid running {engine} version `{version}`: {message}")]
+    InvalidRunningEngineVersion {
+        engine: String,
+        version: String,
+        message: String,
+    },
+
     #[error("engine requirements are unsatisfiable for `{name}`: {message}")]
     RequiresMarsUnsatisfiable { name: String, message: String },
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,6 +52,22 @@ pub enum LockError {
 /// Resolution errors
 #[derive(Debug, thiserror::Error)]
 pub enum ResolutionError {
+    #[error(
+        "invalid {engine} version requirement `{requirement}` in package `{package}`: {message}"
+    )]
+    InvalidEngineRequirement {
+        package: String,
+        engine: String,
+        requirement: String,
+        message: String,
+    },
+
+    #[error("engine requirements are unsatisfiable for `{name}`: {message}")]
+    RequiresMarsUnsatisfiable { name: String, message: String },
+
+    #[error("source `{name}` is incompatible with the running engine: {message}")]
+    RequiresEngineIncompatible { name: String, message: String },
+
     #[error("version conflict for `{name}`: {message}")]
     VersionConflict { name: String, message: String },
 

--- a/src/models/dependencies.rs
+++ b/src/models/dependencies.rs
@@ -163,6 +163,8 @@ mod tests {
                 name: name.to_string(),
                 version: "1.0.0".to_string(),
                 description: None,
+                requires_mars: None,
+                requires_meridian: None,
             },
             dependencies: IndexMap::new(),
             models,

--- a/src/resolve/AGENTS.md
+++ b/src/resolve/AGENTS.md
@@ -22,7 +22,15 @@ The bottom-up phase can discover that an already-resolved package would select a
 2. Carries it as override into a fresh `ResolverContext`
 3. Restarts bottom-up from scratch
 
-Convergence is guaranteed — versions only move upward toward the lock-preferred/latest-compatible optimum. Oscillation detection reports true per-package ref cycles.
+Convergence is guaranteed by two monotones: constraint-driven selections move
+toward the lock-preferred/latest-compatible optimum, while engine-incompatible
+`(source, version)` exclusions only accumulate across restarts and move that
+optimum downward. Oscillation detection reports true per-package ref cycles.
+
+Package `requires-mars` and `requires-meridian` checks run after manifest read
+and before manifest dependency collection. Semver sources walk down to the
+newest compatible candidate; path, ref-pinned, and untagged sources hard-error
+because they have no alternate candidate.
 
 ## Staging Seam
 

--- a/src/resolve/AGENTS.md
+++ b/src/resolve/AGENTS.md
@@ -1,6 +1,6 @@
 # src/resolve/ — Package Resolution
 
-Dependency resolution with semver constraints. 11 files, ~8000 lines.
+Dependency resolution with semver constraints. 11 source files + tests, ~9500 lines.
 
 ## Mental Model
 

--- a/src/resolve/AGENTS.md
+++ b/src/resolve/AGENTS.md
@@ -32,6 +32,11 @@ and before manifest dependency collection. Semver sources walk down to the
 newest compatible candidate; path, ref-pinned, and untagged sources hard-error
 because they have no alternate candidate.
 
+Resolution-summary diagnostics (e.g. `engine_fallbacks`) are reconciled
+against the final `ResolvedGraph` after the restart loop settles — never
+trust state accumulated during passes, since a restart can change which
+sources and versions appear in the final graph.
+
 ## Staging Seam
 
 `ResolveOptions.staging_root` (resolve/types.rs:304) enables per-dependency canonical source staging.

--- a/src/resolve/context.rs
+++ b/src/resolve/context.rs
@@ -101,6 +101,31 @@ impl ResolverContext {
         self.version_overrides.get(name).cloned()
     }
 
+    pub(super) fn set_version_override(
+        &mut self,
+        name: SourceName,
+        value: (
+            ResolvedRef,
+            RootedSourceRef,
+            crate::staging::HookSurfaceState,
+        ),
+    ) {
+        self.version_overrides.insert(name, value);
+    }
+
+    pub(super) fn version_overrides(
+        &self,
+    ) -> &HashMap<
+        SourceName,
+        (
+            ResolvedRef,
+            RootedSourceRef,
+            crate::staging::HookSurfaceState,
+        ),
+    > {
+        &self.version_overrides
+    }
+
     /// Record the restart info: the package that triggered a restart and the ref
     /// it should be resolved to on the next pass. Called by `resolve_package_bottom_up`
     /// just before returning `ResolutionRestartNeeded`.

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -19,7 +19,7 @@ mod skill;
 mod types;
 mod version;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::Path;
 
 #[cfg(test)]
@@ -48,6 +48,9 @@ use filter::is_item_excluded;
 use package::resolve_package_bottom_up;
 use skill::{parse_pending_item_skill_deps, resolve_skill_ref};
 use version::validate_all_constraints;
+
+pub(crate) type EngineExclusions =
+    HashMap<(SourceName, semver::Version), Vec<EngineRequirementFailure>>;
 
 #[derive(Debug)]
 enum VersionAction {
@@ -243,7 +246,7 @@ pub fn resolve(
     > = HashMap::new();
     // Per-package restart history used for true oscillation detection.
     let mut restart_history: HashMap<SourceName, Vec<ResolvedRef>> = HashMap::new();
-    let mut exclusions: HashSet<(SourceName, semver::Version)> = HashSet::new();
+    let mut exclusions = EngineExclusions::new();
 
     // Restart loop: normally executes once. Restarts only when a package would
     // resolve differently under the full constraint set than it did at first-resolution
@@ -291,6 +294,7 @@ pub fn resolve(
 
         match bottom_up_result {
             Err(MarsError::ResolutionRestartNeeded { package }) => {
+                version_overrides = ctx.version_overrides().clone();
                 // Read the override info before discarding ctx.
                 let Some((pkg_name, new_ref, new_rooted, hook_surface)) =
                     ctx.take_pending_restart()

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -28,8 +28,7 @@ use indexmap::IndexMap;
 pub use constraint::parse_version_constraint;
 pub use context::ResolverContext;
 pub(crate) use requires::{
-    EngineRequirementFailure, check_consumer_package_requirements, check_package_requirements,
-    validate_package_requirement_syntax,
+    check_consumer_package_requirements, validate_package_requirement_syntax,
 };
 pub use types::*;
 
@@ -49,8 +48,8 @@ use package::resolve_package_bottom_up;
 use skill::{parse_pending_item_skill_deps, resolve_skill_ref};
 use version::validate_all_constraints;
 
-pub(crate) type EngineExclusions =
-    HashMap<(SourceName, semver::Version), Vec<EngineRequirementFailure>>;
+type EngineExclusions =
+    HashMap<(SourceName, semver::Version), Vec<requires::EngineRequirementFailure>>;
 
 #[derive(Debug)]
 enum VersionAction {

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -416,6 +416,7 @@ pub fn resolve(
     let graph = ctx.into_graph();
 
     validate_all_constraints(&graph.nodes, &version_constraints)?;
+    diag.reconcile_engine_fallbacks(&graph);
 
     Ok(graph)
 }

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -14,11 +14,12 @@ mod context;
 mod filter;
 mod package;
 mod path;
+mod requires;
 mod skill;
 mod types;
 mod version;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 #[cfg(test)]
@@ -26,6 +27,7 @@ use indexmap::IndexMap;
 
 pub use constraint::parse_version_constraint;
 pub use context::ResolverContext;
+pub(crate) use requires::{EngineRequirementFailure, check_package_requirements};
 pub use types::*;
 
 pub(crate) use package::{PackageResolutionState, PendingSource, RegisteredPackage};
@@ -238,6 +240,7 @@ pub fn resolve(
     > = HashMap::new();
     // Per-package restart history used for true oscillation detection.
     let mut restart_history: HashMap<SourceName, Vec<ResolvedRef>> = HashMap::new();
+    let mut exclusions: HashSet<(SourceName, semver::Version)> = HashSet::new();
 
     // Restart loop: normally executes once. Restarts only when a package would
     // resolve differently under the full constraint set than it did at first-resolution
@@ -253,7 +256,15 @@ pub fn resolve(
                 .filter(|request| filter::is_unfiltered_request(&request.filter))
             {
                 resolve_package_bottom_up(
-                    request, true, provider, locked, options, config, diag, &mut ctx,
+                    request,
+                    true,
+                    provider,
+                    locked,
+                    options,
+                    config,
+                    diag,
+                    &mut ctx,
+                    &mut exclusions,
                 )?;
             }
             for request in direct_requests
@@ -261,7 +272,15 @@ pub fn resolve(
                 .filter(|request| !filter::is_unfiltered_request(&request.filter))
             {
                 resolve_package_bottom_up(
-                    request, true, provider, locked, options, config, diag, &mut ctx,
+                    request,
+                    true,
+                    provider,
+                    locked,
+                    options,
+                    config,
+                    diag,
+                    &mut ctx,
+                    &mut exclusions,
                 )?;
             }
             Ok(())

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -27,7 +27,10 @@ use indexmap::IndexMap;
 
 pub use constraint::parse_version_constraint;
 pub use context::ResolverContext;
-pub(crate) use requires::{EngineRequirementFailure, check_package_requirements};
+pub(crate) use requires::{
+    EngineRequirementFailure, check_consumer_package_requirements, check_package_requirements,
+    validate_package_requirement_syntax,
+};
 pub use types::*;
 
 pub(crate) use package::{PackageResolutionState, PendingSource, RegisteredPackage};

--- a/src/resolve/package.rs
+++ b/src/resolve/package.rs
@@ -11,14 +11,15 @@ use crate::staging;
 use crate::types::{ItemName, SourceId, SourceName, SourceSubpath};
 use indexmap::IndexMap;
 
+use super::EngineExclusions;
 use super::SourceProvider;
 use super::constraint::parse_version_constraint;
 use super::context::ResolverContext;
 use super::filter::is_unfiltered_request;
 use super::path::{apply_subpath, source_id_for_pending_spec};
+use super::requires::{EngineRequirementFailure, check_package_requirements};
 use super::types::{PendingItem, ResolveOptions, ResolvedNode, VersionConstraint};
 use super::version::resolve_single_source;
-use super::{EngineExclusions, EngineRequirementFailure, check_package_requirements};
 
 /// Internal: a source waiting to be resolved.
 #[derive(Debug, Clone)]

--- a/src/resolve/package.rs
+++ b/src/resolve/package.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use crate::config::{EffectiveConfig, FilterMode, GitSpec, Manifest, SourceSpec};
@@ -18,7 +18,7 @@ use super::filter::is_unfiltered_request;
 use super::path::{apply_subpath, source_id_for_pending_spec};
 use super::types::{PendingItem, ResolveOptions, ResolvedNode, VersionConstraint};
 use super::version::resolve_single_source;
-use super::{EngineRequirementFailure, check_package_requirements};
+use super::{EngineExclusions, EngineRequirementFailure, check_package_requirements};
 
 /// Internal: a source waiting to be resolved.
 #[derive(Debug, Clone)]
@@ -88,7 +88,7 @@ pub(crate) fn resolve_package_bottom_up(
     effective_config: &EffectiveConfig,
     diag: &mut DiagnosticCollector,
     ctx: &mut ResolverContext,
-    exclusions: &mut HashSet<(SourceName, semver::Version)>,
+    exclusions: &mut EngineExclusions,
 ) -> Result<(), MarsError> {
     if let Some(existing_name) = ctx.id_index().get(&pending_src.source_id)
         && existing_name != &pending_src.name
@@ -160,7 +160,7 @@ pub(crate) fn resolve_package_bottom_up(
             };
 
             if !skip {
-                let new_ref = resolve_single_source(
+                let new_ref = match resolve_single_source(
                     pending_src,
                     provider,
                     locked,
@@ -168,7 +168,19 @@ pub(crate) fn resolve_package_bottom_up(
                     ctx.version_constraints(),
                     exclusions,
                     diag,
-                )?;
+                ) {
+                    Ok(resolved) => resolved,
+                    Err(error @ MarsError::Resolution(ResolutionError::VersionConflict { .. })) => {
+                        return Err(engine_unsatisfiable_error(
+                            &pending_src.name,
+                            exclusions,
+                            ctx.version_constraints(),
+                        )
+                        .map(MarsError::Resolution)
+                        .unwrap_or(error));
+                    }
+                    Err(error) => return Err(error),
+                };
 
                 // Compare version AND commit (N3: same semver, different commit when
                 // maximize policy changes after a locked-commit first-pass).
@@ -250,7 +262,13 @@ pub(crate) fn resolve_package_bottom_up(
     //   B2: we fall through to normal first-resolution logic below, which runs the
     //       same seed_items / filter path as any non-overridden first resolution.
     let mut rejected: Vec<(String, Vec<EngineRequirementFailure>)> = Vec::new();
-    let mut override_candidate = ctx.version_override(&pending_src.name);
+    let mut override_candidate =
+        ctx.version_override(&pending_src.name)
+            .filter(|(resolved, _, _)| {
+                resolved.version.as_ref().is_none_or(|version| {
+                    !exclusions.contains_key(&(pending_src.name.clone(), version.clone()))
+                })
+            });
     let (resolved_ref, rooted_ref, hook_surface, manifest) = loop {
         let candidate = if let Some(value) = override_candidate.take() {
             value
@@ -282,7 +300,13 @@ pub(crate) fn resolve_package_bottom_up(
                 Err(MarsError::Resolution(ResolutionError::VersionConflict { .. }))
                     if !rejected.is_empty() =>
                 {
-                    return Err(engine_unsatisfiable_error(&pending_src.name, &rejected).into());
+                    return Err(engine_unsatisfiable_error(
+                        &pending_src.name,
+                        exclusions,
+                        ctx.version_constraints(),
+                    )
+                    .expect("the just-rejected candidate is persisted")
+                    .into());
                 }
                 Err(error) => return Err(error),
             }
@@ -320,7 +344,7 @@ pub(crate) fn resolve_package_bottom_up(
             }
             .into());
         };
-        exclusions.insert((pending_src.name.clone(), version));
+        exclusions.insert((pending_src.name.clone(), version), failures.clone());
         diag.warn(
             "requires-mars-fallback",
             format!(
@@ -332,6 +356,16 @@ pub(crate) fn resolve_package_bottom_up(
         );
         rejected.push((label, failures));
     };
+    if !rejected.is_empty() {
+        ctx.set_version_override(
+            pending_src.name.clone(),
+            (
+                resolved_ref.clone(),
+                rooted_ref.clone(),
+                hook_surface.clone(),
+            ),
+        );
+    }
     ctx.set_hook_surface(&pending_src.name, hook_surface);
     if let Some((locked_version, failures)) = rejected.first()
         && locked
@@ -513,17 +547,36 @@ fn describe_engine_failures(failures: &[EngineRequirementFailure]) -> String {
 
 fn engine_unsatisfiable_error(
     name: &SourceName,
-    rejected: &[(String, Vec<EngineRequirementFailure>)],
-) -> ResolutionError {
-    let candidates = rejected
+    exclusions: &EngineExclusions,
+    constraints: &HashMap<SourceName, Vec<(String, VersionConstraint)>>,
+) -> Option<ResolutionError> {
+    let mut rejected = exclusions
         .iter()
+        .filter(|((source, version), _)| {
+            source == name
+                && constraints.get(name).is_none_or(|constraints| {
+                    constraints.iter().all(|(_, constraint)| match constraint {
+                        VersionConstraint::Semver(requirement) => requirement.matches(version),
+                        VersionConstraint::Latest => true,
+                        VersionConstraint::RefPin(_) => false,
+                    })
+                })
+        })
+        .map(|((_, version), failures)| (version, failures))
+        .collect::<Vec<_>>();
+    rejected.sort_by(|(left, _), (right, _)| right.cmp(left));
+    if rejected.is_empty() {
+        return None;
+    }
+    let candidates = rejected
+        .into_iter()
         .map(|(version, failures)| format!("  {version}: {}", describe_engine_failures(failures)))
         .collect::<Vec<_>>()
         .join("\n");
-    ResolutionError::RequiresMarsUnsatisfiable {
+    Some(ResolutionError::RequiresMarsUnsatisfiable {
         name: name.to_string(),
         message: format!("no compatible candidate remains:\n{candidates}"),
-    }
+    })
 }
 
 fn stage_rooted_package(

--- a/src/resolve/package.rs
+++ b/src/resolve/package.rs
@@ -349,6 +349,37 @@ pub(crate) fn resolve_package_bottom_up(
             ),
         );
     }
+    if !rejected.is_empty() {
+        let mut engines = Vec::new();
+        let skipped = rejected
+            .iter()
+            .map(|(version, failures)| {
+                let requirements = failures
+                    .iter()
+                    .map(|failure| {
+                        let engine = failure.engine.to_string();
+                        if !engines.contains(&engine) {
+                            engines.push(engine.clone());
+                        }
+                        super::EngineFallbackRequirement {
+                            engine,
+                            requirement: failure.requirement.clone(),
+                        }
+                    })
+                    .collect();
+                super::EngineFallbackSkippedVersion {
+                    version: version.clone(),
+                    requirements,
+                }
+            })
+            .collect();
+        diag.record_engine_fallback(super::EngineFallback {
+            source: pending_src.name.to_string(),
+            skipped,
+            selected_version: candidate_version_label(&resolved_ref),
+            engines,
+        });
+    }
     let manifest_requests =
         collect_manifest_requests(pending_src, &rooted_ref.package_root, &manifest, options)?;
     let deps = manifest_requests

--- a/src/resolve/package.rs
+++ b/src/resolve/package.rs
@@ -333,7 +333,7 @@ pub(crate) fn resolve_package_bottom_up(
         rejected.push((label, failures));
     };
     ctx.set_hook_surface(&pending_src.name, hook_surface);
-    if let Some((locked_version, _)) = rejected.first()
+    if let Some((locked_version, failures)) = rejected.first()
         && locked
             .and_then(|lock| lock.dependencies.get(&pending_src.name))
             .and_then(|source| source.version.as_deref())
@@ -342,8 +342,9 @@ pub(crate) fn resolve_package_bottom_up(
         diag.warn(
             "requires-mars-lock-fallback",
             format!(
-                "locked `{}` {locked_version} is engine-incompatible; selected {} instead",
+                "locked `{}` {locked_version} is engine-incompatible ({}); selected {} instead",
                 pending_src.name,
+                describe_engine_failures(failures),
                 candidate_version_label(&resolved_ref)
             ),
         );

--- a/src/resolve/package.rs
+++ b/src/resolve/package.rs
@@ -537,8 +537,12 @@ fn describe_engine_failures(failures: &[EngineRequirementFailure]) -> String {
         .iter()
         .map(|failure| {
             format!(
-                "requires-{} `{}` (running {}; upgrade {} to a matching version)",
-                failure.engine, failure.requirement, failure.running, failure.engine
+                "requires-{} `{}` (running {}; use a {} version matching `{}`)",
+                failure.engine,
+                failure.requirement,
+                failure.running,
+                failure.engine,
+                failure.requirement
             )
         })
         .collect::<Vec<_>>()

--- a/src/resolve/package.rs
+++ b/src/resolve/package.rs
@@ -414,10 +414,6 @@ pub(crate) fn resolve_package_bottom_up(
             engines,
         });
     }
-    diag.update_engine_fallback_selection(
-        pending_src.name.as_ref(),
-        candidate_version_label(&resolved_ref),
-    );
     let manifest_requests =
         collect_manifest_requests(pending_src, &rooted_ref.package_root, &manifest, options)?;
     let deps = manifest_requests

--- a/src/resolve/package.rs
+++ b/src/resolve/package.rs
@@ -18,6 +18,7 @@ use super::filter::is_unfiltered_request;
 use super::path::{apply_subpath, source_id_for_pending_spec};
 use super::types::{PendingItem, ResolveOptions, ResolvedNode, VersionConstraint};
 use super::version::resolve_single_source;
+use super::{EngineRequirementFailure, check_package_requirements};
 
 /// Internal: a source waiting to be resolved.
 #[derive(Debug, Clone)]
@@ -87,6 +88,7 @@ pub(crate) fn resolve_package_bottom_up(
     effective_config: &EffectiveConfig,
     diag: &mut DiagnosticCollector,
     ctx: &mut ResolverContext,
+    exclusions: &mut HashSet<(SourceName, semver::Version)>,
 ) -> Result<(), MarsError> {
     if let Some(existing_name) = ctx.id_index().get(&pending_src.source_id)
         && existing_name != &pending_src.name
@@ -164,6 +166,7 @@ pub(crate) fn resolve_package_bottom_up(
                     locked,
                     options,
                     ctx.version_constraints(),
+                    exclusions,
                     diag,
                 )?;
 
@@ -246,32 +249,105 @@ pub(crate) fn resolve_package_bottom_up(
     //   B1: no stale manifest-derived constraints — fresh context, fresh accumulator.
     //   B2: we fall through to normal first-resolution logic below, which runs the
     //       same seed_items / filter path as any non-overridden first resolution.
-    let (resolved_ref, rooted_ref, hook_surface) =
-        if let Some((override_ref, override_rooted, hook_surface)) =
-            ctx.version_override(&pending_src.name)
-        {
-            // Use the pre-computed ref from the prior pass.
-            (override_ref, override_rooted, hook_surface)
+    let mut rejected: Vec<(String, Vec<EngineRequirementFailure>)> = Vec::new();
+    let mut override_candidate = ctx.version_override(&pending_src.name);
+    let (resolved_ref, rooted_ref, hook_surface, manifest) = loop {
+        let candidate = if let Some(value) = override_candidate.take() {
+            value
         } else {
-            let ref_ = resolve_single_source(
+            match resolve_single_source(
                 pending_src,
                 provider,
                 locked,
                 options,
                 ctx.version_constraints(),
+                exclusions,
                 diag,
-            )?;
-            let rooted = apply_subpath(
-                &pending_src.name,
-                &ref_.tree_path,
-                pending_src.subpath.as_ref(),
-            )?;
-            let staged =
-                stage_rooted_package(&pending_src.name, rooted, effective_config, options, diag)?;
-            (ref_, staged.rooted, staged.hook_surface)
+            ) {
+                Ok(ref_) => {
+                    let rooted = apply_subpath(
+                        &pending_src.name,
+                        &ref_.tree_path,
+                        pending_src.subpath.as_ref(),
+                    )?;
+                    let staged = stage_rooted_package(
+                        &pending_src.name,
+                        rooted,
+                        effective_config,
+                        options,
+                        diag,
+                    )?;
+                    (ref_, staged.rooted, staged.hook_surface)
+                }
+                Err(MarsError::Resolution(ResolutionError::VersionConflict { .. }))
+                    if !rejected.is_empty() =>
+                {
+                    return Err(engine_unsatisfiable_error(&pending_src.name, &rejected).into());
+                }
+                Err(error) => return Err(error),
+            }
         };
+        let manifest = provider.read_manifest(&candidate.1.package_root, diag)?;
+        let failures = manifest
+            .as_ref()
+            .map(|manifest| check_package_requirements(&manifest.package, options))
+            .transpose()?
+            .unwrap_or_default();
+        if failures.is_empty() {
+            break (candidate.0, candidate.1, candidate.2, manifest);
+        }
+
+        let label = candidate_version_label(&candidate.0);
+        if options.version_selection_policy(&pending_src.name)
+            == super::types::VersionSelectionPolicy::LockOnly
+        {
+            return Err(MarsError::FrozenViolation {
+                message: format!(
+                    "--frozen locked source `{}` version {label} is incompatible: {}",
+                    pending_src.name,
+                    describe_engine_failures(&failures)
+                ),
+            });
+        }
+        let Some(version) = candidate.0.version.clone() else {
+            return Err(ResolutionError::RequiresEngineIncompatible {
+                name: pending_src.name.to_string(),
+                message: format!(
+                    "version {label} requires {}; required by {}",
+                    describe_engine_failures(&failures),
+                    pending_src.required_by
+                ),
+            }
+            .into());
+        };
+        exclusions.insert((pending_src.name.clone(), version));
+        diag.warn(
+            "requires-mars-fallback",
+            format!(
+                "skipping `{}` {label}: {}; required by {}",
+                pending_src.name,
+                describe_engine_failures(&failures),
+                pending_src.required_by
+            ),
+        );
+        rejected.push((label, failures));
+    };
     ctx.set_hook_surface(&pending_src.name, hook_surface);
-    let manifest = provider.read_manifest(&rooted_ref.package_root, diag)?;
+    if let Some((locked_version, _)) = rejected.first()
+        && locked
+            .and_then(|lock| lock.dependencies.get(&pending_src.name))
+            .and_then(|source| source.version.as_deref())
+            .is_some_and(|version| version.trim_start_matches('v') == locked_version)
+    {
+        diag.warn(
+            "requires-mars-lock-fallback",
+            format!(
+                "locked `{}` {locked_version} is engine-incompatible; selected {} instead",
+                pending_src.name,
+                candidate_version_label(&resolved_ref)
+            ),
+        );
+    }
     let manifest_requests =
         collect_manifest_requests(pending_src, &rooted_ref.package_root, &manifest, options)?;
     let deps = manifest_requests
@@ -327,6 +403,7 @@ pub(crate) fn resolve_package_bottom_up(
             effective_config,
             diag,
             ctx,
+            exclusions,
         )?;
     }
     for request in manifest_requests
@@ -342,6 +419,7 @@ pub(crate) fn resolve_package_bottom_up(
             effective_config,
             diag,
             ctx,
+            exclusions,
         )?;
     }
 
@@ -377,6 +455,43 @@ pub(crate) fn resolve_package_bottom_up(
     }
 
     Ok(())
+}
+
+fn candidate_version_label(resolved: &crate::source::ResolvedRef) -> String {
+    resolved
+        .version
+        .as_ref()
+        .map(ToString::to_string)
+        .or_else(|| resolved.version_tag.clone())
+        .unwrap_or_else(|| "HEAD/path".to_string())
+}
+
+fn describe_engine_failures(failures: &[EngineRequirementFailure]) -> String {
+    failures
+        .iter()
+        .map(|failure| {
+            format!(
+                "requires-{} `{}` (running {}; upgrade {} to a matching version)",
+                failure.engine, failure.requirement, failure.running, failure.engine
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+fn engine_unsatisfiable_error(
+    name: &SourceName,
+    rejected: &[(String, Vec<EngineRequirementFailure>)],
+) -> ResolutionError {
+    let candidates = rejected
+        .iter()
+        .map(|(version, failures)| format!("  {version}: {}", describe_engine_failures(failures)))
+        .collect::<Vec<_>>()
+        .join("\n");
+    ResolutionError::RequiresMarsUnsatisfiable {
+        name: name.to_string(),
+        message: format!("no compatible candidate remains:\n{candidates}"),
+    }
 }
 
 fn stage_rooted_package(

--- a/src/resolve/package.rs
+++ b/src/resolve/package.rs
@@ -414,6 +414,10 @@ pub(crate) fn resolve_package_bottom_up(
             engines,
         });
     }
+    diag.update_engine_fallback_selection(
+        pending_src.name.as_ref(),
+        candidate_version_label(&resolved_ref),
+    );
     let manifest_requests =
         collect_manifest_requests(pending_src, &rooted_ref.package_root, &manifest, options)?;
     let deps = manifest_requests

--- a/src/resolve/requires.rs
+++ b/src/resolve/requires.rs
@@ -86,12 +86,33 @@ fn mars_version(options: &ResolveOptions) -> Version {
     })
 }
 
-fn meridian_version(options: &ResolveOptions) -> Option<Version> {
-    options.meridian_version.clone().or_else(|| {
-        std::env::var("MERIDIAN_VERSION")
-            .ok()
-            .and_then(|raw| Version::parse(&raw).ok())
-    })
+fn parse_meridian_version(
+    raw: Option<std::ffi::OsString>,
+) -> Result<Option<Version>, ResolutionError> {
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+    let raw = raw
+        .into_string()
+        .map_err(|raw| ResolutionError::InvalidRunningEngineVersion {
+            engine: "meridian".to_string(),
+            version: raw.to_string_lossy().into_owned(),
+            message: "value is not valid Unicode".to_string(),
+        })?;
+    Version::parse(&raw)
+        .map(Some)
+        .map_err(|error| ResolutionError::InvalidRunningEngineVersion {
+            engine: "meridian".to_string(),
+            version: raw,
+            message: error.to_string(),
+        })
+}
+
+fn meridian_version(options: &ResolveOptions) -> Result<Option<Version>, ResolutionError> {
+    if let Some(version) = &options.meridian_version {
+        return Ok(Some(version.clone()));
+    }
+    parse_meridian_version(std::env::var_os("MERIDIAN_VERSION"))
 }
 
 pub(crate) fn check_package_requirements(
@@ -114,7 +135,7 @@ pub(crate) fn check_package_requirements(
             &package.name,
             "meridian",
             package.requires_meridian.as_deref(),
-            meridian_version(options),
+            meridian_version(options)?,
         )?
     {
         failures.push(failure);
@@ -200,6 +221,21 @@ mod tests {
             .unwrap()
             .is_none()
         );
+    }
+
+    #[test]
+    fn absent_meridian_version_is_the_only_silent_skip() {
+        assert_eq!(parse_meridian_version(None).unwrap(), None);
+    }
+
+    #[test]
+    fn malformed_meridian_version_is_an_error() {
+        let error = parse_meridian_version(Some("not-semver".into())).unwrap_err();
+        assert!(matches!(
+            error,
+            ResolutionError::InvalidRunningEngineVersion { engine, version, .. }
+                if engine == "meridian" && version == "not-semver"
+        ));
     }
 
     #[test]

--- a/src/resolve/requires.rs
+++ b/src/resolve/requires.rs
@@ -1,0 +1,188 @@
+use semver::{BuildMetadata, Prerelease, Version, VersionReq};
+
+use crate::config::PackageInfo;
+use crate::error::ResolutionError;
+
+use super::ResolveOptions;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EngineRequirementFailure {
+    pub(crate) engine: &'static str,
+    pub(crate) requirement: String,
+    pub(crate) running: Version,
+}
+
+fn parse_requirement(
+    package: &str,
+    engine: &'static str,
+    raw: &str,
+) -> Result<VersionReq, ResolutionError> {
+    let raw = raw.trim();
+    let parts: Vec<&str> = raw.split('.').collect();
+    let normalized = if (1..=3).contains(&parts.len())
+        && parts
+            .iter()
+            .all(|part| !part.is_empty() && part.chars().all(|c| c.is_ascii_digit()))
+    {
+        let mut parts = parts;
+        while parts.len() < 3 {
+            parts.push("0");
+        }
+        format!(">={}", parts.join("."))
+    } else {
+        raw.to_string()
+    };
+    VersionReq::parse(&normalized).map_err(|error| ResolutionError::InvalidEngineRequirement {
+        package: package.to_string(),
+        engine: engine.to_string(),
+        requirement: raw.to_string(),
+        message: error.to_string(),
+    })
+}
+
+fn stable_running_version(version: &Version) -> Version {
+    let mut stable = version.clone();
+    stable.pre = Prerelease::EMPTY;
+    stable.build = BuildMetadata::EMPTY;
+    stable
+}
+
+fn check_engine_requirement(
+    package: &str,
+    engine: &'static str,
+    requirement: Option<&str>,
+    running: Option<Version>,
+) -> Result<Option<EngineRequirementFailure>, ResolutionError> {
+    let (Some(requirement), Some(running)) = (requirement, running) else {
+        return Ok(None);
+    };
+    let parsed = parse_requirement(package, engine, requirement)?;
+    if parsed.matches(&stable_running_version(&running)) {
+        Ok(None)
+    } else {
+        Ok(Some(EngineRequirementFailure {
+            engine,
+            requirement: requirement.to_string(),
+            running,
+        }))
+    }
+}
+
+fn mars_version(options: &ResolveOptions) -> Version {
+    options.mars_version.clone().unwrap_or_else(|| {
+        Version::parse(env!("CARGO_PKG_VERSION")).expect("crate version is semver")
+    })
+}
+
+fn meridian_version(options: &ResolveOptions) -> Option<Version> {
+    options.meridian_version.clone().or_else(|| {
+        std::env::var("MERIDIAN_VERSION")
+            .ok()
+            .and_then(|raw| Version::parse(&raw).ok())
+    })
+}
+
+pub(crate) fn check_package_requirements(
+    package: &PackageInfo,
+    options: &ResolveOptions,
+) -> Result<Vec<EngineRequirementFailure>, ResolutionError> {
+    let mut failures = Vec::new();
+    if !options.ignore_requires_mars
+        && let Some(failure) = check_engine_requirement(
+            &package.name,
+            "mars",
+            package.requires_mars.as_deref(),
+            Some(mars_version(options)),
+        )?
+    {
+        failures.push(failure);
+    }
+    if !options.ignore_requires_meridian
+        && let Some(failure) = check_engine_requirement(
+            &package.name,
+            "meridian",
+            package.requires_meridian.as_deref(),
+            meridian_version(options),
+        )?
+    {
+        failures.push(failure);
+    }
+    Ok(failures)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn package(requirement: Option<&str>) -> PackageInfo {
+        PackageInfo {
+            name: "pkg".into(),
+            version: "1.0.0".into(),
+            description: None,
+            requires_mars: requirement.map(str::to_string),
+            requires_meridian: None,
+        }
+    }
+
+    #[test]
+    fn bare_version_is_a_minimum() {
+        let options = ResolveOptions {
+            mars_version: Some(Version::new(0, 13, 0)),
+            ..ResolveOptions::default()
+        };
+        assert!(
+            check_package_requirements(&package(Some("0.12")), &options)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn prerelease_running_version_matches_stable_floor() {
+        let options = ResolveOptions {
+            mars_version: Some(Version::parse("0.12.0-rc.1").unwrap()),
+            ..ResolveOptions::default()
+        };
+        assert!(
+            check_package_requirements(&package(Some(">=0.12.0")), &options)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn meridian_absence_skips_requirement() {
+        let mut package = package(None);
+        package.requires_meridian = Some(">=999.0.0".into());
+        assert!(
+            check_engine_requirement(
+                &package.name,
+                "meridian",
+                package.requires_meridian.as_deref(),
+                None,
+            )
+            .unwrap()
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn invalid_requirement_is_not_treated_as_a_ref_pin() {
+        let error = parse_requirement("pkg", "mars", "definitely-not-semver").unwrap_err();
+        assert!(matches!(
+            error,
+            ResolutionError::InvalidEngineRequirement { .. }
+        ));
+    }
+
+    #[test]
+    fn old_manifest_serialization_does_not_gain_engine_fields() {
+        let raw = "name = \"pkg\"\nversion = \"1.0.0\"\n";
+        let parsed: PackageInfo = toml::from_str(raw).unwrap();
+        assert_eq!(parsed.requires_mars, None);
+        assert_eq!(parsed.requires_meridian, None);
+        let serialized = toml::to_string(&parsed).unwrap();
+        assert!(!serialized.contains("requires-mars"));
+        assert!(!serialized.contains("requires-meridian"));
+    }
+}

--- a/src/resolve/requires.rs
+++ b/src/resolve/requires.rs
@@ -121,6 +121,7 @@ pub(crate) fn check_package_requirements(
 ) -> Result<Vec<EngineRequirementFailure>, ResolutionError> {
     let mut failures = Vec::new();
     if !options.ignore_requires_mars
+        && package.requires_mars.is_some()
         && let Some(failure) = check_engine_requirement(
             &package.name,
             "mars",
@@ -131,6 +132,7 @@ pub(crate) fn check_package_requirements(
         failures.push(failure);
     }
     if !options.ignore_requires_meridian
+        && package.requires_meridian.is_some()
         && let Some(failure) = check_engine_requirement(
             &package.name,
             "meridian",
@@ -170,6 +172,31 @@ pub(crate) fn check_consumer_package_requirements(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
+
+    struct MeridianVersionEnv(Option<std::ffi::OsString>);
+
+    impl MeridianVersionEnv {
+        fn set(value: &str) -> Self {
+            let previous = std::env::var_os("MERIDIAN_VERSION");
+            // SAFETY: tests that mutate MERIDIAN_VERSION are serialized.
+            unsafe { std::env::set_var("MERIDIAN_VERSION", value) };
+            Self(previous)
+        }
+    }
+
+    impl Drop for MeridianVersionEnv {
+        fn drop(&mut self) {
+            // SAFETY: tests that mutate MERIDIAN_VERSION are serialized.
+            unsafe {
+                if let Some(previous) = self.0.take() {
+                    std::env::set_var("MERIDIAN_VERSION", previous);
+                } else {
+                    std::env::remove_var("MERIDIAN_VERSION");
+                }
+            }
+        }
+    }
 
     fn package(requirement: Option<&str>) -> PackageInfo {
         PackageInfo {
@@ -235,6 +262,30 @@ mod tests {
             error,
             ResolutionError::InvalidRunningEngineVersion { engine, version, .. }
                 if engine == "meridian" && version == "not-semver"
+        ));
+    }
+
+    #[test]
+    #[serial]
+    fn absent_meridian_requirement_does_not_parse_ambient_version() {
+        let _env = MeridianVersionEnv::set("not-semver");
+        assert!(
+            check_package_requirements(&package(None), &ResolveOptions::default())
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn present_meridian_requirement_rejects_malformed_ambient_version() {
+        let _env = MeridianVersionEnv::set("not-semver");
+        let mut package = package(None);
+        package.requires_meridian = Some(">=1".into());
+        assert!(matches!(
+            check_package_requirements(&package, &ResolveOptions::default()),
+            Err(ResolutionError::InvalidRunningEngineVersion { engine, .. })
+                if engine == "meridian"
         ));
     }
 

--- a/src/resolve/requires.rs
+++ b/src/resolve/requires.rs
@@ -6,10 +6,10 @@ use crate::error::ResolutionError;
 use super::ResolveOptions;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct EngineRequirementFailure {
-    pub(crate) engine: &'static str,
-    pub(crate) requirement: String,
-    pub(crate) running: Version,
+pub(super) struct EngineRequirementFailure {
+    pub(super) engine: &'static str,
+    pub(super) requirement: String,
+    pub(super) running: Version,
 }
 
 fn parse_requirement(
@@ -115,7 +115,7 @@ fn meridian_version(options: &ResolveOptions) -> Result<Option<Version>, Resolut
     parse_meridian_version(std::env::var_os("MERIDIAN_VERSION"))
 }
 
-pub(crate) fn check_package_requirements(
+pub(super) fn check_package_requirements(
     package: &PackageInfo,
     options: &ResolveOptions,
 ) -> Result<Vec<EngineRequirementFailure>, ResolutionError> {

--- a/src/resolve/requires.rs
+++ b/src/resolve/requires.rs
@@ -40,6 +40,18 @@ fn parse_requirement(
     })
 }
 
+pub(crate) fn validate_package_requirement_syntax(
+    package: &PackageInfo,
+) -> Result<(), ResolutionError> {
+    if let Some(requirement) = package.requires_mars.as_deref() {
+        parse_requirement(&package.name, "mars", requirement)?;
+    }
+    if let Some(requirement) = package.requires_meridian.as_deref() {
+        parse_requirement(&package.name, "meridian", requirement)?;
+    }
+    Ok(())
+}
+
 fn stable_running_version(version: &Version) -> Version {
     let mut stable = version.clone();
     stable.pre = Prerelease::EMPTY;
@@ -110,6 +122,30 @@ pub(crate) fn check_package_requirements(
     Ok(failures)
 }
 
+pub(crate) fn check_consumer_package_requirements(
+    package: &PackageInfo,
+    options: &ResolveOptions,
+) -> Result<(), ResolutionError> {
+    let failures = check_package_requirements(package, options)?;
+    if failures.is_empty() {
+        return Ok(());
+    }
+    Err(ResolutionError::RequiresEngineIncompatible {
+        name: package.name.clone(),
+        message: format!(
+            "consumer package requires {}",
+            failures
+                .iter()
+                .map(|failure| format!(
+                    "{} `{}` (running {})",
+                    failure.engine, failure.requirement, failure.running
+                ))
+                .collect::<Vec<_>>()
+                .join(" and ")
+        ),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -173,6 +209,40 @@ mod tests {
             error,
             ResolutionError::InvalidEngineRequirement { .. }
         ));
+    }
+
+    #[test]
+    fn syntax_validation_accepts_bare_and_range_requirements_for_both_engines() {
+        for requirement in ["0.12", ">=0.12.0", ">=0.12, <2"] {
+            let mut package = package(Some(requirement));
+            package.requires_meridian = Some(requirement.into());
+            validate_package_requirement_syntax(&package).unwrap();
+        }
+    }
+
+    #[test]
+    fn syntax_validation_rejects_garbage_for_either_engine() {
+        let mut mars_package = package(Some("not a version"));
+        assert!(validate_package_requirement_syntax(&mars_package).is_err());
+        mars_package.requires_mars = None;
+        mars_package.requires_meridian = Some("still not a version".into());
+        assert!(validate_package_requirement_syntax(&mars_package).is_err());
+    }
+
+    #[test]
+    fn consumer_requirement_is_hard_unless_ignored() {
+        let options = ResolveOptions {
+            mars_version: Some(Version::new(0, 11, 0)),
+            ..ResolveOptions::default()
+        };
+        let package = package(Some(">=99"));
+        assert!(check_consumer_package_requirements(&package, &options).is_err());
+
+        let ignored = ResolveOptions {
+            ignore_requires_mars: true,
+            ..options
+        };
+        check_consumer_package_requirements(&package, &ignored).unwrap();
     }
 
     #[test]

--- a/src/resolve/tests/integration_tests.rs
+++ b/src/resolve/tests/integration_tests.rs
@@ -2186,6 +2186,17 @@ fn either_engine_constraint_excludes_candidate_and_ignore_knobs_bypass_checks() 
         )),
     );
     let config = make_config(vec![("a", git_spec("https://example.com/a.git", None))]);
+    let enforced = ResolveOptions {
+        mars_version: Some(Version::new(100, 0, 0)),
+        meridian_version: Some(Version::new(1, 0, 0)),
+        ..default_options()
+    };
+    assert!(matches!(
+        resolve(&config, &provider, None, &enforced),
+        Err(MarsError::Resolution(
+            ResolutionError::RequiresMarsUnsatisfiable { .. }
+        ))
+    ));
     let options = ResolveOptions {
         mars_version: Some(Version::new(1, 0, 0)),
         meridian_version: Some(Version::new(1, 0, 0)),
@@ -2194,4 +2205,139 @@ fn either_engine_constraint_excludes_candidate_and_ignore_knobs_bypass_checks() 
         ..default_options()
     };
     assert!(resolve(&config, &provider, None, &options).is_ok());
+}
+
+#[test]
+fn transitive_engine_fallback_names_requiring_package() {
+    let dir = TempDir::new().unwrap();
+    let a_tree = dir.path().join("a");
+    let b_old = dir.path().join("b-old");
+    let b_new = dir.path().join("b-new");
+    for tree in [&a_tree, &b_old, &b_new] {
+        std::fs::create_dir_all(tree).unwrap();
+    }
+    let mut provider = MockProvider::new();
+    provider.add_versions("https://example.com/a.git", vec![(1, 0, 0)]);
+    provider.add_versions("https://example.com/b.git", vec![(1, 0, 0), (2, 0, 0)]);
+    provider.add_source(
+        "a",
+        a_tree,
+        Some(make_manifest(
+            "a",
+            "1.0.0",
+            vec![("b", "https://example.com/b.git", ">=1")],
+        )),
+    );
+    provider.add_versioned_source(
+        "b",
+        "v1.0.0",
+        b_old,
+        Some(make_engine_manifest("b", "1.0.0", None, None)),
+    );
+    provider.add_versioned_source(
+        "b",
+        "v2.0.0",
+        b_new,
+        Some(make_engine_manifest("b", "2.0.0", Some(">=99"), None)),
+    );
+    let config = make_config(vec![("a", git_spec("https://example.com/a.git", None))]);
+    let options = ResolveOptions {
+        mars_version: Some(Version::new(1, 0, 0)),
+        ..default_options()
+    };
+    let (result, diagnostics) = resolve_with_diagnostics(&config, &provider, None, &options);
+    assert_eq!(
+        result.unwrap().nodes["b"].resolved_ref.version,
+        Some(Version::new(1, 0, 0))
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == "requires-mars-fallback" && d.message.contains("required by a"))
+    );
+}
+
+#[test]
+fn path_engine_incompatibility_is_a_hard_error() {
+    let dir = TempDir::new().unwrap();
+    let tree = dir.path().join("a");
+    std::fs::create_dir_all(&tree).unwrap();
+    let mut provider = MockProvider::new();
+    provider.add_source(
+        "a",
+        tree.clone(),
+        Some(make_engine_manifest("a", "1.0.0", Some(">=99"), None)),
+    );
+    let config = make_config(vec![("a", SourceSpec::Path(tree))]);
+    let options = ResolveOptions {
+        mars_version: Some(Version::new(1, 0, 0)),
+        ..default_options()
+    };
+    assert!(matches!(
+        resolve(&config, &provider, None, &options),
+        Err(MarsError::Resolution(
+            ResolutionError::RequiresEngineIncompatible { .. }
+        ))
+    ));
+}
+
+#[test]
+fn engine_exclusions_survive_restart_and_prevent_oscillation() {
+    let dir = TempDir::new().unwrap();
+    let a_old = dir.path().join("a-old");
+    let a_new = dir.path().join("a-new");
+    let b_tree = dir.path().join("b");
+    for tree in [&a_old, &a_new, &b_tree] {
+        std::fs::create_dir_all(tree).unwrap();
+    }
+    let mut provider = MockProvider::new();
+    provider.add_versions("https://example.com/a.git", vec![(1, 0, 0), (2, 0, 0)]);
+    provider.add_versions("https://example.com/b.git", vec![(1, 0, 0)]);
+    let old_manifest = make_engine_manifest("a", "1.0.0", None, None);
+    provider.add_source("a", a_old.clone(), Some(old_manifest.clone()));
+    provider.add_versioned_source("a", "v1.0.0", a_old, Some(old_manifest));
+    provider.add_versioned_source(
+        "a",
+        "v2.0.0",
+        a_new,
+        Some(make_engine_manifest("a", "2.0.0", Some(">=99"), None)),
+    );
+    provider.add_source(
+        "b",
+        b_tree,
+        Some(make_manifest(
+            "b",
+            "1.0.0",
+            vec![("a", "https://example.com/a.git", "")],
+        )),
+    );
+    let config = make_config(vec![
+        ("a", git_spec("https://example.com/a.git", Some(">=1"))),
+        ("b", git_spec("https://example.com/b.git", Some("v1.0.0"))),
+    ]);
+    let mut lock = LockFile::empty();
+    lock.dependencies.insert(
+        "a".into(),
+        crate::lock::LockedSource {
+            url: Some("https://example.com/a.git".into()),
+            path: None,
+            subpath: None,
+            version: Some("v1.0.0".into()),
+            commit: Some("locked-a".into()),
+        },
+    );
+    let options = ResolveOptions {
+        mars_version: Some(Version::new(1, 0, 0)),
+        ..default_options()
+    };
+    let (result, diagnostics) = resolve_with_diagnostics(&config, &provider, Some(&lock), &options);
+    assert_eq!(
+        result.unwrap().nodes["a"].resolved_ref.version,
+        Some(Version::new(1, 0, 0))
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == "requires-mars-fallback")
+    );
 }

--- a/src/resolve/tests/integration_tests.rs
+++ b/src/resolve/tests/integration_tests.rs
@@ -1712,6 +1712,102 @@ fn restart_fresh_context_drops_removed_transitive_dependency_and_lock_entry() {
 }
 
 #[test]
+fn restart_fresh_context_drops_removed_transitive_engine_fallback() {
+    let dir = TempDir::new().unwrap();
+    let tree_a = dir.path().join("a");
+    let tree_b = dir.path().join("b");
+    let tree_shared_v1 = dir.path().join("shared-v1");
+    let tree_shared_v2 = dir.path().join("shared-v2");
+    let tree_x_v1 = dir.path().join("x-v1");
+    let tree_x_v2 = dir.path().join("x-v2");
+    for tree in [
+        &tree_a,
+        &tree_b,
+        &tree_shared_v1,
+        &tree_shared_v2,
+        &tree_x_v1,
+        &tree_x_v2,
+    ] {
+        std::fs::create_dir_all(tree).unwrap();
+    }
+
+    // A resolves shared@v1 first; that version depends on X, whose newest version
+    // is engine-incompatible. B then contributes Latest for shared, restarting at
+    // shared@v2, which no longer depends on X.
+    let manifest_a = make_manifest(
+        "a",
+        "1.0.0",
+        vec![(
+            "shared",
+            "https://example.com/shared.git",
+            ">=1.0.0, <3.0.0",
+        )],
+    );
+    let manifest_b = make_manifest(
+        "b",
+        "1.0.0",
+        vec![("shared", "https://example.com/shared.git", "")],
+    );
+    let manifest_shared_v1 = make_manifest(
+        "shared",
+        "1.0.0",
+        vec![("x", "https://example.com/x.git", "")],
+    );
+    let manifest_shared_v2 = make_manifest("shared", "2.0.0", vec![]);
+
+    let mut provider = MockProvider::new();
+    provider.add_versions("https://example.com/a.git", vec![(1, 0, 0)]);
+    provider.add_versions("https://example.com/b.git", vec![(1, 0, 0)]);
+    provider.add_versions("https://example.com/shared.git", vec![(1, 0, 0), (2, 0, 0)]);
+    provider.add_versions("https://example.com/x.git", vec![(1, 0, 0), (2, 0, 0)]);
+    provider.add_source("a", tree_a, Some(manifest_a));
+    provider.add_source("b", tree_b, Some(manifest_b));
+    provider.add_versioned_source("shared", "v1.0.0", tree_shared_v1, Some(manifest_shared_v1));
+    provider.add_versioned_source("shared", "v2.0.0", tree_shared_v2, Some(manifest_shared_v2));
+    provider.add_versioned_source(
+        "x",
+        "v1.0.0",
+        tree_x_v1,
+        Some(make_engine_manifest("x", "1.0.0", None, None)),
+    );
+    provider.add_versioned_source(
+        "x",
+        "v2.0.0",
+        tree_x_v2,
+        Some(make_engine_manifest("x", "2.0.0", Some(">=99"), None)),
+    );
+
+    let config = make_config(vec![
+        ("a", git_spec("https://example.com/a.git", Some("v1.0.0"))),
+        ("b", git_spec("https://example.com/b.git", Some("v1.0.0"))),
+    ]);
+    let options = ResolveOptions {
+        mars_version: Some(Version::new(1, 0, 0)),
+        ..default_options()
+    };
+    let mut lock = LockFile::empty();
+    lock.dependencies.insert(
+        "shared".into(),
+        crate::lock::LockedSource {
+            url: Some("https://example.com/shared.git".into()),
+            path: None,
+            subpath: None,
+            version: Some("v1.0.0".into()),
+            commit: None,
+        },
+    );
+
+    let (result, fallbacks) =
+        resolve_with_report_details(&config, &provider, Some(&lock), &options);
+    let graph = result.unwrap();
+    assert!(!graph.nodes.contains_key("x"));
+    assert!(
+        fallbacks.is_empty(),
+        "fallback report must not retain X from the abandoned resolution pass"
+    );
+}
+
+#[test]
 fn restart_fresh_context_materializes_new_transitive_dependency_filters() {
     let dir = TempDir::new().unwrap();
     let tree_a_v1 = dir.path().join("a-v1");

--- a/src/resolve/tests/integration_tests.rs
+++ b/src/resolve/tests/integration_tests.rs
@@ -2054,6 +2054,61 @@ fn engine_walk_down_error_lists_every_rejected_candidate() {
 }
 
 #[test]
+fn tightened_constraint_reports_persisted_engine_rejection() {
+    let dir = TempDir::new().unwrap();
+    let a_old = dir.path().join("a-old");
+    let a_new = dir.path().join("a-new");
+    let b_tree = dir.path().join("b");
+    for tree in [&a_old, &a_new, &b_tree] {
+        std::fs::create_dir_all(tree).unwrap();
+    }
+
+    let mut provider = MockProvider::new();
+    provider.add_versions("https://example.com/a.git", vec![(1, 0, 0), (2, 0, 0)]);
+    provider.add_versions("https://example.com/b.git", vec![(1, 0, 0)]);
+    provider.add_versioned_source(
+        "a",
+        "v1.0.0",
+        a_old,
+        Some(make_engine_manifest("a", "1.0.0", None, None)),
+    );
+    provider.add_versioned_source(
+        "a",
+        "v2.0.0",
+        a_new,
+        Some(make_engine_manifest("a", "2.0.0", Some(">=99"), None)),
+    );
+    provider.add_source(
+        "b",
+        b_tree,
+        Some(make_manifest(
+            "b",
+            "1.0.0",
+            vec![("a", "https://example.com/a.git", ">=2")],
+        )),
+    );
+    let config = make_config(vec![
+        ("a", git_spec("https://example.com/a.git", Some(">=1"))),
+        ("b", git_spec("https://example.com/b.git", Some("v1.0.0"))),
+    ]);
+    let options = ResolveOptions {
+        mars_version: Some(Version::new(1, 0, 0)),
+        ..default_options()
+    };
+
+    let error = resolve(&config, &provider, None, &options).unwrap_err();
+    match error {
+        MarsError::Resolution(ResolutionError::RequiresMarsUnsatisfiable { name, message }) => {
+            assert_eq!(name, "a");
+            assert!(message.contains("2.0.0"), "{message}");
+            assert!(message.contains("requires-mars `>=99`"), "{message}");
+            assert!(message.contains("running 1.0.0"), "{message}");
+        }
+        other => panic!("expected persisted engine incompatibility, got {other:?}"),
+    }
+}
+
+#[test]
 fn frozen_rejects_engine_incompatible_lock() {
     let dir = TempDir::new().unwrap();
     let tree = dir.path().join("a");
@@ -2287,12 +2342,16 @@ fn engine_exclusions_survive_restart_and_prevent_oscillation() {
     let a_old = dir.path().join("a-old");
     let a_new = dir.path().join("a-new");
     let b_tree = dir.path().join("b");
-    for tree in [&a_old, &a_new, &b_tree] {
+    let c_tree = dir.path().join("c");
+    let d_tree = dir.path().join("d");
+    for tree in [&a_old, &a_new, &b_tree, &c_tree, &d_tree] {
         std::fs::create_dir_all(tree).unwrap();
     }
     let mut provider = MockProvider::new();
     provider.add_versions("https://example.com/a.git", vec![(1, 0, 0), (2, 0, 0)]);
     provider.add_versions("https://example.com/b.git", vec![(1, 0, 0)]);
+    provider.add_versions("https://example.com/c.git", vec![(1, 0, 0), (1, 5, 0)]);
+    provider.add_versions("https://example.com/d.git", vec![(1, 0, 0)]);
     let old_manifest = make_engine_manifest("a", "1.0.0", None, None);
     provider.add_source("a", a_old.clone(), Some(old_manifest.clone()));
     provider.add_versioned_source("a", "v1.0.0", a_old, Some(old_manifest));
@@ -2311,9 +2370,21 @@ fn engine_exclusions_survive_restart_and_prevent_oscillation() {
             vec![("a", "https://example.com/a.git", "")],
         )),
     );
+    provider.add_source("c", c_tree, None);
+    provider.add_source(
+        "d",
+        d_tree,
+        Some(make_manifest(
+            "d",
+            "1.0.0",
+            vec![("c", "https://example.com/c.git", "")],
+        )),
+    );
     let config = make_config(vec![
         ("a", git_spec("https://example.com/a.git", Some(">=1"))),
         ("b", git_spec("https://example.com/b.git", Some("v1.0.0"))),
+        ("c", git_spec("https://example.com/c.git", Some(">=1, <2"))),
+        ("d", git_spec("https://example.com/d.git", Some("v1.0.0"))),
     ]);
     let mut lock = LockFile::empty();
     lock.dependencies.insert(
@@ -2326,6 +2397,16 @@ fn engine_exclusions_survive_restart_and_prevent_oscillation() {
             commit: Some("locked-a".into()),
         },
     );
+    lock.dependencies.insert(
+        "c".into(),
+        crate::lock::LockedSource {
+            url: Some("https://example.com/c.git".into()),
+            path: None,
+            subpath: None,
+            version: Some("v1.0.0".into()),
+            commit: Some("locked-c".into()),
+        },
+    );
     let options = ResolveOptions {
         mars_version: Some(Version::new(1, 0, 0)),
         ..default_options()
@@ -2335,9 +2416,12 @@ fn engine_exclusions_survive_restart_and_prevent_oscillation() {
         result.unwrap().nodes["a"].resolved_ref.version,
         Some(Version::new(1, 0, 0))
     );
-    assert!(
+    assert_eq!(
         diagnostics
             .iter()
-            .any(|d| d.code == "requires-mars-fallback")
+            .filter(|d| d.code == "requires-mars-fallback" && d.message.contains("`a` 2.0.0"))
+            .count(),
+        1,
+        "a known-incompatible restart override must not be proposed again"
     );
 }

--- a/src/resolve/tests/integration_tests.rs
+++ b/src/resolve/tests/integration_tests.rs
@@ -2427,3 +2427,68 @@ fn engine_exclusions_survive_restart_and_prevent_oscillation() {
         "a known-incompatible restart override must not be proposed again"
     );
 }
+
+#[test]
+fn engine_fallback_report_tracks_final_selection_after_constraint_restart() {
+    let dir = TempDir::new().unwrap();
+    let a_v1 = dir.path().join("a-v1");
+    let a_v2 = dir.path().join("a-v2");
+    let a_v3 = dir.path().join("a-v3");
+    let b_tree = dir.path().join("b");
+    for tree in [&a_v1, &a_v2, &a_v3, &b_tree] {
+        std::fs::create_dir_all(tree).unwrap();
+    }
+
+    let mut provider = MockProvider::new();
+    provider.add_versions(
+        "https://example.com/a.git",
+        vec![(1, 0, 0), (2, 0, 0), (3, 0, 0)],
+    );
+    provider.add_versions("https://example.com/b.git", vec![(1, 0, 0)]);
+    provider.add_versioned_source(
+        "a",
+        "v1.0.0",
+        a_v1,
+        Some(make_engine_manifest("a", "1.0.0", None, None)),
+    );
+    provider.add_versioned_source(
+        "a",
+        "v2.0.0",
+        a_v2,
+        Some(make_engine_manifest("a", "2.0.0", None, None)),
+    );
+    provider.add_versioned_source(
+        "a",
+        "v3.0.0",
+        a_v3,
+        Some(make_engine_manifest("a", "3.0.0", Some(">=99"), None)),
+    );
+    provider.add_source(
+        "b",
+        b_tree,
+        Some(make_manifest(
+            "b",
+            "1.0.0",
+            vec![("a", "https://example.com/a.git", "<2")],
+        )),
+    );
+
+    let config = make_config(vec![
+        ("a", git_spec("https://example.com/a.git", Some(">=1"))),
+        ("b", git_spec("https://example.com/b.git", Some("v1.0.0"))),
+    ]);
+    let options = ResolveOptions {
+        mars_version: Some(Version::new(1, 0, 0)),
+        ..default_options()
+    };
+
+    let (result, fallbacks) = resolve_with_report_details(&config, &provider, None, &options);
+    assert_eq!(
+        result.unwrap().nodes["a"].resolved_ref.version,
+        Some(Version::new(1, 0, 0))
+    );
+    assert_eq!(fallbacks.len(), 1);
+    assert_eq!(fallbacks[0].source, "a");
+    assert_eq!(fallbacks[0].selected_version, "1.0.0");
+    assert_eq!(fallbacks[0].skipped[0].version, "3.0.0");
+}

--- a/src/resolve/tests/integration_tests.rs
+++ b/src/resolve/tests/integration_tests.rs
@@ -134,6 +134,8 @@ fn transitive_override_does_not_collapse_conflicting_declared_identities() {
             name: name.to_string(),
             version: "1.0.0".to_string(),
             description: None,
+            requires_mars: None,
+            requires_meridian: None,
         },
         dependencies: IndexMap::from([(
             "shared".to_string(),
@@ -308,6 +310,8 @@ fn source_identity_mismatch_detects_different_subpaths_for_same_name() {
             name: "a".to_string(),
             version: "1.0.0".to_string(),
             description: None,
+            requires_mars: None,
+            requires_meridian: None,
         },
         dependencies: manifest_deps,
         models: IndexMap::new(),
@@ -395,6 +399,8 @@ fn transitive_dep_propagates_subpath_into_source_identity() {
             name: "a".to_string(),
             version: "1.0.0".to_string(),
             description: None,
+            requires_mars: None,
+            requires_meridian: None,
         },
         dependencies: manifest_deps,
         models: IndexMap::new(),
@@ -725,6 +731,8 @@ fn latest_and_pinned_revisit_re_resolves_to_pinned_version() {
             name: "a".to_string(),
             version: "1.0.0".to_string(),
             description: None,
+            requires_mars: None,
+            requires_meridian: None,
         },
         dependencies: deps_a,
         models: IndexMap::new(),
@@ -1116,6 +1124,8 @@ fn resolver_reads_manifest_from_package_root_not_checkout_root() {
             name: "foo".to_string(),
             version: "1.0.0".to_string(),
             description: None,
+            requires_mars: None,
+            requires_meridian: None,
         },
         dependencies: IndexMap::new(),
         models: IndexMap::new(),
@@ -1284,6 +1294,8 @@ fn transitive_dep_without_subpath_has_none_in_source_identity() {
             name: "a".to_string(),
             version: "1.0.0".to_string(),
             description: None,
+            requires_mars: None,
+            requires_meridian: None,
         },
         dependencies: manifest_deps,
         models: IndexMap::new(),
@@ -1971,4 +1983,215 @@ fn oscillating_ref_selection_errors_with_ref_cycle() {
         }
         other => panic!("expected oscillation VersionConflict, got {other:?}"),
     }
+}
+
+#[test]
+fn engine_walk_down_selects_newest_compatible_version() {
+    let dir = TempDir::new().unwrap();
+    let old = dir.path().join("old");
+    let new = dir.path().join("new");
+    std::fs::create_dir_all(&old).unwrap();
+    std::fs::create_dir_all(&new).unwrap();
+    let mut provider = MockProvider::new();
+    provider.add_versions("https://example.com/a.git", vec![(1, 0, 0), (2, 0, 0)]);
+    provider.add_versioned_source(
+        "a",
+        "v1.0.0",
+        old,
+        Some(make_engine_manifest("a", "1.0.0", Some(">=0.1"), None)),
+    );
+    provider.add_versioned_source(
+        "a",
+        "v2.0.0",
+        new,
+        Some(make_engine_manifest("a", "2.0.0", Some(">=99"), None)),
+    );
+    let config = make_config(vec![("a", git_spec("https://example.com/a.git", None))]);
+    let options = ResolveOptions {
+        mars_version: Some(Version::new(1, 0, 0)),
+        ..default_options()
+    };
+
+    let (result, diagnostics) = resolve_with_diagnostics(&config, &provider, None, &options);
+    assert_eq!(
+        result.unwrap().nodes["a"].resolved_ref.version,
+        Some(Version::new(1, 0, 0))
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == "requires-mars-fallback" && d.message.contains("2.0.0"))
+    );
+}
+
+#[test]
+fn engine_walk_down_error_lists_every_rejected_candidate() {
+    let dir = TempDir::new().unwrap();
+    let mut provider = MockProvider::new();
+    provider.add_versions("https://example.com/a.git", vec![(1, 0, 0), (2, 0, 0)]);
+    for version in ["1.0.0", "2.0.0"] {
+        let tree = dir.path().join(version);
+        std::fs::create_dir_all(&tree).unwrap();
+        provider.add_versioned_source(
+            "a",
+            &format!("v{version}"),
+            tree,
+            Some(make_engine_manifest("a", version, Some(">=99"), None)),
+        );
+    }
+    let config = make_config(vec![("a", git_spec("https://example.com/a.git", None))]);
+    let options = ResolveOptions {
+        mars_version: Some(Version::new(1, 0, 0)),
+        ..default_options()
+    };
+    let error = resolve(&config, &provider, None, &options)
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains("1.0.0") && error.contains("2.0.0") && error.contains("upgrade mars"),
+        "{error}"
+    );
+}
+
+#[test]
+fn frozen_rejects_engine_incompatible_lock() {
+    let dir = TempDir::new().unwrap();
+    let tree = dir.path().join("a");
+    std::fs::create_dir_all(&tree).unwrap();
+    let mut provider = MockProvider::new();
+    provider.add_versions("https://example.com/a.git", vec![(1, 0, 0)]);
+    provider.add_source(
+        "a",
+        tree,
+        Some(make_engine_manifest("a", "1.0.0", Some(">=99"), None)),
+    );
+    let config = make_config(vec![(
+        "a",
+        git_spec("https://example.com/a.git", Some("^1")),
+    )]);
+    let mut lock = LockFile::empty();
+    lock.dependencies.insert(
+        "a".into(),
+        crate::lock::LockedSource {
+            url: Some("https://example.com/a.git".into()),
+            path: None,
+            subpath: None,
+            version: Some("v1.0.0".into()),
+            commit: Some("locked".into()),
+        },
+    );
+    let options = ResolveOptions {
+        mars_version: Some(Version::new(1, 0, 0)),
+        ..ResolveOptions::frozen()
+    };
+    assert!(matches!(
+        resolve(&config, &provider, Some(&lock), &options),
+        Err(MarsError::FrozenViolation { .. })
+    ));
+}
+
+#[test]
+fn incompatible_locked_version_warns_and_falls_back() {
+    let dir = TempDir::new().unwrap();
+    let locked_tree = dir.path().join("locked");
+    let old_tree = dir.path().join("old");
+    std::fs::create_dir_all(&locked_tree).unwrap();
+    std::fs::create_dir_all(&old_tree).unwrap();
+    let mut provider = MockProvider::new();
+    provider.add_versions("https://example.com/a.git", vec![(1, 0, 0), (2, 0, 0)]);
+    provider.add_source(
+        "a",
+        locked_tree,
+        Some(make_engine_manifest("a", "2.0.0", Some(">=99"), None)),
+    );
+    provider.add_versioned_source(
+        "a",
+        "v1.0.0",
+        old_tree,
+        Some(make_engine_manifest("a", "1.0.0", None, None)),
+    );
+    let config = make_config(vec![(
+        "a",
+        git_spec("https://example.com/a.git", Some(">=1")),
+    )]);
+    let mut lock = LockFile::empty();
+    lock.dependencies.insert(
+        "a".into(),
+        crate::lock::LockedSource {
+            url: Some("https://example.com/a.git".into()),
+            path: None,
+            subpath: None,
+            version: Some("v2.0.0".into()),
+            commit: Some("locked".into()),
+        },
+    );
+    let options = ResolveOptions {
+        mars_version: Some(Version::new(1, 0, 0)),
+        ..default_options()
+    };
+    let (result, diagnostics) = resolve_with_diagnostics(&config, &provider, Some(&lock), &options);
+    assert_eq!(
+        result.unwrap().nodes["a"].resolved_ref.version,
+        Some(Version::new(1, 0, 0))
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == "requires-mars-lock-fallback")
+    );
+}
+
+#[test]
+fn refpin_engine_incompatibility_is_a_hard_error() {
+    let dir = TempDir::new().unwrap();
+    let tree = dir.path().join("a");
+    std::fs::create_dir_all(&tree).unwrap();
+    let mut provider = MockProvider::new();
+    provider.add_source(
+        "a",
+        tree,
+        Some(make_engine_manifest("a", "1.0.0", Some(">=99"), None)),
+    );
+    let config = make_config(vec![(
+        "a",
+        git_spec("https://example.com/a.git", Some("main")),
+    )]);
+    let options = ResolveOptions {
+        mars_version: Some(Version::new(1, 0, 0)),
+        ..default_options()
+    };
+    assert!(matches!(
+        resolve(&config, &provider, None, &options),
+        Err(MarsError::Resolution(
+            ResolutionError::RequiresEngineIncompatible { .. }
+        ))
+    ));
+}
+
+#[test]
+fn either_engine_constraint_excludes_candidate_and_ignore_knobs_bypass_checks() {
+    let dir = TempDir::new().unwrap();
+    let tree = dir.path().join("a");
+    std::fs::create_dir_all(&tree).unwrap();
+    let mut provider = MockProvider::new();
+    provider.add_versions("https://example.com/a.git", vec![(1, 0, 0)]);
+    provider.add_source(
+        "a",
+        tree,
+        Some(make_engine_manifest(
+            "a",
+            "1.0.0",
+            Some(">=99"),
+            Some(">=99"),
+        )),
+    );
+    let config = make_config(vec![("a", git_spec("https://example.com/a.git", None))]);
+    let options = ResolveOptions {
+        mars_version: Some(Version::new(1, 0, 0)),
+        meridian_version: Some(Version::new(1, 0, 0)),
+        ignore_requires_mars: true,
+        ignore_requires_meridian: true,
+        ..default_options()
+    };
+    assert!(resolve(&config, &provider, None, &options).is_ok());
 }

--- a/src/resolve/tests/integration_tests.rs
+++ b/src/resolve/tests/integration_tests.rs
@@ -2036,7 +2036,7 @@ fn engine_walk_down_error_lists_every_rejected_candidate() {
             "a",
             &format!("v{version}"),
             tree,
-            Some(make_engine_manifest("a", version, Some(">=99"), None)),
+            Some(make_engine_manifest("a", version, Some("<1"), None)),
         );
     }
     let config = make_config(vec![("a", git_spec("https://example.com/a.git", None))]);
@@ -2048,7 +2048,9 @@ fn engine_walk_down_error_lists_every_rejected_candidate() {
         .unwrap_err()
         .to_string();
     assert!(
-        error.contains("1.0.0") && error.contains("2.0.0") && error.contains("upgrade mars"),
+        error.contains("1.0.0")
+            && error.contains("2.0.0")
+            && error.contains("use a mars version matching `<1`"),
         "{error}"
     );
 }

--- a/src/resolve/tests/mod.rs
+++ b/src/resolve/tests/mod.rs
@@ -449,6 +449,20 @@ fn resolve_with_diagnostics(
     (result, diag.drain())
 }
 
+fn resolve_with_report_details(
+    config: &EffectiveConfig,
+    provider: &dyn SourceProvider,
+    locked: Option<&LockFile>,
+    options: &ResolveOptions,
+) -> (
+    Result<ResolvedGraph, MarsError>,
+    Vec<crate::resolve::EngineFallback>,
+) {
+    let mut diag = DiagnosticCollector::new();
+    let result = super::resolve(config, provider, locked, options, &mut diag);
+    (result, diag.take_engine_fallbacks())
+}
+
 fn write_minimal_package_marker(tree: &Path) {
     std::fs::write(
         tree.join("mars.toml"),

--- a/src/resolve/tests/mod.rs
+++ b/src/resolve/tests/mod.rs
@@ -371,10 +371,24 @@ fn make_manifest(name: &str, version: &str, deps: Vec<(&str, &str, &str)>) -> Ma
             name: name.to_string(),
             version: version.to_string(),
             description: None,
+            requires_mars: None,
+            requires_meridian: None,
         },
         dependencies,
         models: indexmap::IndexMap::new(),
     }
+}
+
+fn make_engine_manifest(
+    name: &str,
+    version: &str,
+    requires_mars: Option<&str>,
+    requires_meridian: Option<&str>,
+) -> Manifest {
+    let mut manifest = make_manifest(name, version, vec![]);
+    manifest.package.requires_mars = requires_mars.map(str::to_string);
+    manifest.package.requires_meridian = requires_meridian.map(str::to_string);
+    manifest
 }
 
 fn make_manifest_with_filters(
@@ -400,6 +414,8 @@ fn make_manifest_with_filters(
             name: name.to_string(),
             version: version.to_string(),
             description: None,
+            requires_mars: None,
+            requires_meridian: None,
         },
         dependencies,
         models: indexmap::IndexMap::new(),

--- a/src/resolve/types.rs
+++ b/src/resolve/types.rs
@@ -33,6 +33,26 @@ pub struct ResolvedGraph {
         std::collections::BTreeMap<SourceName, std::collections::BTreeSet<String>>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct EngineFallbackSkippedVersion {
+    pub version: String,
+    pub requirements: Vec<EngineFallbackRequirement>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct EngineFallbackRequirement {
+    pub engine: String,
+    pub requirement: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct EngineFallback {
+    pub source: String,
+    pub skipped: Vec<EngineFallbackSkippedVersion>,
+    pub selected_version: String,
+    pub engines: Vec<String>,
+}
+
 /// A single node in the resolved graph.
 #[derive(Debug, Clone)]
 pub struct ResolvedNode {

--- a/src/resolve/types.rs
+++ b/src/resolve/types.rs
@@ -298,6 +298,12 @@ pub enum ResolveMode {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolveOptions {
     pub mode: ResolveMode,
+    /// Running mars version override. Production uses the crate version.
+    pub mars_version: Option<semver::Version>,
+    /// Running meridian version override. Production reads `MERIDIAN_VERSION`.
+    pub meridian_version: Option<semver::Version>,
+    pub ignore_requires_mars: bool,
+    pub ignore_requires_meridian: bool,
     /// Per-project directory for dependency-scoped canonical source staging.
     pub staging_root: Option<std::path::PathBuf>,
     /// Local source substitutions, including names first introduced transitively.
@@ -308,6 +314,10 @@ impl Default for ResolveOptions {
     fn default() -> Self {
         Self {
             mode: ResolveMode::Sync,
+            mars_version: None,
+            meridian_version: None,
+            ignore_requires_mars: false,
+            ignore_requires_meridian: false,
             staging_root: None,
             source_overrides: indexmap::IndexMap::new(),
         }
@@ -329,6 +339,10 @@ impl ResolveOptions {
     pub fn sync() -> Self {
         Self {
             mode: ResolveMode::Sync,
+            mars_version: None,
+            meridian_version: None,
+            ignore_requires_mars: false,
+            ignore_requires_meridian: false,
             staging_root: None,
             source_overrides: indexmap::IndexMap::new(),
         }
@@ -337,6 +351,10 @@ impl ResolveOptions {
     pub fn frozen() -> Self {
         Self {
             mode: ResolveMode::Frozen,
+            mars_version: None,
+            meridian_version: None,
+            ignore_requires_mars: false,
+            ignore_requires_meridian: false,
             staging_root: None,
             source_overrides: indexmap::IndexMap::new(),
         }
@@ -348,6 +366,10 @@ impl ResolveOptions {
                 targets,
                 bump_direct_constraints,
             },
+            mars_version: None,
+            meridian_version: None,
+            ignore_requires_mars: false,
+            ignore_requires_meridian: false,
             staging_root: None,
             source_overrides: indexmap::IndexMap::new(),
         }

--- a/src/resolve/version.rs
+++ b/src/resolve/version.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use indexmap::IndexMap;
 use semver::{Version, VersionReq};
@@ -20,6 +20,7 @@ pub(crate) fn resolve_single_source(
     locked: Option<&LockFile>,
     options: &ResolveOptions,
     constraints: &HashMap<SourceName, Vec<(String, VersionConstraint)>>,
+    exclusions: &HashSet<(SourceName, Version)>,
     diag: &mut DiagnosticCollector,
 ) -> Result<ResolvedRef, MarsError> {
     let selection_policy = options.version_selection_policy(&pending.name);
@@ -47,6 +48,7 @@ pub(crate) fn resolve_single_source(
                 provider,
                 locked_source,
                 selection_policy,
+                exclusions,
                 diag,
             )
         }
@@ -331,6 +333,7 @@ pub(crate) fn resolve_git_source(
     provider: &dyn SourceProvider,
     locked_source: Option<&LockedSource>,
     selection_policy: VersionSelectionPolicy,
+    exclusions: &HashSet<(SourceName, Version)>,
     diag: &mut DiagnosticCollector,
 ) -> Result<ResolvedRef, MarsError> {
     let has_latest_constraint = constraints
@@ -376,6 +379,9 @@ pub(crate) fn resolve_git_source(
             let v = v.strip_prefix('v').unwrap_or(v);
             Version::parse(v).ok()
         });
+    let locked_is_excluded = locked_version
+        .as_ref()
+        .is_some_and(|version| exclusions.contains(&(name.clone(), version.clone())));
 
     if selection_policy == VersionSelectionPolicy::LockOnly
         && (locked_version_raw.is_some() || !semver_reqs.is_empty())
@@ -401,6 +407,13 @@ pub(crate) fn resolve_git_source(
             return Err(MarsError::FrozenViolation {
                 message: format!(
                     "--frozen lock version {locked_version} for `{name}` is incompatible with current constraints"
+                ),
+            });
+        }
+        if exclusions.contains(&(name.clone(), locked_version.clone())) {
+            return Err(MarsError::FrozenViolation {
+                message: format!(
+                    "--frozen locked version {locked_version} for `{name}` is incompatible with its engine requirements"
                 ),
             });
         }
@@ -434,6 +447,7 @@ pub(crate) fn resolve_git_source(
     let mut locked_commit_unreachable = false;
     if selection_policy == VersionSelectionPolicy::PreferLockThenLatest
         && !has_latest_constraint
+        && !locked_is_excluded
         && let (Some(locked_version), Some(locked_commit)) =
             (locked_version.as_ref(), locked_commit)
         && semver_constraints_satisfied(locked_version, &semver_reqs)
@@ -492,6 +506,7 @@ pub(crate) fn resolve_git_source(
         &semver_reqs,
         locked_version.as_ref(),
         select_policy,
+        exclusions,
     )?;
 
     let should_try_locked_commit = !locked_commit_unreachable
@@ -541,11 +556,15 @@ pub(crate) fn select_version<'a>(
     constraints: &[(&str, &VersionReq)],
     locked: Option<&Version>,
     selection_policy: VersionSelectionPolicy,
+    exclusions: &HashSet<(SourceName, Version)>,
 ) -> Result<&'a AvailableVersion, MarsError> {
     // Find all versions satisfying all constraints
     let satisfying: Vec<&AvailableVersion> = available
         .iter()
         .filter(|av| {
+            if exclusions.contains(&(source_name.clone(), av.version.clone())) {
+                return false;
+            }
             if constraints.is_empty() {
                 return true;
             }

--- a/src/resolve/version.rs
+++ b/src/resolve/version.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use indexmap::IndexMap;
 use semver::{Version, VersionReq};
@@ -9,6 +9,7 @@ use crate::lock::{LockFile, LockedSource};
 use crate::source::{AvailableVersion, ResolvedRef};
 use crate::types::{SourceId, SourceName, SourceUrl};
 
+use super::EngineExclusions;
 use super::SourceProvider;
 use super::package::PendingSource;
 use super::types::{ResolveOptions, ResolvedNode, VersionConstraint, VersionSelectionPolicy};
@@ -20,7 +21,7 @@ pub(crate) fn resolve_single_source(
     locked: Option<&LockFile>,
     options: &ResolveOptions,
     constraints: &HashMap<SourceName, Vec<(String, VersionConstraint)>>,
-    exclusions: &HashSet<(SourceName, Version)>,
+    exclusions: &EngineExclusions,
     diag: &mut DiagnosticCollector,
 ) -> Result<ResolvedRef, MarsError> {
     let selection_policy = options.version_selection_policy(&pending.name);
@@ -333,7 +334,7 @@ pub(crate) fn resolve_git_source(
     provider: &dyn SourceProvider,
     locked_source: Option<&LockedSource>,
     selection_policy: VersionSelectionPolicy,
-    exclusions: &HashSet<(SourceName, Version)>,
+    exclusions: &EngineExclusions,
     diag: &mut DiagnosticCollector,
 ) -> Result<ResolvedRef, MarsError> {
     let has_latest_constraint = constraints
@@ -381,7 +382,7 @@ pub(crate) fn resolve_git_source(
         });
     let locked_is_excluded = locked_version
         .as_ref()
-        .is_some_and(|version| exclusions.contains(&(name.clone(), version.clone())));
+        .is_some_and(|version| exclusions.contains_key(&(name.clone(), version.clone())));
 
     if selection_policy == VersionSelectionPolicy::LockOnly
         && (locked_version_raw.is_some() || !semver_reqs.is_empty())
@@ -410,7 +411,7 @@ pub(crate) fn resolve_git_source(
                 ),
             });
         }
-        if exclusions.contains(&(name.clone(), locked_version.clone())) {
+        if exclusions.contains_key(&(name.clone(), locked_version.clone())) {
             return Err(MarsError::FrozenViolation {
                 message: format!(
                     "--frozen locked version {locked_version} for `{name}` is incompatible with its engine requirements"
@@ -556,13 +557,13 @@ pub(crate) fn select_version<'a>(
     constraints: &[(&str, &VersionReq)],
     locked: Option<&Version>,
     selection_policy: VersionSelectionPolicy,
-    exclusions: &HashSet<(SourceName, Version)>,
+    exclusions: &EngineExclusions,
 ) -> Result<&'a AvailableVersion, MarsError> {
     // Find all versions satisfying all constraints
     let satisfying: Vec<&AvailableVersion> = available
         .iter()
         .filter(|av| {
-            if exclusions.contains(&(source_name.clone(), av.version.clone())) {
+            if exclusions.contains_key(&(source_name.clone(), av.version.clone())) {
                 return false;
             }
             if constraints.is_empty() {

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -53,6 +53,8 @@ pub struct SyncReport {
     /// Present when a recovery command persisted intent but stopped before
     /// materialization because at least one hook surface was unreadable.
     pub recovery_halt: Option<RecoveryHalt>,
+    /// Version fallbacks caused by package engine requirements.
+    pub engine_fallbacks: Vec<crate::resolve::EngineFallback>,
 }
 
 /// A source package preventing a recovery command from entering the compiler.
@@ -202,6 +204,7 @@ pub fn execute(ctx: &MarsContext, request: &SyncRequest) -> Result<SyncReport, M
             native_emitted: Vec::new(),
             native_removed: Vec::new(),
             recovery_halt: Some(recovery_halt),
+            engine_fallbacks: diag.take_engine_fallbacks(),
         });
     }
     crate::compiler::compile(ctx, ir, request, &mut diag)
@@ -338,6 +341,23 @@ pub(crate) fn load_config(
         crate::config::merge_with_root(config.clone(), local.clone(), project_root)?;
     diag.extend(config_diagnostics);
 
+    if request.options.ignore_requires_mars {
+        diag.warn(
+            "requires-mars-disabled",
+            "`requires-mars` compatibility checks are disabled by --ignore-requires-mars",
+        );
+    }
+    if request.options.ignore_requires_meridian {
+        diag.warn(
+            "requires-meridian-disabled",
+            "`requires-meridian` compatibility checks are disabled by --ignore-requires-meridian",
+        );
+    }
+    if let Some(package) = config.package.as_ref() {
+        let options = to_resolve_options(&request.resolution, &request.options);
+        crate::resolve::check_consumer_package_requirements(package, &options)?;
+    }
+
     // Load existing lock file, routing load diagnostics through sync diagnostics.
     let (old_lock, lock_diagnostics) = match crate::lock::load_with_diagnostics(project_root) {
         Ok(loaded) => loaded,
@@ -388,7 +408,7 @@ pub(crate) fn resolve_graph(
             (name.clone(), path)
         })
         .collect();
-    let resolve_options = to_resolve_options(&request.resolution, request.options.frozen)
+    let resolve_options = to_resolve_options(&request.resolution, &request.options)
         .with_staging_root(ctx.project_root.join(".mars/staging"))
         .with_source_overrides(source_overrides);
     let graph = crate::resolve::resolve(
@@ -1064,6 +1084,7 @@ pub(crate) fn finalize(
         native_emitted,
         native_removed,
         recovery_halt: None,
+        engine_fallbacks: diag.take_engine_fallbacks(),
     })
 }
 
@@ -1179,17 +1200,20 @@ fn validate_targets(
     Ok(())
 }
 
-fn to_resolve_options(mode: &ResolutionMode, frozen: bool) -> ResolveOptions {
-    if frozen {
-        return ResolveOptions::frozen();
-    }
-
-    match mode {
-        ResolutionMode::Normal => ResolveOptions::sync(),
-        ResolutionMode::Maximize { targets, bump } => {
-            ResolveOptions::upgrade(targets.clone(), *bump)
+fn to_resolve_options(mode: &ResolutionMode, options: &SyncOptions) -> ResolveOptions {
+    let mut resolve_options = if options.frozen {
+        ResolveOptions::frozen()
+    } else {
+        match mode {
+            ResolutionMode::Normal => ResolveOptions::sync(),
+            ResolutionMode::Maximize { targets, bump } => {
+                ResolveOptions::upgrade(targets.clone(), *bump)
+            }
         }
-    }
+    };
+    resolve_options.ignore_requires_mars = options.ignore_requires_mars;
+    resolve_options.ignore_requires_meridian = options.ignore_requires_meridian;
+    resolve_options
 }
 
 fn planned_bump_entries(

--- a/src/sync/tests.rs
+++ b/src/sync/tests.rs
@@ -1480,3 +1480,54 @@ fn pipeline_only_agents_no_agents_source() {
     // No agents means nothing gets installed
     assert_eq!(target.items.len(), 0);
 }
+
+#[test]
+fn sync_options_reach_resolver_engine_ignore_knobs() {
+    let options = SyncOptions {
+        ignore_requires_mars: true,
+        ignore_requires_meridian: true,
+        ..SyncOptions::default()
+    };
+    let resolved = super::to_resolve_options(&ResolutionMode::Normal, &options);
+    assert!(resolved.ignore_requires_mars);
+    assert!(resolved.ignore_requires_meridian);
+}
+
+#[test]
+fn consumer_package_requirement_is_hard_and_ignore_flag_bypasses_it() {
+    let fixture = TestFixture::new();
+    fs::write(
+        fixture.project_root().join("mars.toml"),
+        "[package]\nname = \"consumer\"\nversion = \"1.0.0\"\nrequires-mars = \">=99\"\n",
+    )
+    .unwrap();
+    let ctx = MarsContext::for_test(fixture.project_root().to_path_buf());
+    let request = SyncRequest {
+        resolution: ResolutionMode::Normal,
+        mutation: None,
+        options: SyncOptions::default(),
+        recovery: Default::default(),
+        lossiness_mode: LossinessMode::Hidden,
+    };
+    let error = match load_config(&ctx, &request, &mut DiagnosticCollector::new()) {
+        Ok(_) => panic!("incompatible consumer requirement should fail"),
+        Err(error) => error,
+    };
+    assert!(error.to_string().contains("consumer package requires mars"));
+
+    let ignored = SyncRequest {
+        options: SyncOptions {
+            ignore_requires_mars: true,
+            ..SyncOptions::default()
+        },
+        ..request
+    };
+    let mut diagnostics = DiagnosticCollector::new();
+    load_config(&ctx, &ignored, &mut diagnostics).unwrap();
+    assert!(
+        diagnostics
+            .drain()
+            .iter()
+            .any(|diagnostic| diagnostic.code == "requires-mars-disabled")
+    );
+}

--- a/src/sync/types.rs
+++ b/src/sync/types.rs
@@ -15,6 +15,10 @@ pub struct SyncOptions {
     pub no_refresh_models: bool,
     /// Fetch version metadata so sync can report available upgrades.
     pub check_upgrades: bool,
+    /// Skip package `requires-mars` compatibility checks.
+    pub ignore_requires_mars: bool,
+    /// Skip package `requires-meridian` compatibility checks.
+    pub ignore_requires_meridian: bool,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Why

Packages have no way to declare the minimum mars/meridian they need. When a package starts using a newer manifest or content feature, older engines silently install and miscompile it — the exact failure mode npm's advisory `engines` is documented for. Ecosystem study (pip, Cargo, Bundler, npm, Go) converged on hard-filter-with-fallback as the model that serves "give me the newest version that works."

## Goal

A package can declare `requires-mars` / `requires-meridian` in `[package]`, and resolution automatically selects the newest version the running engines can actually handle — loudly, never silently, with escape hatches.

## Summary

Two optional `[package]` fields, `requires-mars` and `requires-meridian` (checked only under `meridian mars ...`, via the `MERIDIAN_VERSION` env var). When the selected version of a dependency declares an unsatisfied engine requirement, the resolver walks down to the newest compatible version and warns; hard error when no candidate is compatible. Exclusions are persisted with failure provenance and survive resolver restarts; the JSON report's `engine_fallbacks` is reconciled against the completed graph. Strict requirement parsing (no RefPin fallback), bare versions rewritten to `>=` minimums, prerelease stripped from the running version before matching.

## Resulting Behavior

- `mars sync` against a dep whose newest version requires a newer mars: selects the newest compatible older version, warns `skipping <pkg> 2.0.0: requires-mars >=99.0.0 (running 0.11.0; use a mars version matching >=99.0.0)`.
- No compatible candidate: hard error before any mutation, listing every candidate's requirement + running version.
- `--ignore-requires-mars` / `--ignore-requires-meridian` on sync/upgrade/add/repair bypass the checks (single disabled-check warning).
- `--frozen` with an engine-incompatible locked version: `FrozenViolation`, no changes on disk.
- Single-candidate sources (RefPin/path/untagged) and the consumer's own `[package]`: hard error, no fallback.
- `MERIDIAN_VERSION` absent → `requires-meridian` silently skipped; present-but-malformed → typed error (only when a requirement exists — fieldless manifests are unaffected).
- `mars check` validates both fields' syntax; JSON sync reports carry `engine_fallbacks` (source, skipped versions + requirements, final selected version, engines).
- Manifests without the fields resolve byte-for-byte as before; no lock schema change.

## Changes

- `src/resolve/requires.rs` (new): strict parse, bare-version→`>=` rewrite, prerelease-stripped matching, shared engine check with injectable versions for tests.
- Resolver: exclusion map (with failure records) in driver state, threaded through `select_version` and restart passes; walk-down loop in `resolve_package_bottom_up` after `read_manifest`; restart overrides retire when excluded; lock-replay fallback warns and rewrites the lock visibly.
- CLI: ignore flags on four commands; consumer-own-package check in `load_config`; `mars check` reuses the resolver parser; `engine_fallbacks` reconciled post-resolution against the final graph.
- Docs: README, `docs/config/mars-toml.md`, `docs/cli/commands.md`; resolver `AGENTS.md` (incl. the final-graph reconciliation invariant and updated convergence argument).
- Dead-code sweep after the fix rounds: removed the vestigial incremental `selected_version` refresh subsumed by reconciliation; tightened engine-internals visibility (`pub(crate)` → private/`pub(super)`).
- Merged with `main` @ v0.12.1 (`0f4c69f`): only `CHANGELOG.md` conflicted (release promotion); released sections kept as published, feature entries consolidated under `[Unreleased]`. Full suite re-run green post-merge (no semantic collision with #155).
- Follow-ups filed: #156 (pre-existing staging residue on failed resolve), #157 (pre-existing `--no-refresh-models` warning wording).

## Work Item

mars-version-constraints

## Verification

- `cargo test` fully green at every commit — final head: 1,493 library tests + all integration/compile-fail suites, 0 failed (1 pre-existing ignored); `cargo clippy --all-targets --all-features -- -D warnings`; `cargo fmt --check`. PR CI green (stable/nightly/Windows).
- Fake-provider coverage: walk-down, unsatisfiable error text, lock-downgrade, frozen violation, transitive fallback chain, restart oscillation with exclusions, RefPin/path hard error, bare-version rewrite, prerelease matching, ignore flags, meridian-absent skip, either-engine rejection, old-manifest round-trip, moot-source report reconciliation, collector dedup.
- Runtime probe against the real binary with tagged local git fixtures: 7 end-to-end scenarios (walk-down, unsatisfiable, ignore flags, env gating incl. fail-closed garbage + bypass, frozen with byte-identical state, `mars check`, JSON report) — all behaviors as specified.
- Four review rounds (2 deep + 2 targeted closure checks); final verdict ship-ready. All 6 findings across rounds fixed and verified closed.

## Knowledge Updates

- `src/resolve/AGENTS.md` updated on the branch: engine-check placement, two-monotone convergence argument, final-graph reconciliation invariant.
- meridian-cli KB: D93 decision record (hard-constraint-with-fallback, rejected alternatives, source study) + resolution-algorithm/sync-model/vocabulary concept pages — committed to the kb repo.
- Design doc with the full ecosystem source study: meridian-cli work item `work/mars-version-constraints/design.md`.

## Spawn Trace

- p5870 coder — phases 1+2: schema, parse helper, resolver walk-down
- p5872 coder — phase 3: CLI flags, load_config check, mars check, JSON report
- p5873 reviewer — resolver-core review (3 should-fix found, probe-reproduced)
- p5874 coder — fix pass 1 (provenance, restart overrides, fail-closed env, wording)
- p5875 reviewer — gate review (2 should-fix found)
- p5876 prober — end-to-end runtime verification, real binary + git fixtures
- p5877 coder — fix pass 2 (report accuracy, fieldless-manifest guard, staging adjudication)
- p5878 reviewer — closure verify (1 medium found)
- p5879 coder — structural fix: reconcile engine_fallbacks with final graph
- p5880 reviewer — final closure verify (approve, ship-ready)
- p5881 coder — dead-code sweep (removed subsumed refresh, tightened visibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
